### PR TITLE
fix: remove Users tag from APIs that have another tag

### DIFF
--- a/contracts/cli.yml
+++ b/contracts/cli.yml
@@ -530,7 +530,6 @@ paths:
     get:
       operationId: GetOrgsIDMembers
       tags:
-        - Users
         - Organizations
       summary: List all members of an organization
       parameters:
@@ -563,7 +562,6 @@ paths:
     post:
       operationId: PostOrgsIDMembers
       tags:
-        - Users
         - Organizations
       summary: Add a member to an organization
       parameters:
@@ -598,7 +596,6 @@ paths:
     delete:
       operationId: DeleteOrgsIDMembersID
       tags:
-        - Users
         - Organizations
       summary: Remove a member from an organization
       parameters:

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -793,7 +793,6 @@ paths:
     get:
       operationId: GetTelegrafsIDMembers
       tags:
-        - Users
         - Telegrafs
       summary: List all users with member privileges for a Telegraf config
       parameters:
@@ -820,7 +819,6 @@ paths:
     post:
       operationId: PostTelegrafsIDMembers
       tags:
-        - Users
         - Telegrafs
       summary: Add a member to a Telegraf config
       parameters:
@@ -855,7 +853,6 @@ paths:
     delete:
       operationId: DeleteTelegrafsIDMembersID
       tags:
-        - Users
         - Telegrafs
       summary: Remove a member from a Telegraf config
       parameters:
@@ -885,7 +882,6 @@ paths:
     get:
       operationId: GetTelegrafsIDOwners
       tags:
-        - Users
         - Telegrafs
       summary: List all owners of a Telegraf config
       parameters:
@@ -912,7 +908,6 @@ paths:
     post:
       operationId: PostTelegrafsIDOwners
       tags:
-        - Users
         - Telegrafs
       summary: Add an owner to a Telegraf config
       parameters:
@@ -947,7 +942,6 @@ paths:
     delete:
       operationId: DeleteTelegrafsIDOwnersID
       tags:
-        - Users
         - Telegrafs
       summary: Remove an owner from a Telegraf config
       parameters:
@@ -1218,7 +1212,6 @@ paths:
     get:
       operationId: GetScrapersIDMembers
       tags:
-        - Users
         - ScraperTargets
       summary: List all users with member privileges for a scraper target
       parameters:
@@ -1245,7 +1238,6 @@ paths:
     post:
       operationId: PostScrapersIDMembers
       tags:
-        - Users
         - ScraperTargets
       summary: Add a member to a scraper target
       parameters:
@@ -1280,7 +1272,6 @@ paths:
     delete:
       operationId: DeleteScrapersIDMembersID
       tags:
-        - Users
         - ScraperTargets
       summary: Remove a member from a scraper target
       parameters:
@@ -1310,7 +1301,6 @@ paths:
     get:
       operationId: GetScrapersIDOwners
       tags:
-        - Users
         - ScraperTargets
       summary: List all owners of a scraper target
       parameters:
@@ -1337,7 +1327,6 @@ paths:
     post:
       operationId: PostScrapersIDOwners
       tags:
-        - Users
         - ScraperTargets
       summary: Add an owner to a scraper target
       parameters:
@@ -1372,7 +1361,6 @@ paths:
     delete:
       operationId: DeleteScrapersIDOwnersID
       tags:
-        - Users
         - ScraperTargets
       summary: Remove an owner from a scraper target
       parameters:
@@ -2604,7 +2592,6 @@ paths:
     get:
       operationId: GetDashboardsIDMembers
       tags:
-        - Users
         - Dashboards
       summary: List all dashboard members
       parameters:
@@ -2631,7 +2618,6 @@ paths:
     post:
       operationId: PostDashboardsIDMembers
       tags:
-        - Users
         - Dashboards
       summary: Add a member to a dashboard
       parameters:
@@ -2666,7 +2652,6 @@ paths:
     delete:
       operationId: DeleteDashboardsIDMembersID
       tags:
-        - Users
         - Dashboards
       summary: Remove a member from a dashboard
       parameters:
@@ -2696,7 +2681,6 @@ paths:
     get:
       operationId: GetDashboardsIDOwners
       tags:
-        - Users
         - Dashboards
       summary: List all dashboard owners
       parameters:
@@ -2723,7 +2707,6 @@ paths:
     post:
       operationId: PostDashboardsIDOwners
       tags:
-        - Users
         - Dashboards
       summary: Add an owner to a dashboard
       parameters:
@@ -2758,7 +2741,6 @@ paths:
     delete:
       operationId: DeleteDashboardsIDOwnersID
       tags:
-        - Users
         - Dashboards
       summary: Remove an owner from a dashboard
       parameters:
@@ -3257,7 +3239,6 @@ paths:
     get:
       operationId: GetBucketsIDMembers
       tags:
-        - Users
         - Buckets
       summary: List all users with member privileges for a bucket
       parameters:
@@ -3284,7 +3265,6 @@ paths:
     post:
       operationId: PostBucketsIDMembers
       tags:
-        - Users
         - Buckets
       summary: Add a member to a bucket
       parameters:
@@ -3319,7 +3299,6 @@ paths:
     delete:
       operationId: DeleteBucketsIDMembersID
       tags:
-        - Users
         - Buckets
       summary: Remove a member from a bucket
       parameters:
@@ -3349,7 +3328,6 @@ paths:
     get:
       operationId: GetBucketsIDOwners
       tags:
-        - Users
         - Buckets
       summary: List all owners of a bucket
       parameters:
@@ -3376,7 +3354,6 @@ paths:
     post:
       operationId: PostBucketsIDOwners
       tags:
-        - Users
         - Buckets
       summary: Add an owner to a bucket
       parameters:
@@ -3411,7 +3388,6 @@ paths:
     delete:
       operationId: DeleteBucketsIDOwnersID
       tags:
-        - Users
         - Buckets
       summary: Remove an owner from a bucket
       parameters:
@@ -3684,7 +3660,6 @@ paths:
     get:
       operationId: GetOrgsIDMembers
       tags:
-        - Users
         - Organizations
       summary: List all members of an organization
       parameters:
@@ -3717,7 +3692,6 @@ paths:
     post:
       operationId: PostOrgsIDMembers
       tags:
-        - Users
         - Organizations
       summary: Add a member to an organization
       parameters:
@@ -3752,7 +3726,6 @@ paths:
     delete:
       operationId: DeleteOrgsIDMembersID
       tags:
-        - Users
         - Organizations
       summary: Remove a member from an organization
       parameters:
@@ -3782,7 +3755,6 @@ paths:
     get:
       operationId: GetOrgsIDOwners
       tags:
-        - Users
         - Organizations
       summary: List all owners of an organization
       parameters:
@@ -3815,7 +3787,6 @@ paths:
     post:
       operationId: PostOrgsIDOwners
       tags:
-        - Users
         - Organizations
       summary: Add an owner to an organization
       parameters:
@@ -3850,7 +3821,6 @@ paths:
     delete:
       operationId: DeleteOrgsIDOwnersID
       tags:
-        - Users
         - Organizations
       summary: Remove an owner from an organization
       parameters:
@@ -4736,7 +4706,6 @@ paths:
     get:
       operationId: GetTasksIDMembers
       tags:
-        - Users
         - Tasks
       summary: List all task members
       parameters:
@@ -4763,7 +4732,6 @@ paths:
     post:
       operationId: PostTasksIDMembers
       tags:
-        - Users
         - Tasks
       summary: Add a member to a task
       parameters:
@@ -4798,7 +4766,6 @@ paths:
     delete:
       operationId: DeleteTasksIDMembersID
       tags:
-        - Users
         - Tasks
       summary: Remove a member from a task
       parameters:
@@ -4828,7 +4795,6 @@ paths:
     get:
       operationId: GetTasksIDOwners
       tags:
-        - Users
         - Tasks
       summary: List all owners of a task
       parameters:
@@ -4855,7 +4821,6 @@ paths:
     post:
       operationId: PostTasksIDOwners
       tags:
-        - Users
         - Tasks
       summary: Add an owner to a task
       parameters:
@@ -4890,7 +4855,6 @@ paths:
     delete:
       operationId: DeleteTasksIDOwnersID
       tags:
-        - Users
         - Tasks
       summary: Remove an owner from a task
       parameters:

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -793,7 +793,6 @@ paths:
     get:
       operationId: GetTelegrafsIDMembers
       tags:
-        - Users
         - Telegrafs
       summary: List all users with member privileges for a Telegraf config
       parameters:
@@ -820,7 +819,6 @@ paths:
     post:
       operationId: PostTelegrafsIDMembers
       tags:
-        - Users
         - Telegrafs
       summary: Add a member to a Telegraf config
       parameters:
@@ -855,7 +853,6 @@ paths:
     delete:
       operationId: DeleteTelegrafsIDMembersID
       tags:
-        - Users
         - Telegrafs
       summary: Remove a member from a Telegraf config
       parameters:
@@ -885,7 +882,6 @@ paths:
     get:
       operationId: GetTelegrafsIDOwners
       tags:
-        - Users
         - Telegrafs
       summary: List all owners of a Telegraf config
       parameters:
@@ -912,7 +908,6 @@ paths:
     post:
       operationId: PostTelegrafsIDOwners
       tags:
-        - Users
         - Telegrafs
       summary: Add an owner to a Telegraf config
       parameters:
@@ -947,7 +942,6 @@ paths:
     delete:
       operationId: DeleteTelegrafsIDOwnersID
       tags:
-        - Users
         - Telegrafs
       summary: Remove an owner from a Telegraf config
       parameters:
@@ -1218,7 +1212,6 @@ paths:
     get:
       operationId: GetScrapersIDMembers
       tags:
-        - Users
         - ScraperTargets
       summary: List all users with member privileges for a scraper target
       parameters:
@@ -1245,7 +1238,6 @@ paths:
     post:
       operationId: PostScrapersIDMembers
       tags:
-        - Users
         - ScraperTargets
       summary: Add a member to a scraper target
       parameters:
@@ -1280,7 +1272,6 @@ paths:
     delete:
       operationId: DeleteScrapersIDMembersID
       tags:
-        - Users
         - ScraperTargets
       summary: Remove a member from a scraper target
       parameters:
@@ -1310,7 +1301,6 @@ paths:
     get:
       operationId: GetScrapersIDOwners
       tags:
-        - Users
         - ScraperTargets
       summary: List all owners of a scraper target
       parameters:
@@ -1337,7 +1327,6 @@ paths:
     post:
       operationId: PostScrapersIDOwners
       tags:
-        - Users
         - ScraperTargets
       summary: Add an owner to a scraper target
       parameters:
@@ -1372,7 +1361,6 @@ paths:
     delete:
       operationId: DeleteScrapersIDOwnersID
       tags:
-        - Users
         - ScraperTargets
       summary: Remove an owner from a scraper target
       parameters:
@@ -2604,7 +2592,6 @@ paths:
     get:
       operationId: GetDashboardsIDMembers
       tags:
-        - Users
         - Dashboards
       summary: List all dashboard members
       parameters:
@@ -2631,7 +2618,6 @@ paths:
     post:
       operationId: PostDashboardsIDMembers
       tags:
-        - Users
         - Dashboards
       summary: Add a member to a dashboard
       parameters:
@@ -2666,7 +2652,6 @@ paths:
     delete:
       operationId: DeleteDashboardsIDMembersID
       tags:
-        - Users
         - Dashboards
       summary: Remove a member from a dashboard
       parameters:
@@ -2696,7 +2681,6 @@ paths:
     get:
       operationId: GetDashboardsIDOwners
       tags:
-        - Users
         - Dashboards
       summary: List all dashboard owners
       parameters:
@@ -2723,7 +2707,6 @@ paths:
     post:
       operationId: PostDashboardsIDOwners
       tags:
-        - Users
         - Dashboards
       summary: Add an owner to a dashboard
       parameters:
@@ -2758,7 +2741,6 @@ paths:
     delete:
       operationId: DeleteDashboardsIDOwnersID
       tags:
-        - Users
         - Dashboards
       summary: Remove an owner from a dashboard
       parameters:
@@ -3257,7 +3239,6 @@ paths:
     get:
       operationId: GetBucketsIDMembers
       tags:
-        - Users
         - Buckets
       summary: List all users with member privileges for a bucket
       parameters:
@@ -3284,7 +3265,6 @@ paths:
     post:
       operationId: PostBucketsIDMembers
       tags:
-        - Users
         - Buckets
       summary: Add a member to a bucket
       parameters:
@@ -3319,7 +3299,6 @@ paths:
     delete:
       operationId: DeleteBucketsIDMembersID
       tags:
-        - Users
         - Buckets
       summary: Remove a member from a bucket
       parameters:
@@ -3349,7 +3328,6 @@ paths:
     get:
       operationId: GetBucketsIDOwners
       tags:
-        - Users
         - Buckets
       summary: List all owners of a bucket
       parameters:
@@ -3376,7 +3354,6 @@ paths:
     post:
       operationId: PostBucketsIDOwners
       tags:
-        - Users
         - Buckets
       summary: Add an owner to a bucket
       parameters:
@@ -3411,7 +3388,6 @@ paths:
     delete:
       operationId: DeleteBucketsIDOwnersID
       tags:
-        - Users
         - Buckets
       summary: Remove an owner from a bucket
       parameters:
@@ -3684,7 +3660,6 @@ paths:
     get:
       operationId: GetOrgsIDMembers
       tags:
-        - Users
         - Organizations
       summary: List all members of an organization
       parameters:
@@ -3717,7 +3692,6 @@ paths:
     post:
       operationId: PostOrgsIDMembers
       tags:
-        - Users
         - Organizations
       summary: Add a member to an organization
       parameters:
@@ -3752,7 +3726,6 @@ paths:
     delete:
       operationId: DeleteOrgsIDMembersID
       tags:
-        - Users
         - Organizations
       summary: Remove a member from an organization
       parameters:
@@ -3782,7 +3755,6 @@ paths:
     get:
       operationId: GetOrgsIDOwners
       tags:
-        - Users
         - Organizations
       summary: List all owners of an organization
       parameters:
@@ -3815,7 +3787,6 @@ paths:
     post:
       operationId: PostOrgsIDOwners
       tags:
-        - Users
         - Organizations
       summary: Add an owner to an organization
       parameters:
@@ -3850,7 +3821,6 @@ paths:
     delete:
       operationId: DeleteOrgsIDOwnersID
       tags:
-        - Users
         - Organizations
       summary: Remove an owner from an organization
       parameters:
@@ -4736,7 +4706,6 @@ paths:
     get:
       operationId: GetTasksIDMembers
       tags:
-        - Users
         - Tasks
       summary: List all task members
       parameters:
@@ -4763,7 +4732,6 @@ paths:
     post:
       operationId: PostTasksIDMembers
       tags:
-        - Users
         - Tasks
       summary: Add a member to a task
       parameters:
@@ -4798,7 +4766,6 @@ paths:
     delete:
       operationId: DeleteTasksIDMembersID
       tags:
-        - Users
         - Tasks
       summary: Remove a member from a task
       parameters:
@@ -4828,7 +4795,6 @@ paths:
     get:
       operationId: GetTasksIDOwners
       tags:
-        - Users
         - Tasks
       summary: List all owners of a task
       parameters:
@@ -4855,7 +4821,6 @@ paths:
     post:
       operationId: PostTasksIDOwners
       tags:
-        - Users
         - Tasks
       summary: Add an owner to a task
       parameters:
@@ -4890,7 +4855,6 @@ paths:
     delete:
       operationId: DeleteTasksIDOwnersID
       tags:
-        - Users
         - Tasks
       summary: Remove an owner from a task
       parameters:

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -793,7 +793,6 @@ paths:
     get:
       operationId: GetTelegrafsIDMembers
       tags:
-        - Users
         - Telegrafs
       summary: List all users with member privileges for a Telegraf config
       parameters:
@@ -820,7 +819,6 @@ paths:
     post:
       operationId: PostTelegrafsIDMembers
       tags:
-        - Users
         - Telegrafs
       summary: Add a member to a Telegraf config
       parameters:
@@ -855,7 +853,6 @@ paths:
     delete:
       operationId: DeleteTelegrafsIDMembersID
       tags:
-        - Users
         - Telegrafs
       summary: Remove a member from a Telegraf config
       parameters:
@@ -885,7 +882,6 @@ paths:
     get:
       operationId: GetTelegrafsIDOwners
       tags:
-        - Users
         - Telegrafs
       summary: List all owners of a Telegraf config
       parameters:
@@ -912,7 +908,6 @@ paths:
     post:
       operationId: PostTelegrafsIDOwners
       tags:
-        - Users
         - Telegrafs
       summary: Add an owner to a Telegraf config
       parameters:
@@ -947,7 +942,6 @@ paths:
     delete:
       operationId: DeleteTelegrafsIDOwnersID
       tags:
-        - Users
         - Telegrafs
       summary: Remove an owner from a Telegraf config
       parameters:
@@ -1218,7 +1212,6 @@ paths:
     get:
       operationId: GetScrapersIDMembers
       tags:
-        - Users
         - ScraperTargets
       summary: List all users with member privileges for a scraper target
       parameters:
@@ -1245,7 +1238,6 @@ paths:
     post:
       operationId: PostScrapersIDMembers
       tags:
-        - Users
         - ScraperTargets
       summary: Add a member to a scraper target
       parameters:
@@ -1280,7 +1272,6 @@ paths:
     delete:
       operationId: DeleteScrapersIDMembersID
       tags:
-        - Users
         - ScraperTargets
       summary: Remove a member from a scraper target
       parameters:
@@ -1310,7 +1301,6 @@ paths:
     get:
       operationId: GetScrapersIDOwners
       tags:
-        - Users
         - ScraperTargets
       summary: List all owners of a scraper target
       parameters:
@@ -1337,7 +1327,6 @@ paths:
     post:
       operationId: PostScrapersIDOwners
       tags:
-        - Users
         - ScraperTargets
       summary: Add an owner to a scraper target
       parameters:
@@ -1372,7 +1361,6 @@ paths:
     delete:
       operationId: DeleteScrapersIDOwnersID
       tags:
-        - Users
         - ScraperTargets
       summary: Remove an owner from a scraper target
       parameters:
@@ -2604,7 +2592,6 @@ paths:
     get:
       operationId: GetDashboardsIDMembers
       tags:
-        - Users
         - Dashboards
       summary: List all dashboard members
       parameters:
@@ -2631,7 +2618,6 @@ paths:
     post:
       operationId: PostDashboardsIDMembers
       tags:
-        - Users
         - Dashboards
       summary: Add a member to a dashboard
       parameters:
@@ -2666,7 +2652,6 @@ paths:
     delete:
       operationId: DeleteDashboardsIDMembersID
       tags:
-        - Users
         - Dashboards
       summary: Remove a member from a dashboard
       parameters:
@@ -2696,7 +2681,6 @@ paths:
     get:
       operationId: GetDashboardsIDOwners
       tags:
-        - Users
         - Dashboards
       summary: List all dashboard owners
       parameters:
@@ -2723,7 +2707,6 @@ paths:
     post:
       operationId: PostDashboardsIDOwners
       tags:
-        - Users
         - Dashboards
       summary: Add an owner to a dashboard
       parameters:
@@ -2758,7 +2741,6 @@ paths:
     delete:
       operationId: DeleteDashboardsIDOwnersID
       tags:
-        - Users
         - Dashboards
       summary: Remove an owner from a dashboard
       parameters:
@@ -3257,7 +3239,6 @@ paths:
     get:
       operationId: GetBucketsIDMembers
       tags:
-        - Users
         - Buckets
       summary: List all users with member privileges for a bucket
       parameters:
@@ -3284,7 +3265,6 @@ paths:
     post:
       operationId: PostBucketsIDMembers
       tags:
-        - Users
         - Buckets
       summary: Add a member to a bucket
       parameters:
@@ -3319,7 +3299,6 @@ paths:
     delete:
       operationId: DeleteBucketsIDMembersID
       tags:
-        - Users
         - Buckets
       summary: Remove a member from a bucket
       parameters:
@@ -3349,7 +3328,6 @@ paths:
     get:
       operationId: GetBucketsIDOwners
       tags:
-        - Users
         - Buckets
       summary: List all owners of a bucket
       parameters:
@@ -3376,7 +3354,6 @@ paths:
     post:
       operationId: PostBucketsIDOwners
       tags:
-        - Users
         - Buckets
       summary: Add an owner to a bucket
       parameters:
@@ -3411,7 +3388,6 @@ paths:
     delete:
       operationId: DeleteBucketsIDOwnersID
       tags:
-        - Users
         - Buckets
       summary: Remove an owner from a bucket
       parameters:
@@ -3684,7 +3660,6 @@ paths:
     get:
       operationId: GetOrgsIDMembers
       tags:
-        - Users
         - Organizations
       summary: List all members of an organization
       parameters:
@@ -3717,7 +3692,6 @@ paths:
     post:
       operationId: PostOrgsIDMembers
       tags:
-        - Users
         - Organizations
       summary: Add a member to an organization
       parameters:
@@ -3752,7 +3726,6 @@ paths:
     delete:
       operationId: DeleteOrgsIDMembersID
       tags:
-        - Users
         - Organizations
       summary: Remove a member from an organization
       parameters:
@@ -3782,7 +3755,6 @@ paths:
     get:
       operationId: GetOrgsIDOwners
       tags:
-        - Users
         - Organizations
       summary: List all owners of an organization
       parameters:
@@ -3815,7 +3787,6 @@ paths:
     post:
       operationId: PostOrgsIDOwners
       tags:
-        - Users
         - Organizations
       summary: Add an owner to an organization
       parameters:
@@ -3850,7 +3821,6 @@ paths:
     delete:
       operationId: DeleteOrgsIDOwnersID
       tags:
-        - Users
         - Organizations
       summary: Remove an owner from an organization
       parameters:
@@ -4736,7 +4706,6 @@ paths:
     get:
       operationId: GetTasksIDMembers
       tags:
-        - Users
         - Tasks
       summary: List all task members
       parameters:
@@ -4763,7 +4732,6 @@ paths:
     post:
       operationId: PostTasksIDMembers
       tags:
-        - Users
         - Tasks
       summary: Add a member to a task
       parameters:
@@ -4798,7 +4766,6 @@ paths:
     delete:
       operationId: DeleteTasksIDMembersID
       tags:
-        - Users
         - Tasks
       summary: Remove a member from a task
       parameters:
@@ -4828,7 +4795,6 @@ paths:
     get:
       operationId: GetTasksIDOwners
       tags:
-        - Users
         - Tasks
       summary: List all owners of a task
       parameters:
@@ -4855,7 +4821,6 @@ paths:
     post:
       operationId: PostTasksIDOwners
       tags:
-        - Users
         - Tasks
       summary: Add an owner to a task
       parameters:
@@ -4890,7 +4855,6 @@ paths:
     delete:
       operationId: DeleteTasksIDOwnersID
       tags:
-        - Users
         - Tasks
       summary: Remove an owner from a task
       parameters:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -464,7 +464,6 @@ paths:
           description: Unexpected error
       summary: List all users with member privileges for a bucket
       tags:
-      - Users
       - Buckets
     post:
       operationId: PostBucketsIDMembers
@@ -498,7 +497,6 @@ paths:
           description: Unexpected error
       summary: Add a member to a bucket
       tags:
-      - Users
       - Buckets
   /api/v2/buckets/{bucketID}/members/{userID}:
     delete:
@@ -528,7 +526,6 @@ paths:
           description: Unexpected error
       summary: Remove a member from a bucket
       tags:
-      - Users
       - Buckets
   /api/v2/buckets/{bucketID}/owners:
     get:
@@ -556,7 +553,6 @@ paths:
           description: Unexpected error
       summary: List all owners of a bucket
       tags:
-      - Users
       - Buckets
     post:
       operationId: PostBucketsIDOwners
@@ -590,7 +586,6 @@ paths:
           description: Unexpected error
       summary: Add an owner to a bucket
       tags:
-      - Users
       - Buckets
   /api/v2/buckets/{bucketID}/owners/{userID}:
     delete:
@@ -620,7 +615,6 @@ paths:
           description: Unexpected error
       summary: Remove an owner from a bucket
       tags:
-      - Users
       - Buckets
   /api/v2/buckets/{bucketID}/schema/measurements:
     get:
@@ -1747,7 +1741,6 @@ paths:
           description: Unexpected error
       summary: List all dashboard members
       tags:
-      - Users
       - Dashboards
     post:
       operationId: PostDashboardsIDMembers
@@ -1781,7 +1774,6 @@ paths:
           description: Unexpected error
       summary: Add a member to a dashboard
       tags:
-      - Users
       - Dashboards
   /api/v2/dashboards/{dashboardID}/members/{userID}:
     delete:
@@ -1811,7 +1803,6 @@ paths:
           description: Unexpected error
       summary: Remove a member from a dashboard
       tags:
-      - Users
       - Dashboards
   /api/v2/dashboards/{dashboardID}/owners:
     get:
@@ -1839,7 +1830,6 @@ paths:
           description: Unexpected error
       summary: List all dashboard owners
       tags:
-      - Users
       - Dashboards
     post:
       operationId: PostDashboardsIDOwners
@@ -1873,7 +1863,6 @@ paths:
           description: Unexpected error
       summary: Add an owner to a dashboard
       tags:
-      - Users
       - Dashboards
   /api/v2/dashboards/{dashboardID}/owners/{userID}:
     delete:
@@ -1903,7 +1892,6 @@ paths:
           description: Unexpected error
       summary: Remove an owner from a dashboard
       tags:
-      - Users
       - Dashboards
   /api/v2/dbrps:
     get:
@@ -3485,7 +3473,6 @@ paths:
           description: Unexpected error
       summary: List all members of an organization
       tags:
-      - Users
       - Organizations
     post:
       operationId: PostOrgsIDMembers
@@ -3519,7 +3506,6 @@ paths:
           description: Unexpected error
       summary: Add a member to an organization
       tags:
-      - Users
       - Organizations
   /api/v2/orgs/{orgID}/members/{userID}:
     delete:
@@ -3549,7 +3535,6 @@ paths:
           description: Unexpected error
       summary: Remove a member from an organization
       tags:
-      - Users
       - Organizations
   /api/v2/orgs/{orgID}/owners:
     get:
@@ -3583,7 +3568,6 @@ paths:
           description: Unexpected error
       summary: List all owners of an organization
       tags:
-      - Users
       - Organizations
     post:
       operationId: PostOrgsIDOwners
@@ -3617,7 +3601,6 @@ paths:
           description: Unexpected error
       summary: Add an owner to an organization
       tags:
-      - Users
       - Organizations
   /api/v2/orgs/{orgID}/owners/{userID}:
     delete:
@@ -3647,7 +3630,6 @@ paths:
           description: Unexpected error
       summary: Remove an owner from an organization
       tags:
-      - Users
       - Organizations
   /api/v2/orgs/{orgID}/secrets:
     get:
@@ -4556,7 +4538,6 @@ paths:
           description: Unexpected error
       summary: List all users with member privileges for a scraper target
       tags:
-      - Users
       - ScraperTargets
     post:
       operationId: PostScrapersIDMembers
@@ -4590,7 +4571,6 @@ paths:
           description: Unexpected error
       summary: Add a member to a scraper target
       tags:
-      - Users
       - ScraperTargets
   /api/v2/scrapers/{scraperTargetID}/members/{userID}:
     delete:
@@ -4620,7 +4600,6 @@ paths:
           description: Unexpected error
       summary: Remove a member from a scraper target
       tags:
-      - Users
       - ScraperTargets
   /api/v2/scrapers/{scraperTargetID}/owners:
     get:
@@ -4648,7 +4627,6 @@ paths:
           description: Unexpected error
       summary: List all owners of a scraper target
       tags:
-      - Users
       - ScraperTargets
     post:
       operationId: PostScrapersIDOwners
@@ -4682,7 +4660,6 @@ paths:
           description: Unexpected error
       summary: Add an owner to a scraper target
       tags:
-      - Users
       - ScraperTargets
   /api/v2/scrapers/{scraperTargetID}/owners/{userID}:
     delete:
@@ -4712,7 +4689,6 @@ paths:
           description: Unexpected error
       summary: Remove an owner from a scraper target
       tags:
-      - Users
       - ScraperTargets
   /api/v2/setup:
     get:
@@ -5596,7 +5572,6 @@ paths:
           description: Unexpected error
       summary: List all task members
       tags:
-      - Users
       - Tasks
     post:
       operationId: PostTasksIDMembers
@@ -5630,7 +5605,6 @@ paths:
           description: Unexpected error
       summary: Add a member to a task
       tags:
-      - Users
       - Tasks
   /api/v2/tasks/{taskID}/members/{userID}:
     delete:
@@ -5660,7 +5634,6 @@ paths:
           description: Unexpected error
       summary: Remove a member from a task
       tags:
-      - Users
       - Tasks
   /api/v2/tasks/{taskID}/owners:
     get:
@@ -5688,7 +5661,6 @@ paths:
           description: Unexpected error
       summary: List all owners of a task
       tags:
-      - Users
       - Tasks
     post:
       operationId: PostTasksIDOwners
@@ -5722,7 +5694,6 @@ paths:
           description: Unexpected error
       summary: Add an owner to a task
       tags:
-      - Users
       - Tasks
   /api/v2/tasks/{taskID}/owners/{userID}:
     delete:
@@ -5752,7 +5723,6 @@ paths:
           description: Unexpected error
       summary: Remove an owner from a task
       tags:
-      - Users
       - Tasks
   /api/v2/tasks/{taskID}/runs:
     get:
@@ -6263,7 +6233,6 @@ paths:
           description: Unexpected error
       summary: List all users with member privileges for a Telegraf config
       tags:
-      - Users
       - Telegrafs
     post:
       operationId: PostTelegrafsIDMembers
@@ -6297,7 +6266,6 @@ paths:
           description: Unexpected error
       summary: Add a member to a Telegraf config
       tags:
-      - Users
       - Telegrafs
   /api/v2/telegrafs/{telegrafID}/members/{userID}:
     delete:
@@ -6327,7 +6295,6 @@ paths:
           description: Unexpected error
       summary: Remove a member from a Telegraf config
       tags:
-      - Users
       - Telegrafs
   /api/v2/telegrafs/{telegrafID}/owners:
     get:
@@ -6355,7 +6322,6 @@ paths:
           description: Unexpected error
       summary: List all owners of a Telegraf config
       tags:
-      - Users
       - Telegrafs
     post:
       operationId: PostTelegrafsIDOwners
@@ -6389,7 +6355,6 @@ paths:
           description: Unexpected error
       summary: Add an owner to a Telegraf config
       tags:
-      - Users
       - Telegrafs
   /api/v2/telegrafs/{telegrafID}/owners/{userID}:
     delete:
@@ -6419,7 +6384,6 @@ paths:
           description: Unexpected error
       summary: Remove an owner from a Telegraf config
       tags:
-      - Users
       - Telegrafs
   /api/v2/templates/apply:
     post:

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -459,7 +459,6 @@ paths:
           description: Unexpected error
       summary: List all users with member privileges for a bucket
       tags:
-      - Users
       - Buckets
     post:
       operationId: PostBucketsIDMembers
@@ -493,7 +492,6 @@ paths:
           description: Unexpected error
       summary: Add a member to a bucket
       tags:
-      - Users
       - Buckets
   /api/v2/buckets/{bucketID}/members/{userID}:
     delete:
@@ -523,7 +521,6 @@ paths:
           description: Unexpected error
       summary: Remove a member from a bucket
       tags:
-      - Users
       - Buckets
   /api/v2/buckets/{bucketID}/owners:
     get:
@@ -551,7 +548,6 @@ paths:
           description: Unexpected error
       summary: List all owners of a bucket
       tags:
-      - Users
       - Buckets
     post:
       operationId: PostBucketsIDOwners
@@ -585,7 +581,6 @@ paths:
           description: Unexpected error
       summary: Add an owner to a bucket
       tags:
-      - Users
       - Buckets
   /api/v2/buckets/{bucketID}/owners/{userID}:
     delete:
@@ -615,7 +610,6 @@ paths:
           description: Unexpected error
       summary: Remove an owner from a bucket
       tags:
-      - Users
       - Buckets
   /api/v2/checks:
     get:
@@ -1517,7 +1511,6 @@ paths:
           description: Unexpected error
       summary: List all dashboard members
       tags:
-      - Users
       - Dashboards
     post:
       operationId: PostDashboardsIDMembers
@@ -1551,7 +1544,6 @@ paths:
           description: Unexpected error
       summary: Add a member to a dashboard
       tags:
-      - Users
       - Dashboards
   /api/v2/dashboards/{dashboardID}/members/{userID}:
     delete:
@@ -1581,7 +1573,6 @@ paths:
           description: Unexpected error
       summary: Remove a member from a dashboard
       tags:
-      - Users
       - Dashboards
   /api/v2/dashboards/{dashboardID}/owners:
     get:
@@ -1609,7 +1600,6 @@ paths:
           description: Unexpected error
       summary: List all dashboard owners
       tags:
-      - Users
       - Dashboards
     post:
       operationId: PostDashboardsIDOwners
@@ -1643,7 +1633,6 @@ paths:
           description: Unexpected error
       summary: Add an owner to a dashboard
       tags:
-      - Users
       - Dashboards
   /api/v2/dashboards/{dashboardID}/owners/{userID}:
     delete:
@@ -1673,7 +1662,6 @@ paths:
           description: Unexpected error
       summary: Remove an owner from a dashboard
       tags:
-      - Users
       - Dashboards
   /api/v2/dbrps:
     get:
@@ -3252,7 +3240,6 @@ paths:
           description: Unexpected error
       summary: List all members of an organization
       tags:
-      - Users
       - Organizations
     post:
       operationId: PostOrgsIDMembers
@@ -3286,7 +3273,6 @@ paths:
           description: Unexpected error
       summary: Add a member to an organization
       tags:
-      - Users
       - Organizations
   /api/v2/orgs/{orgID}/members/{userID}:
     delete:
@@ -3316,7 +3302,6 @@ paths:
           description: Unexpected error
       summary: Remove a member from an organization
       tags:
-      - Users
       - Organizations
   /api/v2/orgs/{orgID}/owners:
     get:
@@ -3350,7 +3335,6 @@ paths:
           description: Unexpected error
       summary: List all owners of an organization
       tags:
-      - Users
       - Organizations
     post:
       operationId: PostOrgsIDOwners
@@ -3384,7 +3368,6 @@ paths:
           description: Unexpected error
       summary: Add an owner to an organization
       tags:
-      - Users
       - Organizations
   /api/v2/orgs/{orgID}/owners/{userID}:
     delete:
@@ -3414,7 +3397,6 @@ paths:
           description: Unexpected error
       summary: Remove an owner from an organization
       tags:
-      - Users
       - Organizations
   /api/v2/orgs/{orgID}/secrets:
     get:
@@ -4017,7 +3999,6 @@ paths:
           description: Unexpected error
       summary: List all users with member privileges for a scraper target
       tags:
-      - Users
       - ScraperTargets
     post:
       operationId: PostScrapersIDMembers
@@ -4051,7 +4032,6 @@ paths:
           description: Unexpected error
       summary: Add a member to a scraper target
       tags:
-      - Users
       - ScraperTargets
   /api/v2/scrapers/{scraperTargetID}/members/{userID}:
     delete:
@@ -4081,7 +4061,6 @@ paths:
           description: Unexpected error
       summary: Remove a member from a scraper target
       tags:
-      - Users
       - ScraperTargets
   /api/v2/scrapers/{scraperTargetID}/owners:
     get:
@@ -4109,7 +4088,6 @@ paths:
           description: Unexpected error
       summary: List all owners of a scraper target
       tags:
-      - Users
       - ScraperTargets
     post:
       operationId: PostScrapersIDOwners
@@ -4143,7 +4121,6 @@ paths:
           description: Unexpected error
       summary: Add an owner to a scraper target
       tags:
-      - Users
       - ScraperTargets
   /api/v2/scrapers/{scraperTargetID}/owners/{userID}:
     delete:
@@ -4173,7 +4150,6 @@ paths:
           description: Unexpected error
       summary: Remove an owner from a scraper target
       tags:
-      - Users
       - ScraperTargets
   /api/v2/setup:
     get:
@@ -5030,7 +5006,6 @@ paths:
           description: Unexpected error
       summary: List all task members
       tags:
-      - Users
       - Tasks
     post:
       operationId: PostTasksIDMembers
@@ -5064,7 +5039,6 @@ paths:
           description: Unexpected error
       summary: Add a member to a task
       tags:
-      - Users
       - Tasks
   /api/v2/tasks/{taskID}/members/{userID}:
     delete:
@@ -5094,7 +5068,6 @@ paths:
           description: Unexpected error
       summary: Remove a member from a task
       tags:
-      - Users
       - Tasks
   /api/v2/tasks/{taskID}/owners:
     get:
@@ -5122,7 +5095,6 @@ paths:
           description: Unexpected error
       summary: List all owners of a task
       tags:
-      - Users
       - Tasks
     post:
       operationId: PostTasksIDOwners
@@ -5156,7 +5128,6 @@ paths:
           description: Unexpected error
       summary: Add an owner to a task
       tags:
-      - Users
       - Tasks
   /api/v2/tasks/{taskID}/owners/{userID}:
     delete:
@@ -5186,7 +5157,6 @@ paths:
           description: Unexpected error
       summary: Remove an owner from a task
       tags:
-      - Users
       - Tasks
   /api/v2/tasks/{taskID}/runs:
     get:
@@ -5697,7 +5667,6 @@ paths:
           description: Unexpected error
       summary: List all users with member privileges for a Telegraf config
       tags:
-      - Users
       - Telegrafs
     post:
       operationId: PostTelegrafsIDMembers
@@ -5731,7 +5700,6 @@ paths:
           description: Unexpected error
       summary: Add a member to a Telegraf config
       tags:
-      - Users
       - Telegrafs
   /api/v2/telegrafs/{telegrafID}/members/{userID}:
     delete:
@@ -5761,7 +5729,6 @@ paths:
           description: Unexpected error
       summary: Remove a member from a Telegraf config
       tags:
-      - Users
       - Telegrafs
   /api/v2/telegrafs/{telegrafID}/owners:
     get:
@@ -5789,7 +5756,6 @@ paths:
           description: Unexpected error
       summary: List all owners of a Telegraf config
       tags:
-      - Users
       - Telegrafs
     post:
       operationId: PostTelegrafsIDOwners
@@ -5823,7 +5789,6 @@ paths:
           description: Unexpected error
       summary: Add an owner to a Telegraf config
       tags:
-      - Users
       - Telegrafs
   /api/v2/telegrafs/{telegrafID}/owners/{userID}:
     delete:
@@ -5853,7 +5818,6 @@ paths:
           description: Unexpected error
       summary: Remove an owner from a Telegraf config
       tags:
-      - Users
       - Telegrafs
   /api/v2/templates/apply:
     post:

--- a/src/common/paths/buckets_bucketID_members.yml
+++ b/src/common/paths/buckets_bucketID_members.yml
@@ -1,7 +1,6 @@
 get:
   operationId: GetBucketsIDMembers
   tags:
-    - Users
     - Buckets
   summary: List all users with member privileges for a bucket
   parameters:
@@ -28,7 +27,6 @@ get:
 post:
   operationId: PostBucketsIDMembers
   tags:
-    - Users
     - Buckets
   summary: Add a member to a bucket
   parameters:

--- a/src/common/paths/buckets_bucketID_members_userID.yml
+++ b/src/common/paths/buckets_bucketID_members_userID.yml
@@ -1,7 +1,6 @@
 delete:
   operationId: DeleteBucketsIDMembersID
   tags:
-    - Users
     - Buckets
   summary: Remove a member from a bucket
   parameters:

--- a/src/common/paths/buckets_bucketID_owners.yml
+++ b/src/common/paths/buckets_bucketID_owners.yml
@@ -1,7 +1,6 @@
 get:
   operationId: GetBucketsIDOwners
   tags:
-    - Users
     - Buckets
   summary: List all owners of a bucket
   parameters:
@@ -28,7 +27,6 @@ get:
 post:
   operationId: PostBucketsIDOwners
   tags:
-    - Users
     - Buckets
   summary: Add an owner to a bucket
   parameters:

--- a/src/common/paths/buckets_bucketID_owners_userID.yml
+++ b/src/common/paths/buckets_bucketID_owners_userID.yml
@@ -1,7 +1,6 @@
 delete:
   operationId: DeleteBucketsIDOwnersID
   tags:
-    - Users
     - Buckets
   summary: Remove an owner from a bucket
   parameters:

--- a/src/common/paths/dashboards_dashboardID_members.yml
+++ b/src/common/paths/dashboards_dashboardID_members.yml
@@ -1,7 +1,6 @@
 get:
   operationId: GetDashboardsIDMembers
   tags:
-    - Users
     - Dashboards
   summary: List all dashboard members
   parameters:
@@ -28,7 +27,6 @@ get:
 post:
   operationId: PostDashboardsIDMembers
   tags:
-    - Users
     - Dashboards
   summary: Add a member to a dashboard
   parameters:

--- a/src/common/paths/dashboards_dashboardID_members_userID.yml
+++ b/src/common/paths/dashboards_dashboardID_members_userID.yml
@@ -1,7 +1,6 @@
 delete:
   operationId: DeleteDashboardsIDMembersID
   tags:
-    - Users
     - Dashboards
   summary: Remove a member from a dashboard
   parameters:

--- a/src/common/paths/dashboards_dashboardID_owners.yml
+++ b/src/common/paths/dashboards_dashboardID_owners.yml
@@ -1,7 +1,6 @@
 get:
   operationId: GetDashboardsIDOwners
   tags:
-    - Users
     - Dashboards
   summary: List all dashboard owners
   parameters:
@@ -28,7 +27,6 @@ get:
 post:
   operationId: PostDashboardsIDOwners
   tags:
-    - Users
     - Dashboards
   summary: Add an owner to a dashboard
   parameters:

--- a/src/common/paths/dashboards_dashboardID_owners_userID.yml
+++ b/src/common/paths/dashboards_dashboardID_owners_userID.yml
@@ -1,7 +1,6 @@
 delete:
   operationId: DeleteDashboardsIDOwnersID
   tags:
-    - Users
     - Dashboards
   summary: Remove an owner from a dashboard
   parameters:

--- a/src/common/paths/orgs_orgID_members.yml
+++ b/src/common/paths/orgs_orgID_members.yml
@@ -1,7 +1,6 @@
 get:
   operationId: GetOrgsIDMembers
   tags:
-    - Users
     - Organizations
   summary: List all members of an organization
   parameters:
@@ -34,7 +33,6 @@ get:
 post:
   operationId: PostOrgsIDMembers
   tags:
-    - Users
     - Organizations
   summary: Add a member to an organization
   parameters:

--- a/src/common/paths/orgs_orgID_members_userID.yml
+++ b/src/common/paths/orgs_orgID_members_userID.yml
@@ -1,7 +1,6 @@
 delete:
   operationId: DeleteOrgsIDMembersID
   tags:
-    - Users
     - Organizations
   summary: Remove a member from an organization
   parameters:

--- a/src/common/paths/orgs_orgID_owners.yml
+++ b/src/common/paths/orgs_orgID_owners.yml
@@ -1,7 +1,6 @@
 get:
   operationId: GetOrgsIDOwners
   tags:
-    - Users
     - Organizations
   summary: List all owners of an organization
   parameters:
@@ -34,7 +33,6 @@ get:
 post:
   operationId: PostOrgsIDOwners
   tags:
-    - Users
     - Organizations
   summary: Add an owner to an organization
   parameters:

--- a/src/common/paths/orgs_orgID_owners_userID.yml
+++ b/src/common/paths/orgs_orgID_owners_userID.yml
@@ -1,7 +1,6 @@
 delete:
   operationId: DeleteOrgsIDOwnersID
   tags:
-    - Users
     - Organizations
   summary: Remove an owner from an organization
   parameters:

--- a/src/common/paths/scrapers_scraperTargetID_members.yml
+++ b/src/common/paths/scrapers_scraperTargetID_members.yml
@@ -1,7 +1,6 @@
 get:
   operationId: GetScrapersIDMembers
   tags:
-    - Users
     - ScraperTargets
   summary: List all users with member privileges for a scraper target
   parameters:
@@ -28,7 +27,6 @@ get:
 post:
   operationId: PostScrapersIDMembers
   tags:
-    - Users
     - ScraperTargets
   summary: Add a member to a scraper target
   parameters:

--- a/src/common/paths/scrapers_scraperTargetID_members_userID.yml
+++ b/src/common/paths/scrapers_scraperTargetID_members_userID.yml
@@ -1,7 +1,6 @@
 delete:
   operationId: DeleteScrapersIDMembersID
   tags:
-    - Users
     - ScraperTargets
   summary: Remove a member from a scraper target
   parameters:

--- a/src/common/paths/scrapers_scraperTargetID_owners.yml
+++ b/src/common/paths/scrapers_scraperTargetID_owners.yml
@@ -1,7 +1,6 @@
 get:
   operationId: GetScrapersIDOwners
   tags:
-    - Users
     - ScraperTargets
   summary: List all owners of a scraper target
   parameters:
@@ -28,7 +27,6 @@ get:
 post:
   operationId: PostScrapersIDOwners
   tags:
-    - Users
     - ScraperTargets
   summary: Add an owner to a scraper target
   parameters:

--- a/src/common/paths/scrapers_scraperTargetID_owners_userID.yml
+++ b/src/common/paths/scrapers_scraperTargetID_owners_userID.yml
@@ -1,7 +1,6 @@
 delete:
   operationId: DeleteScrapersIDOwnersID
   tags:
-    - Users
     - ScraperTargets
   summary: Remove an owner from a scraper target
   parameters:

--- a/src/common/paths/tasks_taskID_members.yml
+++ b/src/common/paths/tasks_taskID_members.yml
@@ -1,7 +1,6 @@
 get:
   operationId: GetTasksIDMembers
   tags:
-    - Users
     - Tasks
   summary: List all task members
   parameters:
@@ -28,7 +27,6 @@ get:
 post:
   operationId: PostTasksIDMembers
   tags:
-    - Users
     - Tasks
   summary: Add a member to a task
   parameters:

--- a/src/common/paths/tasks_taskID_members_userID.yml
+++ b/src/common/paths/tasks_taskID_members_userID.yml
@@ -1,7 +1,6 @@
 delete:
   operationId: DeleteTasksIDMembersID
   tags:
-    - Users
     - Tasks
   summary: Remove a member from a task
   parameters:

--- a/src/common/paths/tasks_taskID_owners.yml
+++ b/src/common/paths/tasks_taskID_owners.yml
@@ -1,7 +1,6 @@
 get:
   operationId: GetTasksIDOwners
   tags:
-    - Users
     - Tasks
   summary: List all owners of a task
   parameters:
@@ -28,7 +27,6 @@ get:
 post:
   operationId: PostTasksIDOwners
   tags:
-    - Users
     - Tasks
   summary: Add an owner to a task
   parameters:

--- a/src/common/paths/tasks_taskID_owners_userID.yml
+++ b/src/common/paths/tasks_taskID_owners_userID.yml
@@ -1,7 +1,6 @@
 delete:
   operationId: DeleteTasksIDOwnersID
   tags:
-    - Users
     - Tasks
   summary: Remove an owner from a task
   parameters:

--- a/src/common/paths/telegrafs_telegrafID_members.yml
+++ b/src/common/paths/telegrafs_telegrafID_members.yml
@@ -1,7 +1,6 @@
 get:
   operationId: GetTelegrafsIDMembers
   tags:
-    - Users
     - Telegrafs
   summary: List all users with member privileges for a Telegraf config
   parameters:
@@ -28,7 +27,6 @@ get:
 post:
   operationId: PostTelegrafsIDMembers
   tags:
-    - Users
     - Telegrafs
   summary: Add a member to a Telegraf config
   parameters:

--- a/src/common/paths/telegrafs_telegrafID_members_userID.yml
+++ b/src/common/paths/telegrafs_telegrafID_members_userID.yml
@@ -1,7 +1,6 @@
 delete:
   operationId: DeleteTelegrafsIDMembersID
   tags:
-    - Users
     - Telegrafs
   summary: Remove a member from a Telegraf config
   parameters:

--- a/src/common/paths/telegrafs_telegrafID_owners.yml
+++ b/src/common/paths/telegrafs_telegrafID_owners.yml
@@ -1,7 +1,6 @@
 get:
   operationId: GetTelegrafsIDOwners
   tags:
-    - Users
     - Telegrafs
   summary: List all owners of a Telegraf config
   parameters:
@@ -28,7 +27,6 @@ get:
 post:
   operationId: PostTelegrafsIDOwners
   tags:
-    - Users
     - Telegrafs
   summary: Add an owner to a Telegraf config
   parameters:

--- a/src/common/paths/telegrafs_telegrafID_owners_userID.yml
+++ b/src/common/paths/telegrafs_telegrafID_owners_userID.yml
@@ -1,7 +1,6 @@
 delete:
   operationId: DeleteTelegrafsIDOwnersID
   tags:
-    - Users
     - Telegrafs
   summary: Remove an owner from a Telegraf config
   parameters:


### PR DESCRIPTION
Some codegen tools use `tags` to group generated components. The openapi-tools generator produces duplicate outputs for routes that are tagged twice.