### PR TITLE
fix: extend basic oats verification to other definitions

### DIFF
--- a/contracts/swaggerV1Compat.yml
+++ b/contracts/swaggerV1Compat.yml
@@ -21,9 +21,9 @@ paths:
             schema:
               type: string
       parameters:
-        - $ref: "../parameters/TraceSpan.yml"
-        - $ref: "../parameters/AuthUserV1.yml"
-        - $ref: "../parameters/AuthPassV1.yml"
+        - $ref: "#/components/parameters/TraceSpan"
+        - $ref: "#/components/parameters/AuthUserV1"
+        - $ref: "#/components/parameters/AuthPassV1"
         - in: query
           name: db
           schema:
@@ -58,25 +58,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "../schemas/LineProtocolError.yml"
+                $ref: "#/components/schemas/LineProtocolError"
         "401":
           description: Token does not have sufficient permissions to write to this organization and bucket or the organization and bucket do not exist.
           content:
             application/json:
               schema:
-                $ref: "../schemas/Error.yml"
+                $ref: "#/components/schemas/Error"
         "403":
           description: No token was sent and they are required.
           content:
             application/json:
               schema:
-                $ref: "../schemas/Error.yml"
+                $ref: "#/components/schemas/Error"
         "413":
           description: Write has been rejected because the payload is too large. Error message returns max size supported. All data in body was rejected and not written.
           content:
             application/json:
               schema:
-                $ref: "../schemas/LineProtocolLengthError.yml"
+                $ref: "#/components/schemas/LineProtocolLengthError"
         "429":
           description: Token is temporarily over quota. The Retry-After header describes when to try the write again.
           headers:
@@ -98,7 +98,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "../schemas/Error.yml"
+                $ref: "#/components/schemas/Error"
   /query:
     post: # technically this functions with other methods as well
       operationId: PostQueryV1
@@ -112,9 +112,9 @@ paths:
             schema:
               type: string
       parameters:
-        - $ref: "../parameters/TraceSpan.yml"
-        - $ref: "../parameters/AuthUserV1.yml"
-        - $ref: "../parameters/AuthPassV1.yml"
+        - $ref: "#/components/parameters/TraceSpan"
+        - $ref: "#/components/parameters/AuthUserV1"
+        - $ref: "#/components/parameters/AuthPassV1"
         - in: header
           name: Accept
           schema:
@@ -168,13 +168,13 @@ paths:
           content:
             application/csv:
               schema:
-                $ref: "../schemas/InfluxQLCSVResponse.yml"
+                $ref: "#/components/schemas/InfluxQLCSVResponse"
             text/csv:
               schema:
-                $ref: "../schemas/InfluxQLCSVResponse.yml"
+                $ref: "#/components/schemas/InfluxQLCSVResponse"
             application/json:
               schema:
-                $ref: "../schemas/InfluxQLResponse.yml"
+                $ref: "#/components/schemas/InfluxQLResponse"
             application/x-msgpack:
               schema:
                 type: string
@@ -192,7 +192,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "../schemas/Error.yml"
+                $ref: "#/components/schemas/Error"
 components:
   parameters:
     TraceSpan:
@@ -254,7 +254,6 @@ components:
         test_measurement,,1603740794286107366,1,tag_value
         test_measurement,,1603740870053205649,2,tag_value
         test_measurement,,1603741221085428881,3,tag_value
-
     Error:
       properties:
         code:

--- a/scripts/test-oats.sh
+++ b/scripts/test-oats.sh
@@ -2,7 +2,10 @@
 
 CONTRACTS=${CONTRACTS:-openapi/contracts}
 
-/src/node_modules/.bin/oats ${CONTRACTS}/oss.yml > /dev/null || exit 1
+for contract in $(find ${CONTRACTS} -iname *.yml | grep -v 'diff'); do
+    echo "ensuring simple oats compatibility with: ${contract}..."
+    /src/node_modules/.bin/oats "${contract}" > /dev/null || exit 1
+done
 
 ## uncomment below to test against oats' currently generated routes
 # TS=${TS:-ts}


### PR DESCRIPTION
Fixes #28 
This also fixes a quickly addressable bug surfaced while extending the tests.