### PR TITLE
fix: add tableOptions type

### DIFF
--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -9874,6 +9874,7 @@ components:
           description: 'If true, will display note when empty'
           type: boolean
         tableOptions:
+          type: object
           properties:
             verticalTimeAxis:
               description: verticalTimeAxis describes the orientation of the table by indicating whether the time axis will be displayed vertically

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -9094,6 +9094,7 @@ components:
           description: 'If true, will display note when empty'
           type: boolean
         tableOptions:
+          type: object
           properties:
             verticalTimeAxis:
               description: verticalTimeAxis describes the orientation of the table by indicating whether the time axis will be displayed vertically

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -9598,6 +9598,7 @@ components:
           description: 'If true, will display note when empty'
           type: boolean
         tableOptions:
+          type: object
           properties:
             verticalTimeAxis:
               description: verticalTimeAxis describes the orientation of the table by indicating whether the time axis will be displayed vertically

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -12675,6 +12675,7 @@ components:
               - wrap
               - single-line
               type: string
+          type: object
         timeFormat:
           description: timeFormat describes the display format for time values according
             to moment.js date formatting

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -10388,6 +10388,7 @@ components:
               - wrap
               - single-line
               type: string
+          type: object
         timeFormat:
           description: timeFormat describes the display format for time values according
             to moment.js date formatting

--- a/src/common/schemas/TableViewProperties.yml
+++ b/src/common/schemas/TableViewProperties.yml
@@ -32,6 +32,7 @@
       description: If true, will display note when empty
       type: boolean
     tableOptions:
+      type: object
       properties:
         verticalTimeAxis:
           description: >-


### PR DESCRIPTION
Adds `type: object` to `tableOptions` schema. Without `type`, openapi generator produces incorrect / unusable code for some languages.