### PR TITLE
chore: specify schema name for inlined request schema

### DIFF
--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -2180,6 +2180,7 @@ paths:
           application/json:
             schema:
               type: object
+              title: PatchDashboardRequest
               properties:
                 name:
                   description: 'optional, when provided will replace the name'
@@ -3901,6 +3902,7 @@ paths:
           application/json:
             schema:
               type: object
+              title: PostStackRequest
               properties:
                 orgID:
                   type: string
@@ -3970,6 +3972,7 @@ paths:
           application/json:
             schema:
               type: object
+              title: PatchStackRequest
               properties:
                 name:
                   type: string

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -2180,6 +2180,7 @@ paths:
           application/json:
             schema:
               type: object
+              title: PatchDashboardRequest
               properties:
                 name:
                   description: 'optional, when provided will replace the name'
@@ -3901,6 +3902,7 @@ paths:
           application/json:
             schema:
               type: object
+              title: PostStackRequest
               properties:
                 orgID:
                   type: string
@@ -3970,6 +3972,7 @@ paths:
           application/json:
             schema:
               type: object
+              title: PatchStackRequest
               properties:
                 name:
                   type: string

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -2180,6 +2180,7 @@ paths:
           application/json:
             schema:
               type: object
+              title: PatchDashboardRequest
               properties:
                 name:
                   description: 'optional, when provided will replace the name'
@@ -3901,6 +3902,7 @@ paths:
           application/json:
             schema:
               type: object
+              title: PostStackRequest
               properties:
                 orgID:
                   type: string
@@ -3970,6 +3972,7 @@ paths:
           application/json:
             schema:
               type: object
+              title: PatchStackRequest
               properties:
                 name:
                   type: string

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -1322,6 +1322,7 @@ paths:
                 name:
                   description: optional, when provided will replace the name
                   type: string
+              title: PatchDashboardRequest
               type: object
         description: Patching of a dashboard
         required: true
@@ -5060,6 +5061,7 @@ paths:
                   items:
                     type: string
                   type: array
+              title: PostStackRequest
               type: object
         description: Stack to create.
         required: true
@@ -5171,6 +5173,7 @@ paths:
                     type: string
                   nullable: true
                   type: array
+              title: PatchStackRequest
               type: object
         description: Influx stack to update.
         required: true

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -1095,6 +1095,7 @@ paths:
                 name:
                   description: optional, when provided will replace the name
                   type: string
+              title: PatchDashboardRequest
               type: object
         description: Patching of a dashboard
         required: true
@@ -4500,6 +4501,7 @@ paths:
                   items:
                     type: string
                   type: array
+              title: PostStackRequest
               type: object
         description: Stack to create.
         required: true
@@ -4611,6 +4613,7 @@ paths:
                     type: string
                   nullable: true
                   type: array
+              title: PatchStackRequest
               type: object
         description: Influx stack to update.
         required: true

--- a/src/common/paths/dashboards_dashboardID.yml
+++ b/src/common/paths/dashboards_dashboardID.yml
@@ -52,6 +52,7 @@ patch:
       application/json:
         schema:
           type: object
+          title: PatchDashboardRequest
           properties:
             name:
               description: optional, when provided will replace the name

--- a/src/common/paths/stacks.yml
+++ b/src/common/paths/stacks.yml
@@ -50,6 +50,7 @@ post:
       application/json:
         schema:
           type: object
+          title: PostStackRequest
           properties:
             orgID:
               type: string

--- a/src/common/paths/stacks_stack_id.yml
+++ b/src/common/paths/stacks_stack_id.yml
@@ -42,6 +42,7 @@ patch:
       application/json:
         schema:
           type: object
+          title: PatchStackRequest
           properties:
             name:
               type: string


### PR DESCRIPTION
The [OpenApi](https://github.com/OpenAPITools/openapi-generator) generator uses name convention: `InlineObject1`, `InlineObject2`, ... for inlined schema without specified `title`. This naming strategy can brings problems in future maintaining our clients.


- https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#schemaObject