### PR TITLE
feat: add unsupported media type as error code

### DIFF
--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -1570,6 +1570,7 @@ components:
                   - unauthorized
                   - method not allowed
                   - request too large
+                  - unsupported media type
               message:
                 readOnly: true
                 description: message is a human-readable message.

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -8824,6 +8824,7 @@ components:
             - unauthorized
             - method not allowed
             - request too large
+            - unsupported media type
         message:
           readOnly: true
           description: message is a human-readable message.

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -8044,6 +8044,7 @@ components:
             - unauthorized
             - method not allowed
             - request too large
+            - unsupported media type
         message:
           readOnly: true
           description: message is a human-readable message.

--- a/contracts/managed-functions.yml
+++ b/contracts/managed-functions.yml
@@ -302,6 +302,7 @@ components:
             - unauthorized
             - method not allowed
             - request too large
+            - unsupported media type
         message:
           readOnly: true
           description: message is a human-readable message.

--- a/contracts/mapsd.yml
+++ b/contracts/mapsd.yml
@@ -47,6 +47,7 @@ components:
             - unauthorized
             - method not allowed
             - request too large
+            - unsupported media type
         message:
           readOnly: true
           description: message is a human-readable message.

--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -1133,6 +1133,7 @@ components:
                   - unauthorized
                   - method not allowed
                   - request too large
+                  - unsupported media type
               message:
                 readOnly: true
                 description: message is a human-readable message.

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -8548,6 +8548,7 @@ components:
             - unauthorized
             - method not allowed
             - request too large
+            - unsupported media type
         message:
           readOnly: true
           description: message is a human-readable message.

--- a/contracts/priv/annotationd.yml
+++ b/contracts/priv/annotationd.yml
@@ -453,6 +453,7 @@ components:
             - unauthorized
             - method not allowed
             - request too large
+            - unsupported media type
         message:
           readOnly: true
           description: message is a human-readable message.

--- a/contracts/priv/cloud-priv.yml
+++ b/contracts/priv/cloud-priv.yml
@@ -653,6 +653,7 @@ components:
             - unauthorized
             - method not allowed
             - request too large
+            - unsupported media type
         message:
           readOnly: true
           description: message is a human-readable message.

--- a/contracts/priv/notebooksd.yml
+++ b/contracts/priv/notebooksd.yml
@@ -395,6 +395,7 @@ components:
             - unauthorized
             - method not allowed
             - request too large
+            - unsupported media type
         message:
           readOnly: true
           description: message is a human-readable message.

--- a/contracts/priv/quartz-oem.yml
+++ b/contracts/priv/quartz-oem.yml
@@ -246,6 +246,7 @@ components:
             - unauthorized
             - method not allowed
             - request too large
+            - unsupported media type
         message:
           readOnly: true
           description: message is a human-readable message.

--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -875,6 +875,7 @@ components:
             - unauthorized
             - method not allowed
             - request too large
+            - unsupported media type
         message:
           readOnly: true
           description: message is a human-readable message.

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -9038,6 +9038,7 @@ components:
           - unauthorized
           - method not allowed
           - request too large
+          - unsupported media type
           readOnly: true
           type: string
         err:

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -7700,6 +7700,7 @@ components:
           - unauthorized
           - method not allowed
           - request too large
+          - unsupported media type
           readOnly: true
           type: string
         err:

--- a/contracts/svc/annotationd.yml
+++ b/contracts/svc/annotationd.yml
@@ -453,6 +453,7 @@ components:
             - unauthorized
             - method not allowed
             - request too large
+            - unsupported media type
         message:
           readOnly: true
           description: message is a human-readable message.

--- a/contracts/svc/managed-functions.yml
+++ b/contracts/svc/managed-functions.yml
@@ -302,6 +302,7 @@ components:
             - unauthorized
             - method not allowed
             - request too large
+            - unsupported media type
         message:
           readOnly: true
           description: message is a human-readable message.

--- a/contracts/svc/mapsd.yml
+++ b/contracts/svc/mapsd.yml
@@ -47,6 +47,7 @@ components:
             - unauthorized
             - method not allowed
             - request too large
+            - unsupported media type
         message:
           readOnly: true
           description: message is a human-readable message.

--- a/contracts/svc/notebooksd.yml
+++ b/contracts/svc/notebooksd.yml
@@ -395,6 +395,7 @@ components:
             - unauthorized
             - method not allowed
             - request too large
+            - unsupported media type
         message:
           readOnly: true
           description: message is a human-readable message.

--- a/src/common/schemas/ErrorCode.yml
+++ b/src/common/schemas/ErrorCode.yml
@@ -15,3 +15,4 @@ enum:
   - unauthorized
   - method not allowed
   - request too large
+  - unsupported media type


### PR DESCRIPTION
Quartz is going to return a 415 unsupported media type when the content type is not supported. It looks like IDPE translates unsupported media type to invalid, but this will likely be updated in the future.