### PR TITLE
fix(unity): remove response nesting for paths that return one array

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -124,7 +124,7 @@ paths:
         - Usage
       responses:
         '200':
-          description: Usage vectors for the account
+          description: List of usage vectors for the account
           content:
             application/json:
               schema:
@@ -1103,19 +1103,9 @@ components:
           - email
           - role
     Invites:
-      type: object
-      properties:
-        links:
-          type: object
-          readOnly: true
-          properties:
-            self:
-              type: string
-              format: uri
-        invites:
-          type: array
-          items:
-            $ref: '#/components/schemas/Invite'
+      type: array
+      items:
+        $ref: '#/components/schemas/Invite'
     PaymentMethodPut:
       properties:
         paymentMethodId:
@@ -1191,12 +1181,9 @@ components:
           - expirationMonth
           - expirationYear
     UsageVectors:
-      type: object
-      properties:
-        usageVectors:
-          type: array
-          items:
-            $ref: '#/components/schemas/UsageVector'
+      type: array
+      items:
+        $ref: '#/components/schemas/UsageVector'
     UsageVector:
       properties:
         name:
@@ -1238,12 +1225,9 @@ components:
           - targetDate
           - filesId
     Invoices:
-      type: object
-      properties:
-        invoices:
-          type: array
-          items:
-            $ref: '#/components/schemas/Invoice'
+      type: array
+      items:
+        $ref: '#/components/schemas/Invoice'
     User:
       properties:
         id:
@@ -1322,19 +1306,9 @@ components:
           - isOperator
           - isRegionBeta
     Users:
-      type: object
-      properties:
-        links:
-          type: object
-          readOnly: true
-          properties:
-            self:
-              type: string
-              format: uri
-        users:
-          type: array
-          items:
-            $ref: '#/components/schemas/User'
+      type: array
+      items:
+        $ref: '#/components/schemas/User'
     Organization:
       type: object
       properties:

--- a/src/unity/paths/usage_vectors.yml
+++ b/src/unity/paths/usage_vectors.yml
@@ -4,7 +4,7 @@ get:
     - Usage
   responses:
     '200':
-      description: Usage vectors for the account
+      description: List of usage vectors for the account
       content:
         application/json:
           schema:

--- a/src/unity/schemas/Invites.yml
+++ b/src/unity/schemas/Invites.yml
@@ -1,13 +1,3 @@
-type: object
-properties:
-  links:
-    type: object
-    readOnly: true
-    properties:
-      self:
-        type: string
-        format: uri
-  invites:
-    type: array
-    items:
-      $ref: './Invite.yml'
+type: array
+items:
+  $ref: './Invite.yml'

--- a/src/unity/schemas/Invoices.yml
+++ b/src/unity/schemas/Invoices.yml
@@ -1,6 +1,3 @@
-type: object
-properties:
-  invoices:
-    type: array
-    items:
-      $ref: './Invoice.yml'
+type: array
+items:
+  $ref: './Invoice.yml'

--- a/src/unity/schemas/UsageVectors.yml
+++ b/src/unity/schemas/UsageVectors.yml
@@ -1,6 +1,3 @@
-type: object
-properties:
-  usageVectors:
-    type: array
-    items:
-      $ref: './UsageVector.yml'
+type: array
+items:
+  $ref: './UsageVector.yml'

--- a/src/unity/schemas/Users.yml
+++ b/src/unity/schemas/Users.yml
@@ -1,13 +1,3 @@
-type: object
-properties:
-  links:
-    type: object
-    readOnly: true
-    properties:
-      self:
-        type: string
-        format: uri
-  users:
-    type: array
-    items:
-      $ref: './User.yml'
+type: array
+items:
+  $ref: './User.yml'


### PR DESCRIPTION
Initial definitions for routes that return one array of objects were set-up to nest the array within an object: 

Example: 
```
{
"invites": [
    {
      "id": "string",
      "email": "string",
      "role": "member",
      "expiresAt": "2021-05-17T18:09:57.289Z",
      "required": "string"
    }
  ]
}
```

However for consistency with OEM api we are removing the nesting, so the new response for applicable routes will be:
```
{
[
    {
      "id": "string",
      "email": "string",
      "role": "member",
      "expiresAt": "2021-05-17T18:09:57.289Z",
      "required": "string"
    }
  ]
}
```

Effected routes are: 
- `GET /billing/invoices`
- `GET /usage/vectors`
- `GET /orgs/{orgId}/users`
- `GET /orgs/{orgId}/invites`