### PR TITLE
feat: Add explicit schema bucket APIs

### DIFF
--- a/contracts/cli.yml
+++ b/contracts/cli.yml
@@ -438,6 +438,219 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  '/buckets/{bucketID}/schema/measurements':
+    summary: APIs for describing bucket schema
+    get:
+      summary: Retrieve a list of measurement schemas defined for this bucket
+      operationId: getMeasurementSchemas
+      parameters:
+        - in: query
+          name: org
+          description: The organization name.
+          schema:
+            type: string
+        - in: query
+          name: orgID
+          description: The organization ID.
+          schema:
+            type: string
+        - in: path
+          name: bucketID
+          description: The ID of the bucket
+          schema:
+            type: string
+          required: true
+      tags:
+        - Bucket Schemas
+      responses:
+        '200':
+          description: A list of measurement schemas returning summary information
+          headers:
+            ETag:
+              description: The current version of the bucket schema
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MeasurementSchemaList'
+        '404':
+          description: Bucket not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      summary: Create a new measurement schema for this bucket
+      operationId: createMeasurementSchema
+      parameters:
+        - in: query
+          name: org
+          description: The organization name.
+          schema:
+            type: string
+        - in: query
+          name: orgID
+          description: The organization ID.
+          schema:
+            type: string
+        - in: path
+          name: bucketID
+          description: The ID of the bucket
+          schema:
+            type: string
+          required: true
+      tags:
+        - Bucket Schemas
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MeasurementSchemaCreateRequest'
+      responses:
+        '201':
+          description: New measurement schema
+          headers:
+            ETag:
+              description: The current version of the measurement schema
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MeasurementSchema'
+        '400':
+          description: Client error with create request
+          content:
+            application/json:
+              examples:
+                badNameExample:
+                  summary: Invalid name
+                  description: 'The error returned when the name is invalid, such as too few or too many characters or the name contains non-printable ASCII or is not valid UTF-8.'
+                  value:
+                    code: invalid
+                    message: name is invalid
+                missingColumnsExample:
+                  summary: Missing columns
+                  description: The error returned when the request body is missing the columns property.
+                  value:
+                    code: invalid
+                    message: columns is required
+                missingTimestampExample:
+                  summary: Missing timestamp
+                  description: The error returned when the request body is missing a timestamp type column.
+                  value:
+                    code: invalid
+                    message: Timestamp column is required
+                duplicateColumnNamesExample:
+                  summary: Duplicate column names
+                  description: The error returned when the request body contains duplicate column names.
+                  value:
+                    code: invalid
+                    message: Duplicate column names
+                missingFieldExample:
+                  summary: Missing field
+                  description: The error returned when the request body is missing at least one field type column.
+                  value:
+                    code: invalid
+                    message: At least one field column is required
+              schema:
+                $ref: '#/components/schemas/Error'
+  '/buckets/{bucketID}/schema/measurements/{measurementID}':
+    summary: APIs for describing tables
+    get:
+      summary: Fetch schema information for a measurement
+      operationId: getMeasurementSchema
+      parameters:
+        - in: query
+          name: org
+          description: The organization name.
+          schema:
+            type: string
+        - in: query
+          name: orgID
+          description: The organization ID.
+          schema:
+            type: string
+        - in: path
+          name: bucketID
+          description: The ID of the bucket
+          schema:
+            type: string
+          required: true
+        - in: path
+          name: measurementID
+          description: The ID of the measurement
+          schema:
+            type: string
+          required: true
+      tags:
+        - Bucket Schemas
+      responses:
+        '200':
+          description: Schema definition for a single measurement
+          headers:
+            ETag:
+              description: The current version of the measurement schema
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MeasurementSchema'
+    patch:
+      summary: Update existing measurement schema
+      operationId: updateMeasurementSchema
+      parameters:
+        - in: query
+          name: org
+          description: The organization name.
+          schema:
+            type: string
+        - in: query
+          name: orgID
+          description: The organization ID.
+          schema:
+            type: string
+        - in: path
+          name: bucketID
+          description: The ID of the bucket
+          schema:
+            type: string
+          required: true
+        - in: path
+          name: measurementID
+          description: The ID of the measurement
+          schema:
+            type: string
+          required: true
+      tags:
+        - Bucket Schemas
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MeasurementSchemaUpdateRequest'
+      responses:
+        '200':
+          description: Updated measurement schema
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MeasurementSchema'
+        '400':
+          description: Client error updating measurement schema
+          content:
+            application/json:
+              examples:
+                missingColumnsExample:
+                  summary: Deleted columns
+                  description: The error returned when the request body does not contain all the columns from the source.
+                  value:
+                    code: invalid
+                    message: Unable to delete columns from schema
+              schema:
+                $ref: '#/components/schemas/Error'
 components:
   parameters:
     TraceSpan:
@@ -749,6 +962,9 @@ components:
           type: string
         rp:
           type: string
+        schemaType:
+          $ref: '#/components/schemas/SchemaType'
+          default: implicit
         createdAt:
           type: string
           format: date-time
@@ -776,6 +992,9 @@ components:
           type: string
         retentionRules:
           $ref: '#/components/schemas/RetentionRules'
+        schemaType:
+          $ref: '#/components/schemas/SchemaType'
+          default: implicit
       required:
         - orgID
         - name
@@ -1049,3 +1268,164 @@ components:
         - code
         - message
         - maxLength
+    SchemaType:
+      type: string
+      enum:
+        - implicit
+        - explicit
+    ColumnDataType:
+      type: string
+      enum:
+        - integer
+        - float
+        - boolean
+        - string
+        - unsigned
+    ColumnSemanticType:
+      type: string
+      nullable: false
+      enum:
+        - timestamp
+        - tag
+        - field
+    MeasurementSchema:
+      description: The schema definition for a single measurement
+      type: object
+      example:
+        id: 1a3c5e7f9b0a8642
+        name: cpu
+        columns:
+          - name: time
+            type: timestamp
+          - name: host
+            type: tag
+          - name: region
+            type: tag
+          - name: usage_user
+            type: field
+            dataType: float
+          - name: usage_user
+            type: field
+            dataType: float
+        createdAt: '2021-01-21T00:48:40.993Z'
+        updatedAt: '2021-01-21T00:48:40.993Z'
+      required:
+        - id
+        - name
+        - columns
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: string
+          readOnly: true
+        name:
+          type: string
+          nullable: false
+        columns:
+          description: An ordered collection of column definitions
+          type: array
+          items:
+            $ref: '#/components/schemas/MeasurementSchemaColumn'
+        createdAt:
+          type: string
+          format: date-time
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          readOnly: true
+    MeasurementSchemaColumn:
+      description: Definition of a measurement column
+      example:
+        name: time
+        type: timestamp
+      type: object
+      required:
+        - name
+        - type
+      properties:
+        name:
+          type: string
+        type:
+          $ref: '#/components/schemas/ColumnSemanticType'
+        dataType:
+          $ref: '#/components/schemas/ColumnDataType'
+    MeasurementSchemaCreateRequest:
+      description: Create a new measurement schema
+      type: object
+      example:
+        name: cpu
+        columns:
+          - name: time
+            type: timestamp
+          - name: host
+            type: tag
+          - name: region
+            type: tag
+          - name: usage_user
+            type: field
+            dataType: float
+          - name: usage_user
+            type: field
+            dataType: float
+      required:
+        - name
+        - columns
+      properties:
+        name:
+          type: string
+        columns:
+          description: An ordered collection of column definitions
+          type: array
+          items:
+            $ref: '#/components/schemas/MeasurementSchemaColumn'
+    MeasurementSchemaList:
+      description: A list of measurement schemas returning summary information
+      example:
+        measurementSchemas:
+          - id: 1a3c5e7f9b0a8642
+            name: cpu
+            createdAt: '2021-01-21T00:48:40.993Z'
+            updatedAt: '2021-01-21T00:48:40.993Z'
+          - id: 1a3c5e7f9b0a8643
+            name: memory
+            createdAt: '2021-01-21T00:48:40.993Z'
+            updatedAt: '2021-01-21T00:48:40.993Z'
+          - id: 1a3c5e7f9b0a8644
+            name: disk
+            createdAt: '2021-01-21T00:48:40.993Z'
+            updatedAt: '2021-01-21T00:48:40.993Z'
+      type: object
+      required:
+        - measurementSchemas
+      properties:
+        measurementSchemas:
+          type: array
+          items:
+            $ref: '#/components/schemas/MeasurementSchema'
+    MeasurementSchemaUpdateRequest:
+      description: Update an existing measurement schema
+      type: object
+      example:
+        columns:
+          - name: time
+            type: timestamp
+          - name: host
+            type: tag
+          - name: region
+            type: tag
+          - name: usage_user
+            type: field
+            dataType: float
+          - name: usage_user
+            type: field
+            dataType: float
+      required:
+        - columns
+      properties:
+        columns:
+          description: An ordered collection of column definitions
+          type: array
+          items:
+            $ref: '#/components/schemas/MeasurementSchemaColumn'

--- a/contracts/cli.yml
+++ b/contracts/cli.yml
@@ -454,6 +454,11 @@ paths:
           description: The organization ID.
           schema:
             type: string
+        - in: query
+          name: name
+          description: Find a measurement with matching name.
+          schema:
+            type: string
         - in: path
           name: bucketID
           description: The ID of the bucket

--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -614,6 +614,11 @@ paths:
           description: The organization ID.
           schema:
             type: string
+        - in: query
+          name: name
+          description: Find a measurement with matching name.
+          schema:
+            type: string
         - in: path
           name: bucketID
           description: The ID of the bucket

--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -598,6 +598,219 @@ paths:
             application/json:
               schema:
                 $ref: '#/paths/~1users/get/responses/default/content/application~1json/schema'
+  '/buckets/{bucketID}/schema/measurements':
+    summary: APIs for describing bucket schema
+    get:
+      summary: Retrieve a list of measurement schemas defined for this bucket
+      operationId: getMeasurementSchemas
+      parameters:
+        - in: query
+          name: org
+          description: The organization name.
+          schema:
+            type: string
+        - in: query
+          name: orgID
+          description: The organization ID.
+          schema:
+            type: string
+        - in: path
+          name: bucketID
+          description: The ID of the bucket
+          schema:
+            type: string
+          required: true
+      tags:
+        - Bucket Schemas
+      responses:
+        '200':
+          description: A list of measurement schemas returning summary information
+          headers:
+            ETag:
+              description: The current version of the bucket schema
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MeasurementSchemaList'
+        '404':
+          description: Bucket not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/paths/~1users/get/responses/default/content/application~1json/schema'
+    post:
+      summary: Create a new measurement schema for this bucket
+      operationId: createMeasurementSchema
+      parameters:
+        - in: query
+          name: org
+          description: The organization name.
+          schema:
+            type: string
+        - in: query
+          name: orgID
+          description: The organization ID.
+          schema:
+            type: string
+        - in: path
+          name: bucketID
+          description: The ID of the bucket
+          schema:
+            type: string
+          required: true
+      tags:
+        - Bucket Schemas
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MeasurementSchemaCreateRequest'
+      responses:
+        '201':
+          description: New measurement schema
+          headers:
+            ETag:
+              description: The current version of the measurement schema
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MeasurementSchema'
+        '400':
+          description: Client error with create request
+          content:
+            application/json:
+              examples:
+                badNameExample:
+                  summary: Invalid name
+                  description: 'The error returned when the name is invalid, such as too few or too many characters or the name contains non-printable ASCII or is not valid UTF-8.'
+                  value:
+                    code: invalid
+                    message: name is invalid
+                missingColumnsExample:
+                  summary: Missing columns
+                  description: The error returned when the request body is missing the columns property.
+                  value:
+                    code: invalid
+                    message: columns is required
+                missingTimestampExample:
+                  summary: Missing timestamp
+                  description: The error returned when the request body is missing a timestamp type column.
+                  value:
+                    code: invalid
+                    message: Timestamp column is required
+                duplicateColumnNamesExample:
+                  summary: Duplicate column names
+                  description: The error returned when the request body contains duplicate column names.
+                  value:
+                    code: invalid
+                    message: Duplicate column names
+                missingFieldExample:
+                  summary: Missing field
+                  description: The error returned when the request body is missing at least one field type column.
+                  value:
+                    code: invalid
+                    message: At least one field column is required
+              schema:
+                $ref: '#/paths/~1users/get/responses/default/content/application~1json/schema'
+  '/buckets/{bucketID}/schema/measurements/{measurementID}':
+    summary: APIs for describing tables
+    get:
+      summary: Fetch schema information for a measurement
+      operationId: getMeasurementSchema
+      parameters:
+        - in: query
+          name: org
+          description: The organization name.
+          schema:
+            type: string
+        - in: query
+          name: orgID
+          description: The organization ID.
+          schema:
+            type: string
+        - in: path
+          name: bucketID
+          description: The ID of the bucket
+          schema:
+            type: string
+          required: true
+        - in: path
+          name: measurementID
+          description: The ID of the measurement
+          schema:
+            type: string
+          required: true
+      tags:
+        - Bucket Schemas
+      responses:
+        '200':
+          description: Schema definition for a single measurement
+          headers:
+            ETag:
+              description: The current version of the measurement schema
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MeasurementSchema'
+    patch:
+      summary: Update existing measurement schema
+      operationId: updateMeasurementSchema
+      parameters:
+        - in: query
+          name: org
+          description: The organization name.
+          schema:
+            type: string
+        - in: query
+          name: orgID
+          description: The organization ID.
+          schema:
+            type: string
+        - in: path
+          name: bucketID
+          description: The ID of the bucket
+          schema:
+            type: string
+          required: true
+        - in: path
+          name: measurementID
+          description: The ID of the measurement
+          schema:
+            type: string
+          required: true
+      tags:
+        - Bucket Schemas
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MeasurementSchemaUpdateRequest'
+      responses:
+        '200':
+          description: Updated measurement schema
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MeasurementSchema'
+        '400':
+          description: Client error updating measurement schema
+          content:
+            application/json:
+              examples:
+                missingColumnsExample:
+                  summary: Deleted columns
+                  description: The error returned when the request body does not contain all the columns from the source.
+                  value:
+                    code: invalid
+                    message: Unable to delete columns from schema
+              schema:
+                $ref: '#/paths/~1users/get/responses/default/content/application~1json/schema'
 components:
   parameters: null
   schemas:
@@ -940,6 +1153,12 @@ components:
               type: string
             rp:
               type: string
+            schemaType:
+              default: implicit
+              type: string
+              enum:
+                - implicit
+                - explicit
             createdAt:
               type: string
               format: date-time
@@ -1182,6 +1401,162 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Variable'
+    ColumnDataType:
+      type: string
+      enum:
+        - integer
+        - float
+        - boolean
+        - string
+        - unsigned
+    ColumnSemanticType:
+      type: string
+      nullable: false
+      enum:
+        - timestamp
+        - tag
+        - field
+    MeasurementSchema:
+      description: The schema definition for a single measurement
+      type: object
+      example:
+        id: 1a3c5e7f9b0a8642
+        name: cpu
+        columns:
+          - name: time
+            type: timestamp
+          - name: host
+            type: tag
+          - name: region
+            type: tag
+          - name: usage_user
+            type: field
+            dataType: float
+          - name: usage_user
+            type: field
+            dataType: float
+        createdAt: '2021-01-21T00:48:40.993Z'
+        updatedAt: '2021-01-21T00:48:40.993Z'
+      required:
+        - id
+        - name
+        - columns
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: string
+          readOnly: true
+        name:
+          type: string
+          nullable: false
+        columns:
+          description: An ordered collection of column definitions
+          type: array
+          items:
+            $ref: '#/components/schemas/MeasurementSchemaColumn'
+        createdAt:
+          type: string
+          format: date-time
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          readOnly: true
+    MeasurementSchemaColumn:
+      description: Definition of a measurement column
+      example:
+        name: time
+        type: timestamp
+      type: object
+      required:
+        - name
+        - type
+      properties:
+        name:
+          type: string
+        type:
+          $ref: '#/components/schemas/ColumnSemanticType'
+        dataType:
+          $ref: '#/components/schemas/ColumnDataType'
+    MeasurementSchemaCreateRequest:
+      description: Create a new measurement schema
+      type: object
+      example:
+        name: cpu
+        columns:
+          - name: time
+            type: timestamp
+          - name: host
+            type: tag
+          - name: region
+            type: tag
+          - name: usage_user
+            type: field
+            dataType: float
+          - name: usage_user
+            type: field
+            dataType: float
+      required:
+        - name
+        - columns
+      properties:
+        name:
+          type: string
+        columns:
+          description: An ordered collection of column definitions
+          type: array
+          items:
+            $ref: '#/components/schemas/MeasurementSchemaColumn'
+    MeasurementSchemaList:
+      description: A list of measurement schemas returning summary information
+      example:
+        measurementSchemas:
+          - id: 1a3c5e7f9b0a8642
+            name: cpu
+            createdAt: '2021-01-21T00:48:40.993Z'
+            updatedAt: '2021-01-21T00:48:40.993Z'
+          - id: 1a3c5e7f9b0a8643
+            name: memory
+            createdAt: '2021-01-21T00:48:40.993Z'
+            updatedAt: '2021-01-21T00:48:40.993Z'
+          - id: 1a3c5e7f9b0a8644
+            name: disk
+            createdAt: '2021-01-21T00:48:40.993Z'
+            updatedAt: '2021-01-21T00:48:40.993Z'
+      type: object
+      required:
+        - measurementSchemas
+      properties:
+        measurementSchemas:
+          type: array
+          items:
+            $ref: '#/components/schemas/MeasurementSchema'
+    MeasurementSchemaUpdateRequest:
+      description: Update an existing measurement schema
+      type: object
+      example:
+        columns:
+          - name: time
+            type: timestamp
+          - name: host
+            type: tag
+          - name: region
+            type: tag
+          - name: usage_user
+            type: field
+            dataType: float
+          - name: usage_user
+            type: field
+            dataType: float
+      required:
+        - columns
+      properties:
+        columns:
+          description: An ordered collection of column definitions
+          type: array
+          items:
+            $ref: '#/components/schemas/MeasurementSchemaColumn'
   securitySchemes:
     BasicAuth:
       type: http

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -6447,6 +6447,11 @@ paths:
           description: The organization ID.
           schema:
             type: string
+        - in: query
+          name: name
+          description: Find a measurement with matching name.
+          schema:
+            type: string
         - in: path
           name: bucketID
           description: The ID of the bucket

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -6431,6 +6431,219 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  '/buckets/{bucketID}/schema/measurements':
+    summary: APIs for describing bucket schema
+    get:
+      summary: Retrieve a list of measurement schemas defined for this bucket
+      operationId: getMeasurementSchemas
+      parameters:
+        - in: query
+          name: org
+          description: The organization name.
+          schema:
+            type: string
+        - in: query
+          name: orgID
+          description: The organization ID.
+          schema:
+            type: string
+        - in: path
+          name: bucketID
+          description: The ID of the bucket
+          schema:
+            type: string
+          required: true
+      tags:
+        - Bucket Schemas
+      responses:
+        '200':
+          description: A list of measurement schemas returning summary information
+          headers:
+            ETag:
+              description: The current version of the bucket schema
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MeasurementSchemaList'
+        '404':
+          description: Bucket not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      summary: Create a new measurement schema for this bucket
+      operationId: createMeasurementSchema
+      parameters:
+        - in: query
+          name: org
+          description: The organization name.
+          schema:
+            type: string
+        - in: query
+          name: orgID
+          description: The organization ID.
+          schema:
+            type: string
+        - in: path
+          name: bucketID
+          description: The ID of the bucket
+          schema:
+            type: string
+          required: true
+      tags:
+        - Bucket Schemas
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MeasurementSchemaCreateRequest'
+      responses:
+        '201':
+          description: New measurement schema
+          headers:
+            ETag:
+              description: The current version of the measurement schema
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MeasurementSchema'
+        '400':
+          description: Client error with create request
+          content:
+            application/json:
+              examples:
+                badNameExample:
+                  summary: Invalid name
+                  description: 'The error returned when the name is invalid, such as too few or too many characters or the name contains non-printable ASCII or is not valid UTF-8.'
+                  value:
+                    code: invalid
+                    message: name is invalid
+                missingColumnsExample:
+                  summary: Missing columns
+                  description: The error returned when the request body is missing the columns property.
+                  value:
+                    code: invalid
+                    message: columns is required
+                missingTimestampExample:
+                  summary: Missing timestamp
+                  description: The error returned when the request body is missing a timestamp type column.
+                  value:
+                    code: invalid
+                    message: Timestamp column is required
+                duplicateColumnNamesExample:
+                  summary: Duplicate column names
+                  description: The error returned when the request body contains duplicate column names.
+                  value:
+                    code: invalid
+                    message: Duplicate column names
+                missingFieldExample:
+                  summary: Missing field
+                  description: The error returned when the request body is missing at least one field type column.
+                  value:
+                    code: invalid
+                    message: At least one field column is required
+              schema:
+                $ref: '#/components/schemas/Error'
+  '/buckets/{bucketID}/schema/measurements/{measurementID}':
+    summary: APIs for describing tables
+    get:
+      summary: Fetch schema information for a measurement
+      operationId: getMeasurementSchema
+      parameters:
+        - in: query
+          name: org
+          description: The organization name.
+          schema:
+            type: string
+        - in: query
+          name: orgID
+          description: The organization ID.
+          schema:
+            type: string
+        - in: path
+          name: bucketID
+          description: The ID of the bucket
+          schema:
+            type: string
+          required: true
+        - in: path
+          name: measurementID
+          description: The ID of the measurement
+          schema:
+            type: string
+          required: true
+      tags:
+        - Bucket Schemas
+      responses:
+        '200':
+          description: Schema definition for a single measurement
+          headers:
+            ETag:
+              description: The current version of the measurement schema
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MeasurementSchema'
+    patch:
+      summary: Update existing measurement schema
+      operationId: updateMeasurementSchema
+      parameters:
+        - in: query
+          name: org
+          description: The organization name.
+          schema:
+            type: string
+        - in: query
+          name: orgID
+          description: The organization ID.
+          schema:
+            type: string
+        - in: path
+          name: bucketID
+          description: The ID of the bucket
+          schema:
+            type: string
+          required: true
+        - in: path
+          name: measurementID
+          description: The ID of the measurement
+          schema:
+            type: string
+          required: true
+      tags:
+        - Bucket Schemas
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MeasurementSchemaUpdateRequest'
+      responses:
+        '200':
+          description: Updated measurement schema
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MeasurementSchema'
+        '400':
+          description: Client error updating measurement schema
+          content:
+            application/json:
+              examples:
+                missingColumnsExample:
+                  summary: Deleted columns
+                  description: The error returned when the request body does not contain all the columns from the source.
+                  value:
+                    code: invalid
+                    message: Unable to delete columns from schema
+              schema:
+                $ref: '#/components/schemas/Error'
 components:
   parameters:
     TraceSpan:
@@ -7049,6 +7262,9 @@ components:
           type: string
         retentionRules:
           $ref: '#/components/schemas/RetentionRules'
+        schemaType:
+          $ref: '#/components/schemas/SchemaType'
+          default: implicit
       required:
         - orgID
         - name
@@ -7102,6 +7318,9 @@ components:
           type: string
         rp:
           type: string
+        schemaType:
+          $ref: '#/components/schemas/SchemaType'
+          default: implicit
         createdAt:
           type: string
           format: date-time
@@ -12111,6 +12330,11 @@ components:
           type: boolean
         links:
           $ref: '#/components/schemas/Links'
+    SchemaType:
+      type: string
+      enum:
+        - implicit
+        - explicit
     Resource:
       type: object
       required:
@@ -12458,6 +12682,162 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Variable'
+    ColumnDataType:
+      type: string
+      enum:
+        - integer
+        - float
+        - boolean
+        - string
+        - unsigned
+    ColumnSemanticType:
+      type: string
+      nullable: false
+      enum:
+        - timestamp
+        - tag
+        - field
+    MeasurementSchema:
+      description: The schema definition for a single measurement
+      type: object
+      example:
+        id: 1a3c5e7f9b0a8642
+        name: cpu
+        columns:
+          - name: time
+            type: timestamp
+          - name: host
+            type: tag
+          - name: region
+            type: tag
+          - name: usage_user
+            type: field
+            dataType: float
+          - name: usage_user
+            type: field
+            dataType: float
+        createdAt: '2021-01-21T00:48:40.993Z'
+        updatedAt: '2021-01-21T00:48:40.993Z'
+      required:
+        - id
+        - name
+        - columns
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: string
+          readOnly: true
+        name:
+          type: string
+          nullable: false
+        columns:
+          description: An ordered collection of column definitions
+          type: array
+          items:
+            $ref: '#/components/schemas/MeasurementSchemaColumn'
+        createdAt:
+          type: string
+          format: date-time
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          readOnly: true
+    MeasurementSchemaColumn:
+      description: Definition of a measurement column
+      example:
+        name: time
+        type: timestamp
+      type: object
+      required:
+        - name
+        - type
+      properties:
+        name:
+          type: string
+        type:
+          $ref: '#/components/schemas/ColumnSemanticType'
+        dataType:
+          $ref: '#/components/schemas/ColumnDataType'
+    MeasurementSchemaCreateRequest:
+      description: Create a new measurement schema
+      type: object
+      example:
+        name: cpu
+        columns:
+          - name: time
+            type: timestamp
+          - name: host
+            type: tag
+          - name: region
+            type: tag
+          - name: usage_user
+            type: field
+            dataType: float
+          - name: usage_user
+            type: field
+            dataType: float
+      required:
+        - name
+        - columns
+      properties:
+        name:
+          type: string
+        columns:
+          description: An ordered collection of column definitions
+          type: array
+          items:
+            $ref: '#/components/schemas/MeasurementSchemaColumn'
+    MeasurementSchemaList:
+      description: A list of measurement schemas returning summary information
+      example:
+        measurementSchemas:
+          - id: 1a3c5e7f9b0a8642
+            name: cpu
+            createdAt: '2021-01-21T00:48:40.993Z'
+            updatedAt: '2021-01-21T00:48:40.993Z'
+          - id: 1a3c5e7f9b0a8643
+            name: memory
+            createdAt: '2021-01-21T00:48:40.993Z'
+            updatedAt: '2021-01-21T00:48:40.993Z'
+          - id: 1a3c5e7f9b0a8644
+            name: disk
+            createdAt: '2021-01-21T00:48:40.993Z'
+            updatedAt: '2021-01-21T00:48:40.993Z'
+      type: object
+      required:
+        - measurementSchemas
+      properties:
+        measurementSchemas:
+          type: array
+          items:
+            $ref: '#/components/schemas/MeasurementSchema'
+    MeasurementSchemaUpdateRequest:
+      description: Update an existing measurement schema
+      type: object
+      example:
+        columns:
+          - name: time
+            type: timestamp
+          - name: host
+            type: tag
+          - name: region
+            type: tag
+          - name: usage_user
+            type: field
+            dataType: float
+          - name: usage_user
+            type: field
+            dataType: float
+      required:
+        - columns
+      properties:
+        columns:
+          description: An ordered collection of column definitions
+          type: array
+          items:
+            $ref: '#/components/schemas/MeasurementSchemaColumn'
   securitySchemes:
     BasicAuth:
       type: http

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -6502,6 +6502,9 @@ components:
           type: string
         retentionRules:
           $ref: '#/components/schemas/RetentionRules'
+        schemaType:
+          $ref: '#/components/schemas/SchemaType'
+          default: implicit
       required:
         - orgID
         - name
@@ -6555,6 +6558,9 @@ components:
           type: string
         rp:
           type: string
+        schemaType:
+          $ref: '#/components/schemas/SchemaType'
+          default: implicit
         createdAt:
           type: string
           format: date-time
@@ -11564,3 +11570,8 @@ components:
           type: boolean
         links:
           $ref: '#/components/schemas/Links'
+    SchemaType:
+      type: string
+      enum:
+        - implicit
+        - explicit

--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -985,6 +985,12 @@ components:
               type: string
             rp:
               type: string
+            schemaType:
+              default: implicit
+              type: string
+              enum:
+                - implicit
+                - explicit
             createdAt:
               type: string
               format: date-time

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -7065,6 +7065,9 @@ components:
           type: string
         retentionRules:
           $ref: '#/components/schemas/RetentionRules'
+        schemaType:
+          $ref: '#/components/schemas/SchemaType'
+          default: implicit
       required:
         - orgID
         - name
@@ -7118,6 +7121,9 @@ components:
           type: string
         rp:
           type: string
+        schemaType:
+          $ref: '#/components/schemas/SchemaType'
+          default: implicit
         createdAt:
           type: string
           format: date-time
@@ -12127,6 +12133,11 @@ components:
           type: boolean
         links:
           $ref: '#/components/schemas/Links'
+    SchemaType:
+      type: string
+      enum:
+        - implicit
+        - explicit
     Authorization:
       required:
         - orgID

--- a/contracts/priv/cloud-priv.yml
+++ b/contracts/priv/cloud-priv.yml
@@ -443,6 +443,12 @@ components:
               type: string
             rp:
               type: string
+            schemaType:
+              default: implicit
+              type: string
+              enum:
+                - implicit
+                - explicit
             createdAt:
               type: string
               format: date-time

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -19,6 +19,11 @@ paths:
     $ref: "./common/paths/buckets_bucketID.yml"
   /orgs:
     $ref: "./common/paths/orgs.yml"
+  /buckets/{bucketID}/schema/measurements:
+    $ref: "./cloud/paths/measurements.yml"
+  /buckets/{bucketID}/schema/measurements/{measurementID}:
+    $ref: "./cloud/paths/measurements_measurementID.yml"
+
 components:
   parameters:
     TraceSpan:
@@ -86,3 +91,19 @@ components:
       $ref: "./common/schemas/LineProtocolError.yml"
     LineProtocolLengthError:
       $ref: "./common/schemas/LineProtocolLengthError.yml"
+    SchemaType:
+      $ref: "./common/schemas/SchemaType.yml"
+    ColumnDataType:
+      $ref: "./cloud/schemas/ColumnDataType.yml"
+    ColumnSemanticType:
+      $ref: "./cloud/schemas/ColumnSemanticType.yml"
+    MeasurementSchema:
+      $ref: "./cloud/schemas/MeasurementSchema.yml"
+    MeasurementSchemaColumn:
+      $ref: "./cloud/schemas/MeasurementSchemaColumn.yml"
+    MeasurementSchemaCreateRequest:
+      $ref: "./cloud/schemas/MeasurementSchemaCreateRequest.yml"
+    MeasurementSchemaList:
+      $ref: "./cloud/schemas/MeasurementSchemaList.yml"
+    MeasurementSchemaUpdateRequest:
+      $ref: "./cloud/schemas/MeasurementSchemaUpdateRequest.yml"

--- a/src/cloud.yml
+++ b/src/cloud.yml
@@ -22,6 +22,10 @@ paths:
     $ref: "./cloud/paths/variables.yml"
   "/variables/{variableID}":
     $ref: "./cloud/paths/variables_variableID.yml"
+  /buckets/{bucketID}/schema/measurements:
+    $ref: "./cloud/paths/measurements.yml"
+  /buckets/{bucketID}/schema/measurements/{measurementID}:
+    $ref: "./cloud/paths/measurements_measurementID.yml"
 components:
   parameters:
 #REF_COMMON_PARAMETERS
@@ -49,6 +53,20 @@ components:
       $ref: "./cloud/schemas/Variable.yml"
     Variables:
       $ref: "./cloud/schemas/Variables.yml"
+    ColumnDataType:
+      $ref: "./cloud/schemas/ColumnDataType.yml"
+    ColumnSemanticType:
+      $ref: "./cloud/schemas/ColumnSemanticType.yml"
+    MeasurementSchema:
+      $ref: "./cloud/schemas/MeasurementSchema.yml"
+    MeasurementSchemaColumn:
+      $ref: "./cloud/schemas/MeasurementSchemaColumn.yml"
+    MeasurementSchemaCreateRequest:
+      $ref: "./cloud/schemas/MeasurementSchemaCreateRequest.yml"
+    MeasurementSchemaList:
+      $ref: "./cloud/schemas/MeasurementSchemaList.yml"
+    MeasurementSchemaUpdateRequest:
+      $ref: "./cloud/schemas/MeasurementSchemaUpdateRequest.yml"
   securitySchemes:
     BasicAuth:
       type: http

--- a/src/cloud/paths/measurements.yml
+++ b/src/cloud/paths/measurements.yml
@@ -1,0 +1,128 @@
+summary: APIs for describing bucket schema
+get:
+  summary: Retrieve a list of measurement schemas defined for this bucket
+  operationId: getMeasurementSchemas
+  parameters:
+    - in: query
+      name: org
+      description: The organization name.
+      schema:
+        type: string
+    - in: query
+      name: orgID
+      description: The organization ID.
+      schema:
+        type: string
+    - in: path
+      name: bucketID
+      description: The ID of the bucket
+      schema:
+        type: string
+      required: true
+  tags: ["Bucket Schemas"]
+  responses:
+    200:
+      description: A list of measurement schemas returning summary information
+      headers:
+        ETag:
+          description: The current version of the bucket schema
+          schema:
+            type: string
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/MeasurementSchemaList.yml"
+    404:
+      description: Bucket not found
+      content:
+        application/json:
+          schema:
+            $ref: "../../common/schemas/Error.yml"
+post:
+  summary: Create a new measurement schema for this bucket
+  operationId: createMeasurementSchema
+  parameters:
+    - in: query
+      name: org
+      description: The organization name.
+      schema:
+        type: string
+    - in: query
+      name: orgID
+      description: The organization ID.
+      schema:
+        type: string
+    - in: path
+      name: bucketID
+      description: The ID of the bucket
+      schema:
+        type: string
+      required: true
+  tags: ["Bucket Schemas"]
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: "../schemas/MeasurementSchemaCreateRequest.yml"
+  responses:
+    201:
+      description: "New measurement schema"
+      headers:
+        ETag:
+          description: The current version of the measurement schema
+          schema:
+            type: string
+
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/MeasurementSchema.yml"
+    400:
+      description: Client error with create request
+      content:
+        application/json:
+          examples:
+            badNameExample:
+              summary: Invalid name
+              description: >-
+                The error returned when the name is invalid,
+                such as too few or too many characters or the
+                name contains non-printable ASCII or is not valid
+                UTF-8.
+              value:
+                code: invalid
+                message: name is invalid
+            missingColumnsExample:
+              summary: Missing columns
+              description: >-
+                The error returned when the request body
+                is missing the columns property.
+              value:
+                code: invalid
+                message: columns is required
+            missingTimestampExample:
+              summary: Missing timestamp
+              description: >-
+                The error returned when the request body
+                is missing a timestamp type column.
+              value:
+                code: invalid
+                message: Timestamp column is required
+            duplicateColumnNamesExample:
+              summary: Duplicate column names
+              description: >-
+                The error returned when the request body
+                contains duplicate column names.
+              value:
+                code: invalid
+                message: Duplicate column names
+            missingFieldExample:
+              summary: Missing field
+              description: >-
+                The error returned when the request body
+                is missing at least one field type column.
+              value:
+                code: invalid
+                message: At least one field column is required
+          schema:
+            $ref: "../../common/schemas/Error.yml"

--- a/src/cloud/paths/measurements.yml
+++ b/src/cloud/paths/measurements.yml
@@ -13,6 +13,11 @@ get:
       description: The organization ID.
       schema:
         type: string
+    - in: query
+      name: name
+      description: Find a measurement with matching name.
+      schema:
+        type: string
     - in: path
       name: bucketID
       description: The ID of the bucket

--- a/src/cloud/paths/measurements_measurementID.yml
+++ b/src/cloud/paths/measurements_measurementID.yml
@@ -1,0 +1,96 @@
+summary: APIs for describing tables
+get:
+  summary: Fetch schema information for a measurement
+  operationId: getMeasurementSchema
+  parameters:
+    - in: query
+      name: org
+      description: The organization name.
+      schema:
+        type: string
+    - in: query
+      name: orgID
+      description: The organization ID.
+      schema:
+        type: string
+    - in: path
+      name: bucketID
+      description: The ID of the bucket
+      schema:
+        type: string
+      required: true
+    - in: path
+      name: measurementID
+      description: The ID of the measurement
+      schema:
+        type: string
+      required: true
+  tags: [ "Bucket Schemas" ]
+  responses:
+    200:
+      description: Schema definition for a single measurement
+      headers:
+        ETag:
+          description: The current version of the measurement schema
+          schema:
+            type: string
+
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/MeasurementSchema.yml"
+patch:
+  summary: Update existing measurement schema
+  operationId: updateMeasurementSchema
+  parameters:
+    - in: query
+      name: org
+      description: The organization name.
+      schema:
+        type: string
+    - in: query
+      name: orgID
+      description: The organization ID.
+      schema:
+        type: string
+    - in: path
+      name: bucketID
+      description: The ID of the bucket
+      schema:
+        type: string
+      required: true
+    - in: path
+      name: measurementID
+      description: The ID of the measurement
+      schema:
+        type: string
+      required: true
+  tags: [ "Bucket Schemas" ]
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: "../schemas/MeasurementSchemaUpdateRequest.yml"
+
+  responses:
+    200:
+      description: "Updated measurement schema"
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/MeasurementSchema.yml"
+    400:
+      description: Client error updating measurement schema
+      content:
+        application/json:
+          examples:
+            missingColumnsExample:
+              summary: Deleted columns
+              description: >-
+                The error returned when the request body does
+                not contain all the columns from the source.
+              value:
+                code: invalid
+                message: Unable to delete columns from schema
+          schema:
+            $ref: "../../common/schemas/Error.yml"

--- a/src/cloud/schemas/ColumnDataType.yml
+++ b/src/cloud/schemas/ColumnDataType.yml
@@ -1,0 +1,7 @@
+  type: string
+  enum:
+    - integer
+    - float
+    - boolean
+    - string
+    - unsigned

--- a/src/cloud/schemas/ColumnSemanticType.yml
+++ b/src/cloud/schemas/ColumnSemanticType.yml
@@ -1,0 +1,6 @@
+  type: string
+  nullable: false
+  enum:
+    - timestamp
+    - tag
+    - field

--- a/src/cloud/schemas/MeasurementSchema.yml
+++ b/src/cloud/schemas/MeasurementSchema.yml
@@ -1,0 +1,42 @@
+  description: The schema definition for a single measurement
+  type: object
+  example:
+    id: 1a3c5e7f9b0a8642
+    name: cpu
+    columns:
+      - name: time
+        type: timestamp
+      - name: host
+        type: tag
+      - name: region
+        type: tag
+      - name: usage_user
+        type: field
+        dataType: float
+      - name: usage_user
+        type: field
+        dataType: float
+    createdAt: "2021-01-21T00:48:40.993Z"
+    updatedAt: "2021-01-21T00:48:40.993Z"
+  required: [ "id", "name", "columns", "createdAt", "updatedAt" ]
+  properties:
+    id:
+      type: string
+      readOnly: true
+    name:
+      type: string
+      nullable: false
+    columns:
+      description: >-
+        An ordered collection of column definitions
+      type: array
+      items:
+        $ref: './MeasurementSchemaColumn.yml'
+    createdAt:
+      type: string
+      format: date-time
+      readOnly: true
+    updatedAt:
+      type: string
+      format: date-time
+      readOnly: true

--- a/src/cloud/schemas/MeasurementSchemaColumn.yml
+++ b/src/cloud/schemas/MeasurementSchemaColumn.yml
@@ -1,0 +1,13 @@
+  description: Definition of a measurement column
+  example:
+    name: time
+    type: timestamp
+  type: object
+  required: ["name", "type"]
+  properties:
+    name:
+      type: string
+    type:
+      $ref: "./ColumnSemanticType.yml"
+    dataType:
+      $ref: "./ColumnDataType.yml"

--- a/src/cloud/schemas/MeasurementSchemaCreateRequest.yml
+++ b/src/cloud/schemas/MeasurementSchemaCreateRequest.yml
@@ -1,0 +1,27 @@
+  description: Create a new measurement schema
+  type: object
+  example:
+    name: cpu
+    columns:
+      - name: time
+        type: timestamp
+      - name: host
+        type: tag
+      - name: region
+        type: tag
+      - name: usage_user
+        type: field
+        dataType: float
+      - name: usage_user
+        type: field
+        dataType: float
+  required: ["name", "columns"]
+  properties:
+    name:
+      type: string
+    columns:
+      description: >-
+        An ordered collection of column definitions
+      type: array
+      items:
+        $ref: './MeasurementSchemaColumn.yml'

--- a/src/cloud/schemas/MeasurementSchemaList.yml
+++ b/src/cloud/schemas/MeasurementSchemaList.yml
@@ -1,0 +1,22 @@
+  description: A list of measurement schemas returning summary information
+  example:
+    measurementSchemas:
+      - id: 1a3c5e7f9b0a8642
+        name: cpu
+        createdAt: "2021-01-21T00:48:40.993Z"
+        updatedAt: "2021-01-21T00:48:40.993Z"
+      - id: 1a3c5e7f9b0a8643
+        name: memory
+        createdAt: "2021-01-21T00:48:40.993Z"
+        updatedAt: "2021-01-21T00:48:40.993Z"
+      - id: 1a3c5e7f9b0a8644
+        name: disk
+        createdAt: "2021-01-21T00:48:40.993Z"
+        updatedAt: "2021-01-21T00:48:40.993Z"
+  type: object
+  required: ["measurementSchemas"]
+  properties:
+    measurementSchemas:
+      type: array
+      items:
+        $ref: './MeasurementSchema.yml'

--- a/src/cloud/schemas/MeasurementSchemaUpdateRequest.yml
+++ b/src/cloud/schemas/MeasurementSchemaUpdateRequest.yml
@@ -1,0 +1,24 @@
+  description: Update an existing measurement schema
+  type: object
+  example:
+    columns:
+      - name: time
+        type: timestamp
+      - name: host
+        type: tag
+      - name: region
+        type: tag
+      - name: usage_user
+        type: field
+        dataType: float
+      - name: usage_user
+        type: field
+        dataType: float
+  required: ["columns"]
+  properties:
+    columns:
+      description: >-
+        An ordered collection of column definitions
+      type: array
+      items:
+        $ref: './MeasurementSchemaColumn.yml'

--- a/src/common/_schemas.yml
+++ b/src/common/_schemas.yml
@@ -522,3 +522,5 @@
       $ref: "./common/schemas/DBRPs.yml"
     DBRPUpdate:
       $ref: "./common/schemas/DBRPUpdate.yml"
+    SchemaType:
+      $ref: "./common/schemas/SchemaType.yml"

--- a/src/common/schemas/Bucket.yml
+++ b/src/common/schemas/Bucket.yml
@@ -46,6 +46,9 @@
       type: string
     rp:
       type: string
+    schemaType:
+      $ref: "./SchemaType.yml"
+      default: implicit
     createdAt:
       type: string
       format: date-time

--- a/src/common/schemas/PostBucketRequest.yml
+++ b/src/common/schemas/PostBucketRequest.yml
@@ -9,4 +9,7 @@
       type: string
     retentionRules:
       $ref: "./RetentionRules.yml"
+    schemaType:
+      $ref: "./SchemaType.yml"
+      default: implicit
   required: [orgID, name, retentionRules]

--- a/src/common/schemas/SchemaType.yml
+++ b/src/common/schemas/SchemaType.yml
@@ -1,0 +1,4 @@
+  type: string
+  enum:
+    - implicit
+    - explicit


### PR DESCRIPTION
This PR introduces Cloud 2 specific APIs for managing explicit schema buckets. Most of the changes are in the `cloud`
source tree, as the feature is Cloud 2 only.

The `Bucket` type adds a `schemaType` property. 

* For OSS it is expected to return `implicit`. 
* For Cloud 2 it can be either `implicit` or `explicit`, once the feature is available.