### PR TITLE
fix: adding servers property for /health and /ready (#31)

### DIFF
--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -6,6 +6,8 @@ servers:
   - url: /api/v2
 paths:
   /health:
+    servers:
+      - url: ''
     get:
       operationId: GetHealth
       tags:
@@ -54,6 +56,8 @@ paths:
               schema:
                 $ref: '#/paths/~1ready/get/responses/default/content/application~1json/schema'
   /ready:
+    servers:
+      - url: ''
     get:
       operationId: GetReady
       tags:

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -5879,6 +5879,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
   /health:
+    servers:
+      - url: ''
     get:
       operationId: GetHealth
       tags:
@@ -5906,6 +5908,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
   /ready:
+    servers:
+      - url: ''
     get:
       operationId: GetReady
       tags:

--- a/src/oss.yml
+++ b/src/oss.yml
@@ -7,8 +7,12 @@ servers:
 paths:
 #REF_COMMON_PATHS
   /health:
+    servers:
+      - url: ''
     $ref: "./oss/paths/health.yml"
   /ready:
+    servers:
+      - url: ''
     $ref: "./oss/paths/ready.yml"
   /users:
     $ref: "./common/paths/users.yml"


### PR DESCRIPTION
Closes #31 

Specified different URL for `/health` and `/ready` via `servers` property.
