### PR TITLE
feat: extend CLI contract enough to implement `influx bucket` commands

### DIFF
--- a/contracts/cli.yml
+++ b/contracts/cli.yml
@@ -233,6 +233,11 @@ paths:
           description: Only returns buckets with a specific name.
           schema:
             type: string
+        - in: query
+          name: id
+          description: Only returns buckets with a specific ID.
+          schema:
+            type: string
       responses:
         '200':
           description: A list of buckets

--- a/contracts/cli.yml
+++ b/contracts/cli.yml
@@ -367,6 +367,72 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /orgs:
+    get:
+      operationId: GetOrgs
+      tags:
+        - Organizations
+      summary: List all organizations
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - $ref: '#/components/parameters/Offset'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Descending'
+        - in: query
+          name: org
+          schema:
+            type: string
+          description: Filter organizations to a specific organization name.
+        - in: query
+          name: orgID
+          schema:
+            type: string
+          description: Filter organizations to a specific organization ID.
+        - in: query
+          name: userID
+          schema:
+            type: string
+          description: Filter organizations to a specific user ID.
+      responses:
+        '200':
+          description: A list of organizations
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Organizations'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      operationId: PostOrgs
+      tags:
+        - Organizations
+      summary: Create an organization
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+      requestBody:
+        description: Organization to create
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Organization'
+      responses:
+        '201':
+          description: Organization created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Organization'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 components:
   parameters:
     TraceSpan:
@@ -405,6 +471,13 @@ components:
         type: string
       description: |
         The last resource ID from which to seek from (but not including). This is to be used instead of `offset`.
+    Descending:
+      in: query
+      name: descending
+      required: false
+      schema:
+        type: boolean
+        default: false
   schemas:
     Error:
       properties:
@@ -532,11 +605,31 @@ components:
               format: uri
       required:
         - name
+    Links:
+      type: object
+      properties:
+        next:
+          $ref: '#/components/schemas/Link'
+        self:
+          $ref: '#/components/schemas/Link'
+        prev:
+          $ref: '#/components/schemas/Link'
+      required:
+        - self
     Link:
       type: string
       format: uri
       readOnly: true
       description: URI of resource.
+    Organizations:
+      type: object
+      properties:
+        links:
+          $ref: '#/components/schemas/Links'
+        orgs:
+          type: array
+          items:
+            $ref: '#/components/schemas/Organization'
     Organization:
       properties:
         links:
@@ -597,16 +690,7 @@ components:
       properties:
         links:
           readOnly: true
-          type: object
-          properties:
-            next:
-              $ref: '#/components/schemas/Link'
-            self:
-              $ref: '#/components/schemas/Link'
-            prev:
-              $ref: '#/components/schemas/Link'
-          required:
-            - self
+          $ref: '#/components/schemas/Links'
         buckets:
           type: array
           items:

--- a/contracts/cli.yml
+++ b/contracts/cli.yml
@@ -322,7 +322,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Bucket'
+              $ref: '#/components/schemas/PatchBucketRequest'
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -806,6 +806,42 @@ components:
       required:
         - type
         - everySeconds
+    PatchBucketRequest:
+      type: object
+      description: Updates to an existing bucket resource.
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        retentionRules:
+          $ref: '#/components/schemas/PatchRetentionRules'
+    PatchRetentionRules:
+      type: array
+      description: Updates to rules to expire or retain data. No rules means no updates.
+      items:
+        $ref: '#/components/schemas/PatchRetentionRule'
+    PatchRetentionRule:
+      type: object
+      description: Updates to a rule to expire or retain data.
+      properties:
+        type:
+          type: string
+          default: expire
+          enum:
+            - expire
+        everySeconds:
+          type: integer
+          format: int64
+          description: Duration in seconds for how long data will be kept in the database. 0 means infinite.
+          example: 86400
+          minimum: 0
+        shardGroupDurationSeconds:
+          type: integer
+          format: int64
+          description: Shard duration measured in seconds.
+      required:
+        - type
     Labels:
       type: array
       items:

--- a/contracts/cli.yml
+++ b/contracts/cli.yml
@@ -207,6 +207,166 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /buckets:
+    get:
+      operationId: GetBuckets
+      tags:
+        - Buckets
+      summary: List all buckets
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - $ref: '#/components/parameters/Offset'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/After'
+        - in: query
+          name: org
+          description: The organization name.
+          schema:
+            type: string
+        - in: query
+          name: orgID
+          description: The organization ID.
+          schema:
+            type: string
+        - in: query
+          name: name
+          description: Only returns buckets with a specific name.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: A list of buckets
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Buckets'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      operationId: PostBuckets
+      tags:
+        - Buckets
+      summary: Create a bucket
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+      requestBody:
+        description: Bucket to create
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PostBucketRequest'
+      responses:
+        '201':
+          description: Bucket created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Bucket'
+        '422':
+          description: Request body failed validation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  '/buckets/{bucketID}':
+    get:
+      operationId: GetBucketsID
+      tags:
+        - Buckets
+      summary: Retrieve a bucket
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: path
+          name: bucketID
+          schema:
+            type: string
+          required: true
+          description: The bucket ID.
+      responses:
+        '200':
+          description: Bucket details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Bucket'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    patch:
+      operationId: PatchBucketsID
+      tags:
+        - Buckets
+      summary: Update a bucket
+      requestBody:
+        description: Bucket update to apply
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Bucket'
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: path
+          name: bucketID
+          schema:
+            type: string
+          required: true
+          description: The bucket ID.
+      responses:
+        '200':
+          description: An updated bucket
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Bucket'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    delete:
+      operationId: DeleteBucketsID
+      tags:
+        - Buckets
+      summary: Delete a bucket
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: path
+          name: bucketID
+          schema:
+            type: string
+          required: true
+          description: The ID of the bucket to delete.
+      responses:
+        '204':
+          description: Delete has been accepted
+        '404':
+          description: Bucket not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 components:
   parameters:
     TraceSpan:
@@ -221,6 +381,30 @@ components:
       required: false
       schema:
         type: string
+    Offset:
+      in: query
+      name: offset
+      required: false
+      schema:
+        type: integer
+        minimum: 0
+    Limit:
+      in: query
+      name: limit
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 20
+    After:
+      in: query
+      name: after
+      required: false
+      schema:
+        type: string
+      description: |
+        The last resource ID from which to seek from (but not including). This is to be used instead of `offset`.
   schemas:
     Error:
       properties:
@@ -408,6 +592,25 @@ components:
             - inactive
       required:
         - name
+    Buckets:
+      type: object
+      properties:
+        links:
+          readOnly: true
+          type: object
+          properties:
+            next:
+              $ref: '#/components/schemas/Link'
+            self:
+              $ref: '#/components/schemas/Link'
+            prev:
+              $ref: '#/components/schemas/Link'
+          required:
+            - self
+        buckets:
+          type: array
+          items:
+            $ref: '#/components/schemas/Bucket'
     Bucket:
       properties:
         links:
@@ -470,6 +673,22 @@ components:
         labels:
           $ref: '#/components/schemas/Labels'
       required:
+        - name
+        - retentionRules
+    PostBucketRequest:
+      properties:
+        orgID:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        rp:
+          type: string
+        retentionRules:
+          $ref: '#/components/schemas/RetentionRules'
+      required:
+        - orgID
         - name
         - retentionRules
     RetentionRules:

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -3019,6 +3019,11 @@ paths:
           description: Only returns buckets with a specific name.
           schema:
             type: string
+        - in: query
+          name: id
+          description: Only returns buckets with a specific ID.
+          schema:
+            type: string
       responses:
         '200':
           description: A list of buckets

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -3108,7 +3108,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Bucket'
+              $ref: '#/components/schemas/PatchBucketRequest'
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -7132,6 +7132,42 @@ components:
       description: Rules to expire or retain data.  No rules means data never expires.
       items:
         $ref: '#/components/schemas/RetentionRule'
+    PatchBucketRequest:
+      type: object
+      description: Updates to an existing bucket resource.
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        retentionRules:
+          $ref: '#/components/schemas/PatchRetentionRules'
+    PatchRetentionRules:
+      type: array
+      description: Updates to rules to expire or retain data. No rules means no updates.
+      items:
+        $ref: '#/components/schemas/PatchRetentionRule'
+    PatchRetentionRule:
+      type: object
+      description: Updates to a rule to expire or retain data.
+      properties:
+        type:
+          type: string
+          default: expire
+          enum:
+            - expire
+        everySeconds:
+          type: integer
+          format: int64
+          description: Duration in seconds for how long data will be kept in the database. 0 means infinite.
+          example: 86400
+          minimum: 0
+        shardGroupDurationSeconds:
+          type: integer
+          format: int64
+          description: Shard duration measured in seconds.
+      required:
+        - type
     RetentionRule:
       type: object
       properties:

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -3019,6 +3019,11 @@ paths:
           description: Only returns buckets with a specific name.
           schema:
             type: string
+        - in: query
+          name: id
+          description: Only returns buckets with a specific ID.
+          schema:
+            type: string
       responses:
         '200':
           description: A list of buckets

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -3108,7 +3108,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Bucket'
+              $ref: '#/components/schemas/PatchBucketRequest'
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -6585,6 +6585,42 @@ components:
       description: Rules to expire or retain data.  No rules means data never expires.
       items:
         $ref: '#/components/schemas/RetentionRule'
+    PatchBucketRequest:
+      type: object
+      description: Updates to an existing bucket resource.
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        retentionRules:
+          $ref: '#/components/schemas/PatchRetentionRules'
+    PatchRetentionRules:
+      type: array
+      description: Updates to rules to expire or retain data. No rules means no updates.
+      items:
+        $ref: '#/components/schemas/PatchRetentionRule'
+    PatchRetentionRule:
+      type: object
+      description: Updates to a rule to expire or retain data.
+      properties:
+        type:
+          type: string
+          default: expire
+          enum:
+            - expire
+        everySeconds:
+          type: integer
+          format: int64
+          description: Duration in seconds for how long data will be kept in the database. 0 means infinite.
+          example: 86400
+          minimum: 0
+        shardGroupDurationSeconds:
+          type: integer
+          format: int64
+          description: Shard duration measured in seconds.
+      required:
+        - type
     RetentionRule:
       type: object
       properties:

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -3019,6 +3019,11 @@ paths:
           description: Only returns buckets with a specific name.
           schema:
             type: string
+        - in: query
+          name: id
+          description: Only returns buckets with a specific ID.
+          schema:
+            type: string
       responses:
         '200':
           description: A list of buckets

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -3108,7 +3108,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Bucket'
+              $ref: '#/components/schemas/PatchBucketRequest'
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -7177,6 +7177,42 @@ components:
       description: Rules to expire or retain data.  No rules means data never expires.
       items:
         $ref: '#/components/schemas/RetentionRule'
+    PatchBucketRequest:
+      type: object
+      description: Updates to an existing bucket resource.
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        retentionRules:
+          $ref: '#/components/schemas/PatchRetentionRules'
+    PatchRetentionRules:
+      type: array
+      description: Updates to rules to expire or retain data. No rules means no updates.
+      items:
+        $ref: '#/components/schemas/PatchRetentionRule'
+    PatchRetentionRule:
+      type: object
+      description: Updates to a rule to expire or retain data.
+      properties:
+        type:
+          type: string
+          default: expire
+          enum:
+            - expire
+        everySeconds:
+          type: integer
+          format: int64
+          description: Duration in seconds for how long data will be kept in the database. 0 means infinite.
+          example: 86400
+          minimum: 0
+        shardGroupDurationSeconds:
+          type: integer
+          format: int64
+          description: Shard duration measured in seconds.
+      required:
+        - type
     RetentionRule:
       type: object
       properties:

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -64,6 +64,12 @@ components:
       $ref: "./common/schemas/RetentionRules.yml"
     RetentionRule:
       $ref: "./common/schemas/RetentionRule.yml"
+    PatchBucketRequest:
+      $ref: "./common/schemas/PatchBucketRequest.yml"
+    PatchRetentionRules:
+      $ref: "./common/schemas/PatchRetentionRules.yml"
+    PatchRetentionRule:
+      $ref: "./common/schemas/PatchRetentionRule.yml"
     Labels:
       $ref: "./common/schemas/Labels.yml"
     Label:

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -13,10 +13,20 @@ paths:
     $ref: "./common/paths/setup.yml"
   /write:
     $ref: "./common/paths/write.yml"
+  /buckets:
+    $ref: "./common/paths/buckets.yml"
+  /buckets/{bucketID}:
+    $ref: "./common/paths/buckets_bucketID.yml"
 components:
   parameters:
     TraceSpan:
       $ref: "./common/parameters/TraceSpan.yml"
+    Offset:
+      $ref: "./common/parameters/Offset.yml"
+    Limit:
+      $ref: "./common/parameters/Limit.yml"
+    After:
+      $ref: "./common/parameters/After.yml"
   schemas:
     Error:
       $ref: "./common/schemas/Error.yml"
@@ -36,8 +46,12 @@ components:
       $ref: "./common/schemas/Link.yml"
     Organization:
       $ref: "./common/schemas/Organization.yml"
+    Buckets:
+      $ref: "./common/schemas/Buckets.yml"
     Bucket:
       $ref: "./common/schemas/Bucket.yml"
+    PostBucketRequest:
+      $ref: "./common/schemas/PostBucketRequest.yml"
     RetentionRules:
       $ref: "./common/schemas/RetentionRules.yml"
     RetentionRule:

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -17,6 +17,8 @@ paths:
     $ref: "./common/paths/buckets.yml"
   /buckets/{bucketID}:
     $ref: "./common/paths/buckets_bucketID.yml"
+  /orgs:
+    $ref: "./common/paths/orgs.yml"
 components:
   parameters:
     TraceSpan:
@@ -27,6 +29,8 @@ components:
       $ref: "./common/parameters/Limit.yml"
     After:
       $ref: "./common/parameters/After.yml"
+    Descending:
+      $ref: "./common/parameters/Descending.yml"
   schemas:
     Error:
       $ref: "./common/schemas/Error.yml"
@@ -42,8 +46,12 @@ components:
       $ref: "./common/schemas/OnboardingResponse.yml"
     UserResponse:
       $ref: "./common/schemas/UserResponse.yml"
+    Links:
+      $ref: "./common/schemas/Links.yml"
     Link:
       $ref: "./common/schemas/Link.yml"
+    Organizations:
+      $ref: "./common/schemas/Organizations.yml"
     Organization:
       $ref: "./common/schemas/Organization.yml"
     Buckets:

--- a/src/common/_schemas.yml
+++ b/src/common/_schemas.yml
@@ -106,6 +106,12 @@
       $ref: "./common/schemas/Buckets.yml"
     RetentionRules:
       $ref: "./common/schemas/RetentionRules.yml"
+    PatchBucketRequest:
+      $ref: "./common/schemas/PatchBucketRequest.yml"
+    PatchRetentionRules:
+      $ref: "./common/schemas/PatchRetentionRules.yml"
+    PatchRetentionRule:
+      $ref: "./common/schemas/PatchRetentionRule.yml"
     RetentionRule:
       $ref: "./common/schemas/RetentionRule.yml"
     Link:

--- a/src/common/paths/buckets.yml
+++ b/src/common/paths/buckets.yml
@@ -23,6 +23,11 @@ get:
       description: Only returns buckets with a specific name.
       schema:
         type: string
+    - in: query
+      name: id
+      description: Only returns buckets with a specific ID.
+      schema:
+        type: string
   responses:
     "200":
       description: A list of buckets

--- a/src/common/paths/buckets_bucketID.yml
+++ b/src/common/paths/buckets_bucketID.yml
@@ -35,7 +35,7 @@ patch:
     content:
       application/json:
         schema:
-          $ref: "../schemas/Bucket.yml"
+          $ref: "../schemas/PatchBucketRequest.yml"
   parameters:
     - $ref: "../parameters/TraceSpan.yml"
     - in: path

--- a/src/common/schemas/PatchBucketRequest.yml
+++ b/src/common/schemas/PatchBucketRequest.yml
@@ -1,0 +1,9 @@
+type: object
+description: Updates to an existing bucket resource.
+properties:
+  name:
+    type: string
+  description:
+    type: string
+  retentionRules:
+    $ref: "./PatchRetentionRules.yml"

--- a/src/common/schemas/PatchRetentionRule.yml
+++ b/src/common/schemas/PatchRetentionRule.yml
@@ -1,0 +1,19 @@
+type: object
+description: Updates to a rule to expire or retain data.
+properties:
+  type:
+    type: string
+    default: expire
+    enum:
+      - expire
+  everySeconds:
+    type: integer
+    format: int64
+    description: Duration in seconds for how long data will be kept in the database. 0 means infinite.
+    example: 86400
+    minimum: 0
+  shardGroupDurationSeconds:
+    type: integer
+    format: int64
+    description: Shard duration measured in seconds.
+required: [type]

--- a/src/common/schemas/PatchRetentionRules.yml
+++ b/src/common/schemas/PatchRetentionRules.yml
@@ -1,0 +1,4 @@
+  type: array
+  description: Updates to rules to expire or retain data. No rules means no updates.
+  items:
+    $ref: "./PatchRetentionRule.yml"


### PR DESCRIPTION
This required a fix to the spec for the update-bucket API. The previous spec was using `Bucket` as the request body, but that was wrong because:
* Some fields in `Bucket` can't be updated and aren't "seen" by the server-side API implementation
* Things marked as required in `Bucket` aren't necessarily required in update requests