### PR TITLE
fix: use separate models for org POST and PATCH to match actual impl

### DIFF
--- a/contracts/cli.yml
+++ b/contracts/cli.yml
@@ -424,7 +424,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Organization'
+              $ref: '#/components/schemas/PostOrganizationRequest'
       responses:
         '201':
           description: Organization created
@@ -987,6 +987,15 @@ components:
             - inactive
       required:
         - name
+    PostOrganizationRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        required:
+          - name
     Buckets:
       type: object
       properties:

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -3489,7 +3489,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Organization'
+              $ref: '#/components/schemas/PostOrganizationRequest'
       responses:
         '201':
           description: Organization created
@@ -3541,7 +3541,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Organization'
+              $ref: '#/components/schemas/PatchOrganizationRequest'
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -7601,6 +7601,24 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Organization'
+    PostOrganizationRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        required:
+          - name
+    PatchOrganizationRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          description: New name to set on the organization
+        description:
+          type: string
+          description: New description to set on the organization
     TemplateApply:
       type: object
       properties:

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -3489,7 +3489,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Organization'
+              $ref: '#/components/schemas/PostOrganizationRequest'
       responses:
         '201':
           description: Organization created
@@ -3541,7 +3541,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Organization'
+              $ref: '#/components/schemas/PatchOrganizationRequest'
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -6749,6 +6749,24 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Organization'
+    PostOrganizationRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        required:
+          - name
+    PatchOrganizationRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          description: New name to set on the organization
+        description:
+          type: string
+          description: New description to set on the organization
     TemplateApply:
       type: object
       properties:

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -3489,7 +3489,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Organization'
+              $ref: '#/components/schemas/PostOrganizationRequest'
       responses:
         '201':
           description: Organization created
@@ -3541,7 +3541,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Organization'
+              $ref: '#/components/schemas/PatchOrganizationRequest'
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -7319,6 +7319,24 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Organization'
+    PostOrganizationRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        required:
+          - name
+    PatchOrganizationRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          description: New name to set on the organization
+        description:
+          type: string
+          description: New description to set on the organization
     TemplateApply:
       type: object
       properties:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -3314,7 +3314,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Organization'
+              $ref: '#/components/schemas/PostOrganizationRequest'
         description: Organization to create
         required: true
       responses:
@@ -3402,7 +3402,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Organization'
+              $ref: '#/components/schemas/PatchOrganizationRequest'
         description: Organization update to apply
         required: true
       responses:
@@ -11699,6 +11699,15 @@ components:
         retentionRules:
           $ref: '#/components/schemas/PatchRetentionRules'
       type: object
+    PatchOrganizationRequest:
+      properties:
+        description:
+          description: New description to set on the organization
+          type: string
+        name:
+          description: New name to set on the organization
+          type: string
+      type: object
     PatchRetentionRule:
       description: Updates to a rule to expire or retain data.
       properties:
@@ -11783,6 +11792,15 @@ components:
     PostNotificationRule:
       allOf:
       - $ref: '#/components/schemas/NotificationRuleDiscriminator'
+    PostOrganizationRequest:
+      properties:
+        description:
+          type: string
+        name:
+          type: string
+        required:
+        - name
+      type: object
     Property:
       description: The value associated with a key
       properties:

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -3113,7 +3113,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Organization'
+              $ref: '#/components/schemas/PostOrganizationRequest'
         description: Organization to create
         required: true
       responses:
@@ -3201,7 +3201,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Organization'
+              $ref: '#/components/schemas/PatchOrganizationRequest'
         description: Organization update to apply
         required: true
       responses:
@@ -5930,6 +5930,9 @@ paths:
       operationId: GetUsers
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
+      - $ref: '#/components/parameters/Offset'
+      - $ref: '#/components/parameters/Limit'
+      - $ref: '#/components/parameters/After'
       responses:
         "200":
           content:
@@ -9434,6 +9437,15 @@ components:
         retentionRules:
           $ref: '#/components/schemas/PatchRetentionRules'
       type: object
+    PatchOrganizationRequest:
+      properties:
+        description:
+          description: New description to set on the organization
+          type: string
+        name:
+          description: New name to set on the organization
+          type: string
+      type: object
     PatchRetentionRule:
       description: Updates to a rule to expire or retain data.
       properties:
@@ -9518,6 +9530,15 @@ components:
     PostNotificationRule:
       allOf:
       - $ref: '#/components/schemas/NotificationRuleDiscriminator'
+    PostOrganizationRequest:
+      properties:
+        description:
+          type: string
+        name:
+          type: string
+        required:
+        - name
+      type: object
     Property:
       description: The value associated with a key
       properties:

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -60,6 +60,8 @@ components:
       $ref: "./common/schemas/Organizations.yml"
     Organization:
       $ref: "./common/schemas/Organization.yml"
+    PostOrganizationRequest:
+      $ref: "./common/schemas/PostOrganizationRequest.yml"
     Buckets:
       $ref: "./common/schemas/Buckets.yml"
     Bucket:

--- a/src/common/_schemas.yml
+++ b/src/common/_schemas.yml
@@ -126,6 +126,10 @@
       $ref: "./common/schemas/Organization.yml"
     Organizations:
       $ref: "./common/schemas/Organizations.yml"
+    PostOrganizationRequest:
+      $ref: "./common/schemas/PostOrganizationRequest.yml"
+    PatchOrganizationRequest:
+      $ref: "./common/schemas/PatchOrganizationRequest.yml"
     TemplateApply:
       $ref: "./common/schemas/TemplateApply.yml"
     TemplateKind:

--- a/src/common/paths/orgs.yml
+++ b/src/common/paths/orgs.yml
@@ -49,7 +49,7 @@ post:
     content:
       application/json:
         schema:
-          $ref: "../schemas/Organization.yml"
+          $ref: "../schemas/PostOrganizationRequest.yml"
   responses:
     "201":
       description: Organization created

--- a/src/common/paths/orgs_orgID.yml
+++ b/src/common/paths/orgs_orgID.yml
@@ -35,7 +35,7 @@ patch:
     content:
       application/json:
         schema:
-          $ref: "../schemas/Organization.yml"
+          $ref: "../schemas/PatchOrganizationRequest.yml"
   parameters:
     - $ref: "../parameters/TraceSpan.yml"
     - in: path

--- a/src/common/schemas/PatchOrganizationRequest.yml
+++ b/src/common/schemas/PatchOrganizationRequest.yml
@@ -1,0 +1,8 @@
+type: object
+properties:
+  name:
+    type: string
+    description: New name to set on the organization
+  description:
+    type: string
+    description: New description to set on the organization

--- a/src/common/schemas/PostOrganizationRequest.yml
+++ b/src/common/schemas/PostOrganizationRequest.yml
@@ -1,0 +1,7 @@
+type: object
+properties:
+  name:
+    type: string
+  description:
+    type: string
+  required: [name]


### PR DESCRIPTION
Similar to changes made in #36, the spec for patch-/post-ing buckets was reusing the `Organization` schema even though those APIs don't support specifying / overwriting all of the fields that can be in an org.