### PR TITLE
chore: add functions as a resource type

### DIFF
--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -847,6 +847,7 @@ components:
             - dbrp
             - flows
             - annotations
+            - functions
         id:
           type: string
           nullable: true

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -12368,6 +12368,7 @@ components:
             - dbrp
             - flows
             - annotations
+            - functions
         id:
           type: string
           nullable: true

--- a/contracts/priv/cloud-priv.yml
+++ b/contracts/priv/cloud-priv.yml
@@ -576,6 +576,7 @@ components:
                               - dbrp
                               - flows
                               - annotations
+                              - functions
                           id:
                             type: string
                             nullable: true

--- a/src/cloud/schemas/Resource.yml
+++ b/src/cloud/schemas/Resource.yml
@@ -24,6 +24,7 @@
         - dbrp
         - flows
         - annotations
+        - functions
     id:
       type: string
       nullable: true


### PR DESCRIPTION
Adding functions as a resource type in order for the user to create tokens to access reading/writing functions.