### PR TITLE
fix(unity): update vector name to match backend

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -151,7 +151,7 @@ paths:
             type: string
             enum:
               - storage_gb
-              - write_mb
+              - writes_mb
               - reads_gb
               - query_count
           description: The name of the UsageVector to query.

--- a/src/unity/paths/usage_vector_name.yml
+++ b/src/unity/paths/usage_vector_name.yml
@@ -8,7 +8,7 @@ get:
       required: true
       schema:
         type: string
-        enum: [storage_gb, write_mb, reads_gb, query_count]
+        enum: [storage_gb, writes_mb, reads_gb, query_count]
       description: The name of the UsageVector to query.
       example: 'reads_gb'
     - in: query


### PR DESCRIPTION
Quartz handles `writes` as `writes_mb`, so the list of allowed `vector_name` was updated to reflect `writes_mb`.