### PR TITLE
fix: remove unsupported PostSetupUser route from OSS API

### DIFF
--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -306,35 +306,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/paths/~1ready/get/responses/default/content/application~1json/schema'
-  /setup/user:
-    post:
-      operationId: PostSetupUser
-      tags:
-        - Setup
-      summary: 'Set up a new user, org and bucket'
-      description: 'Post an onboarding request to set up a new user, org and bucket.'
-      parameters:
-        - $ref: '#/paths/~1ready/get/parameters/0'
-      requestBody:
-        description: Source to create
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/OnboardingRequest'
-      responses:
-        '201':
-          description: 'Created default user, bucket, org'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/OnboardingResponse'
-        default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/paths/~1ready/get/responses/default/content/application~1json/schema'
   /authorizations:
     get:
       operationId: GetAuthorizations

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -6106,35 +6106,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  /setup/user:
-    post:
-      operationId: PostSetupUser
-      tags:
-        - Setup
-      summary: 'Set up a new user, org and bucket'
-      description: 'Post an onboarding request to set up a new user, org and bucket.'
-      parameters:
-        - $ref: '#/components/parameters/TraceSpan'
-      requestBody:
-        description: Source to create
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/OnboardingRequest'
-      responses:
-        '201':
-          description: 'Created default user, bucket, org'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/OnboardingResponse'
-        default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
   /authorizations:
     get:
       operationId: GetAuthorizations

--- a/src/oss.yml
+++ b/src/oss.yml
@@ -16,8 +16,6 @@ paths:
     $ref: "./common/paths/users_userID.yml"
   /setup:
     $ref: "./common/paths/setup.yml"
-  /setup/user:
-    $ref: "./common/paths/setup_user.yml"
   /authorizations:
     $ref: "./common/paths/authorizations.yml"
   /authorizations/{authID}:


### PR DESCRIPTION
Pre-work for influxdata/influxdb#21201. The API's implementation will remain in the server code for at least 1 more patch release, and influxdata/influxdb#21345 is marking the API as deprecated in the swagger.yml copy still tracked in OSS.