### PR TITLE
fix(unity): add error definition to usage billing stats route

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -208,6 +208,9 @@ paths:
                   #default,billing_stats,,,,
                   ,result,table,_field,_time,_value
                   ,,0,billing_stats,2021-01-13T22:05:00Z,120
+        '401':
+          description: Unauthorized
+          $ref: '#/components/responses/ServerError'
         default:
           description: Unexpected error
           $ref: '#/components/responses/ServerError'

--- a/src/unity/paths/usage_billing_stats.yml
+++ b/src/unity/paths/usage_billing_stats.yml
@@ -15,6 +15,10 @@ get:
               #default,billing_stats,,,,
               ,result,table,_field,_time,_value
               ,,0,billing_stats,2021-01-13T22:05:00Z,120
+    '401':
+      description: Unauthorized
+      $ref: '../../common/responses/ServerError.yml
+'
     default:
       description: Unexpected error
       $ref: '../../common/responses/ServerError.yml


### PR DESCRIPTION
Add error response definition to `GET /usage/billing_stats`.