### PR TITLE
feat: specify date format for DateTimeLiteral

### DIFF
--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -7096,6 +7096,7 @@ components:
           $ref: '#/components/schemas/NodeType'
         value:
           type: string
+          format: date-time
     DurationLiteral:
       description: Represents the elapsed time between two instants as an int64 nanosecond count with syntax of golang's time.Duration
       type: object

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -6316,6 +6316,7 @@ components:
           $ref: '#/components/schemas/NodeType'
         value:
           type: string
+          format: date-time
     DurationLiteral:
       description: Represents the elapsed time between two instants as an int64 nanosecond count with syntax of golang's time.Duration
       type: object

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -6820,6 +6820,7 @@ components:
           $ref: '#/components/schemas/NodeType'
         value:
           type: string
+          format: date-time
     DurationLiteral:
       description: Represents the elapsed time between two instants as an int64 nanosecond count with syntax of golang's time.Duration
       type: object

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -8757,6 +8757,7 @@ components:
         type:
           $ref: '#/components/schemas/NodeType'
         value:
+          format: date-time
           type: string
       type: object
     DeadmanCheck:

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -7419,6 +7419,7 @@ components:
         type:
           $ref: '#/components/schemas/NodeType'
         value:
+          format: date-time
           type: string
       type: object
     DeadmanCheck:

--- a/src/common/schemas/DateTimeLiteral.yml
+++ b/src/common/schemas/DateTimeLiteral.yml
@@ -5,3 +5,4 @@
       $ref: "./NodeType.yml"
     value:
       type: string
+      format: date-time


### PR DESCRIPTION
The `DateTimeLiteral` should be specified  with `format` property as a `date-time`. It is useful for generated client because the property will be defined as a `DateTime` not `String`.

![image](https://user-images.githubusercontent.com/455137/118774244-e8c02600-b885-11eb-9893-87b55743383e.png)
- https://github.com/influxdata/flux/blob/eb2e578d5af6fc5a6f4a3f8a0ec0a640506f7b1d/ast/ast.go#L1738

![image](https://user-images.githubusercontent.com/455137/118774163-d47c2900-b885-11eb-86f4-02dd5db53a3d.png)
- https://swagger.io/docs/specification/data-models/data-types/#format