### PR TITLE
fix(unity): add error definition to usage rate limits

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -178,6 +178,9 @@ paths:
                   #default,reads_gb,,,,
                   ,result,table,_field,_time,_value
                   ,,0,reads_gb,2021-01-13T22:05:00Z,120
+        '400':
+          description: Invalid query param name - Bad request
+          $ref: '#/components/responses/ServerError'
         '401':
           description: Unauthorized
           $ref: '#/components/responses/ServerError'
@@ -236,6 +239,15 @@ paths:
                   #default,rate_limits,,,,
                   ,result,table,_field,_time,_value
                   ,,0,rate_limits,2021-01-13T22:05:00Z,120
+        '400':
+          description: Invalid query param name - Bad request
+          $ref: '#/components/responses/ServerError'
+        '401':
+          description: Unauthorized
+          $ref: '#/components/responses/ServerError'
+        '404':
+          description: Invalid vector_name or start or User/Org not found
+          $ref: '#/components/responses/ServerError'
         default:
           description: Unexpected error
           $ref: '#/components/responses/ServerError'

--- a/src/unity/paths/usage_rate_limits.yml
+++ b/src/unity/paths/usage_rate_limits.yml
@@ -22,18 +22,6 @@ get:
               #default,rate_limits,,,,
               ,result,table,_field,_time,_value
               ,,0,rate_limits,2021-01-13T22:05:00Z,120
-    '400':
-      description: Invalid query param name - Bad Request
-      $ref: '../../common/responses/ServerError.yml
-'
-    '401':
-      description: Unauthorized
-      $ref: '../../common/responses/ServerError.yml
-'
-    '404':
-      description: Invalid vector_name or start or User/Org not found
-      $ref: '../../common/responses/ServerError.yml
-'
     default:
       description: Unexpected error
       $ref: '../../common/responses/ServerError.yml

--- a/src/unity/paths/usage_rate_limits.yml
+++ b/src/unity/paths/usage_rate_limits.yml
@@ -22,6 +22,18 @@ get:
               #default,rate_limits,,,,
               ,result,table,_field,_time,_value
               ,,0,rate_limits,2021-01-13T22:05:00Z,120
+    '400':
+      description: Invalid query param name - Bad request
+      $ref: '../../common/responses/ServerError.yml
+'
+    '401':
+      description: Unauthorized
+      $ref: '../../common/responses/ServerError.yml
+'
+    '404':
+      description: Invalid vector_name or start or User/Org not found
+      $ref: '../../common/responses/ServerError.yml
+'
     default:
       description: Unexpected error
       $ref: '../../common/responses/ServerError.yml

--- a/src/unity/paths/usage_rate_limits.yml
+++ b/src/unity/paths/usage_rate_limits.yml
@@ -22,6 +22,18 @@ get:
               #default,rate_limits,,,,
               ,result,table,_field,_time,_value
               ,,0,rate_limits,2021-01-13T22:05:00Z,120
+    '400':
+      description: Invalid query param name - Bad Request
+      $ref: '../../common/responses/ServerError.yml
+'
+    '401':
+      description: Unauthorized
+      $ref: '../../common/responses/ServerError.yml
+'
+    '404':
+      description: Invalid vector_name or start or User/Org not found
+      $ref: '../../common/responses/ServerError.yml
+'
     default:
       description: Unexpected error
       $ref: '../../common/responses/ServerError.yml

--- a/src/unity/paths/usage_vector_name.yml
+++ b/src/unity/paths/usage_vector_name.yml
@@ -30,6 +30,10 @@ get:
               #default,reads_gb,,,,
               ,result,table,_field,_time,_value
               ,,0,reads_gb,2021-01-13T22:05:00Z,120
+    '400':
+      description: Invalid query param name - Bad request
+      $ref: '../../common/responses/ServerError.yml
+'
     '401':
       description: Unauthorized
       $ref: '../../common/responses/ServerError.yml

--- a/src/unity/paths/usage_vector_name.yml
+++ b/src/unity/paths/usage_vector_name.yml
@@ -30,6 +30,10 @@ get:
               #default,reads_gb,,,,
               ,result,table,_field,_time,_value
               ,,0,reads_gb,2021-01-13T22:05:00Z,120
+    '400':
+      description: Invalid query param name - Bad Request
+      $ref: '../../common/responses/ServerError.yml
+'
     '401':
       description: Unauthorized
       $ref: '../../common/responses/ServerError.yml

--- a/src/unity/paths/usage_vector_name.yml
+++ b/src/unity/paths/usage_vector_name.yml
@@ -30,10 +30,6 @@ get:
               #default,reads_gb,,,,
               ,result,table,_field,_time,_value
               ,,0,reads_gb,2021-01-13T22:05:00Z,120
-    '400':
-      description: Invalid query param name - Bad Request
-      $ref: '../../common/responses/ServerError.yml
-'
     '401':
       description: Unauthorized
       $ref: '../../common/responses/ServerError.yml


### PR DESCRIPTION
Defined specific errors for `GET /usage/rate_limits` and added a missing definition for `GET /usage/{vector_name}`. 

-400: invalid query param name
-401: unauthorized 
-404: invalid path param; user/org not found