### PR TITLE
feat(oss): list users via the API now supports `offset`, `limit` or `after` parameter

### DIFF
--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -140,6 +140,27 @@ paths:
       summary: List all users
       parameters:
         - $ref: '#/paths/~1ready/get/parameters/0'
+        - in: query
+          name: offset
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+        - in: query
+          name: limit
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+        - in: query
+          name: after
+          required: false
+          schema:
+            type: string
+          description: |
+            The last resource ID from which to seek from (but not including). This is to be used instead of `offset`.
       responses:
         '200':
           description: A list of users

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -5944,6 +5944,9 @@ paths:
       summary: List all users
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
+        - $ref: '#/components/parameters/Offset'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/After'
       responses:
         '200':
           description: A list of users

--- a/src/common/paths/users.yml
+++ b/src/common/paths/users.yml
@@ -5,6 +5,9 @@ get:
   summary: List all users
   parameters:
     - $ref: "../../common/parameters/TraceSpan.yml"
+    - $ref: "../../common/parameters/Offset.yml"
+    - $ref: "../../common/parameters/Limit.yml"
+    - $ref: "../../common/parameters/After.yml"
   responses:
     "200":
       description: A list of users


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb/pull/21367
Related to https://github.com/influxdata/influxdb-client-csharp/issues/190

List users via the API now supports offset, limit or after parameter.