### PR TITLE
Add a tag to the PostDelete operation.

### DIFF
--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -1609,6 +1609,8 @@ paths:
   /delete:
     post:
       operationId: PostDelete
+      tags:
+        - Delete
       summary: Delete time series data from InfluxDB
       requestBody:
         description: Predicate delete request

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -1609,6 +1609,8 @@ paths:
   /delete:
     post:
       operationId: PostDelete
+      tags:
+        - Delete
       summary: Delete time series data from InfluxDB
       requestBody:
         description: Predicate delete request

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -1609,6 +1609,8 @@ paths:
   /delete:
     post:
       operationId: PostDelete
+      tags:
+        - Delete
       summary: Delete time series data from InfluxDB
       requestBody:
         description: Predicate delete request

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -2171,6 +2171,8 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: internal server error
       summary: Delete time series data from InfluxDB
+      tags:
+      - Delete
   /api/v2/documents/templates:
     get:
       operationId: GetDocumentsTemplates

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -1941,6 +1941,8 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: internal server error
       summary: Delete time series data from InfluxDB
+      tags:
+      - Delete
   /api/v2/documents/templates:
     get:
       operationId: GetDocumentsTemplates

--- a/src/common/paths/delete.yml
+++ b/src/common/paths/delete.yml
@@ -1,5 +1,7 @@
 post:
   operationId: PostDelete
+  tags:
+    - Delete
   summary: Delete time series data from InfluxDB
   requestBody:
     description: Predicate delete request


### PR DESCRIPTION
This helps codegen systems name the generated API intelligently. Without the tag it ends up in a "default" bucket.