### PR TITLE
chore: updated spacing and enum format to make generated types and stuff check out

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -147,8 +147,8 @@ paths:
         - in: path
           name: vector_name
           required: true
+          type: string
           schema:
-            type: string
             enum:
               - storage_gb
               - writes_mb
@@ -923,10 +923,10 @@ components:
         url:
           description: link to marketplace
           type: string
-        required:
-          - name
-          - shortName
-          - url
+      required:
+        - name
+        - shortName
+        - url
     BillingInfo:
       properties:
         balance:
@@ -941,10 +941,10 @@ components:
           description: date of last update to account
         contact:
           $ref: '#/components/schemas/BillingContact'
-        required:
-          - balance
-          - balanceUpdatedAt
-          - contact
+      required:
+        - balance
+        - balanceUpdatedAt
+        - contact
     Account:
       properties:
         id:
@@ -984,13 +984,13 @@ components:
         billingContact:
           $ref: '#/components/schemas/BillingContact'
           description: billing contact for the account
-        required:
-          - id
-          - balance
-          - billingContact
-          - marketplace
-          - users
-          - type
+      required:
+        - id
+        - balance
+        - billingContact
+        - marketplace
+        - users
+        - type
     Accounts:
       items:
         $ref: '#/components/schemas/Account'
@@ -999,15 +999,15 @@ components:
         title:
           type: string
           description: title of the region
-        required:
-          - title
+      required:
+        - title
     BillingDate:
       properties:
         dateTime:
           type: string
           description: UTC datetime representing the start of the billing period for the account
-        required:
-          - dateTime
+      required:
+        - dateTime
     BillingContact:
       properties:
         companyName:
@@ -1040,15 +1040,15 @@ components:
         postalCode:
           type: number
           description: postal code of billing contact
-        required:
-          - companyName
-          - email
-          - firstName
-          - lastName
-          - country
-          - street1
-          - city
-          - postalCode
+      required:
+        - companyName
+        - email
+        - firstName
+        - lastName
+        - country
+        - street1
+        - city
+        - postalCode
     BillingNotifySettings:
       properties:
         isNotify:
@@ -1060,10 +1060,10 @@ components:
         notifyEmail:
           type: string
           description: email to send notification
-        required:
-          - isNotify
-          - balanceThreshold
-          - notifyEmail
+      required:
+        - isNotify
+        - balanceThreshold
+        - notifyEmail
     CheckoutRequest:
       properties:
         paymentMethodId:
@@ -1114,10 +1114,10 @@ components:
           readOnly: true
           format: date-time
           type: string
-        required:
-          - id
-          - email
-          - role
+      required:
+        - id
+        - email
+        - role
     Invites:
       type: array
       items:
@@ -1165,15 +1165,15 @@ components:
           type: string
           readOnly: true
           description: uri of the embedded iframe
-        required:
-          - id
-          - tenantId
-          - key
-          - signature
-          - token
-          - style
-          - submitEnabled
-          - url
+      required:
+        - id
+        - tenantId
+        - key
+        - signature
+        - token
+        - style
+        - submitEnabled
+        - url
     PaymentMethod:
       properties:
         cardType:
@@ -1191,11 +1191,11 @@ components:
         defaultPaymentMethod:
           description: this the default payment method
           type: boolean
-        required:
-          - cardType
-          - cardNumber
-          - expirationMonth
-          - expirationYear
+      required:
+        - cardType
+        - cardNumber
+        - expirationMonth
+        - expirationYear
     UsageVectors:
       type: array
       items:
@@ -1214,10 +1214,10 @@ components:
           description: key in flux response
           type: string
           example: storage_gb
-        required:
-          - name
-          - unit
-          - fluxKey
+      required:
+        - name
+        - unit
+        - fluxKey
     Invoice:
       properties:
         status:
@@ -1235,11 +1235,11 @@ components:
         filesId:
           description: id of the invoice file
           type: string
-        required:
-          - status
-          - amount
-          - targetDate
-          - filesId
+      required:
+        - status
+        - amount
+        - targetDate
+        - filesId
     Invoices:
       type: array
       items:
@@ -1281,10 +1281,10 @@ components:
               format: uri
           example:
             self: /api/v2private/users/1
-        required:
-          - id
-          - email
-          - role
+      required:
+        - id
+        - email
+        - role
     Me:
       properties:
         id:
@@ -1314,13 +1314,13 @@ components:
         isOperator:
           type: boolean
           description: whether the user is an operator
-        required:
-          - id
-          - accountType
-          - billingProvider
-          - email
-          - isOperator
-          - isRegionBeta
+      required:
+        - id
+        - accountType
+        - billingProvider
+        - email
+        - isOperator
+        - isRegionBeta
     Users:
       type: array
       items:
@@ -1349,13 +1349,13 @@ components:
         relatedAccount:
           $ref: '#/components/schemas/RelatedAccount'
           description: subset of related account information
-        required:
-          - id
-          - quartzId
-          - name
-          - region
-          - provider
-          - date
+      required:
+        - id
+        - quartzId
+        - name
+        - region
+        - provider
+        - date
     Organizations:
       type: array
       items:
@@ -1380,11 +1380,11 @@ components:
         balance:
           type: number
           description: 'remaining balance on the account, nil if none'
-        required:
-          - id
-          - email
-          - type
-          - balance
+      required:
+        - id
+        - email
+        - type
+        - balance
     OrgLimits:
       type: object
       properties:

--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -147,8 +147,8 @@ paths:
         - in: path
           name: vector_name
           required: true
-          type: string
           schema:
+            type: string
             enum:
               - storage_gb
               - writes_mb

--- a/src/unity/paths/payment_form.yml
+++ b/src/unity/paths/payment_form.yml
@@ -8,7 +8,9 @@ get:
       required: true
       schema:
         type: string
-        enum: [checkout, billing]
+        enum:
+          - checkout
+          - billing
       description: The name of the PaymentForm to query.
       example: 'checkout'
   responses:

--- a/src/unity/paths/usage_rate_limits.yml
+++ b/src/unity/paths/usage_rate_limits.yml
@@ -7,7 +7,10 @@ get:
       name: range
       schema:
         type: string
-        enum: [24h, 7d, 30d]
+        enum:
+          - 24h
+          - 7d
+          - 30d
         default: 24h
   responses:
     '200':

--- a/src/unity/paths/usage_vector_name.yml
+++ b/src/unity/paths/usage_vector_name.yml
@@ -6,8 +6,8 @@ get:
     - in: path
       name: vector_name
       required: true
-      type: string
       schema:
+        type: string
         enum:
           - storage_gb
           - writes_mb

--- a/src/unity/paths/usage_vector_name.yml
+++ b/src/unity/paths/usage_vector_name.yml
@@ -6,16 +6,23 @@ get:
     - in: path
       name: vector_name
       required: true
+      type: string
       schema:
-        type: string
-        enum: [storage_gb, writes_mb, reads_gb, query_count]
+        enum:
+          - storage_gb
+          - writes_mb
+          - reads_gb
+          - query_count
       description: The name of the UsageVector to query.
       example: 'reads_gb'
     - in: query
       name: range
       schema:
         type: string
-        enum: [24h, 7d, 30d]
+        enum:
+          - 24h
+          - 7d
+          - 30d
         default: 24h
   responses:
     '200':

--- a/src/unity/schemas/Account.yml
+++ b/src/unity/schemas/Account.yml
@@ -15,9 +15,9 @@ properties:
     type: string
     description: type of the account
     enum:
-    - free
-    - cancelled
-    - pay_as_you_go
+      - free
+      - cancelled
+      - pay_as_you_go
   organizations:
     $ref: './Organizations.yml'
   zuoraAccountId:
@@ -36,4 +36,4 @@ properties:
   billingContact:
     $ref: './BillingContact.yml'
     description: billing contact for the account
-  required: [id, balance, billingContact, marketplace, users, type]
+required: [id, balance, billingContact, marketplace, users, type]

--- a/src/unity/schemas/BillingContact.yml
+++ b/src/unity/schemas/BillingContact.yml
@@ -29,14 +29,5 @@ properties:
   postalCode:
     type: number
     description: postal code of billing contact
-  required:
-    [
-      companyName,
-      email,
-      firstName,
-      lastName,
-      country,
-      street1,
-      city,
-      postalCode,
-    ]
+required:
+  [companyName, email, firstName, lastName, country, street1, city, postalCode]

--- a/src/unity/schemas/BillingDate.yml
+++ b/src/unity/schemas/BillingDate.yml
@@ -2,4 +2,4 @@ properties:
   dateTime:
     type: string
     description: UTC datetime representing the start of the billing period for the account
-  required: [dateTime]
+required: [dateTime]

--- a/src/unity/schemas/BillingInfo.yml
+++ b/src/unity/schemas/BillingInfo.yml
@@ -11,4 +11,4 @@ properties:
     description: date of last update to account
   contact:
     $ref: './BillingContact.yml'
-  required: [balance, balanceUpdatedAt, contact]
+required: [balance, balanceUpdatedAt, contact]

--- a/src/unity/schemas/BillingNotifySettings.yml
+++ b/src/unity/schemas/BillingNotifySettings.yml
@@ -8,4 +8,4 @@ properties:
   notifyEmail:
     type: string
     description: email to send notification
-  required: [isNotify, balanceThreshold, notifyEmail]
+required: [isNotify, balanceThreshold, notifyEmail]

--- a/src/unity/schemas/CreditCardParams.yml
+++ b/src/unity/schemas/CreditCardParams.yml
@@ -27,11 +27,11 @@ properties:
     description: boolean string 'true' or 'false' which allows us to handle submits from our form
     type: string
     enum:
-    - 'true'
-    - 'false'
+      - 'true'
+      - 'false'
     readOnly: true
   url:
     type: string
     readOnly: true
     description: uri of the embedded iframe
-  required: [id, tenantId, key, signature, token, style, submitEnabled, url]
+required: [id, tenantId, key, signature, token, style, submitEnabled, url]

--- a/src/unity/schemas/Invite.yml
+++ b/src/unity/schemas/Invite.yml
@@ -8,11 +8,11 @@ properties:
   role:
     type: string
     enum:
-    - member
-    - owner
+      - member
+      - owner
   expiresAt:
     description: when the invite will expire
     readOnly: true
     format: date-time
     type: string
-  required: [id, email, role]
+required: [id, email, role]

--- a/src/unity/schemas/Invoice.yml
+++ b/src/unity/schemas/Invoice.yml
@@ -14,4 +14,4 @@ properties:
   filesId:
     description: id of the invoice file
     type: string
-  required: [status, amount, targetDate, filesId]
+required: [status, amount, targetDate, filesId]

--- a/src/unity/schemas/Marketplace.yml
+++ b/src/unity/schemas/Marketplace.yml
@@ -19,4 +19,4 @@ properties:
   url:
     description: link to marketplace
     type: string
-  required: [name, shortName, url]
+required: [name, shortName, url]

--- a/src/unity/schemas/Me.yml
+++ b/src/unity/schemas/Me.yml
@@ -9,9 +9,9 @@ properties:
     type: string
     description: type of the account
     enum:
-    - free
-    - cancelled
-    - pay_as_you_go
+      - free
+      - cancelled
+      - pay_as_you_go
   billingProvider:
     type: string
     description: the billing provider for the account, nil if none
@@ -26,4 +26,4 @@ properties:
   isOperator:
     type: boolean
     description: whether the user is an operator
-  required: [id, accountType, billingProvider, email, isOperator, isRegionBeta]
+required: [id, accountType, billingProvider, email, isOperator, isRegionBeta]

--- a/src/unity/schemas/Organization.yml
+++ b/src/unity/schemas/Organization.yml
@@ -21,4 +21,4 @@ properties:
   relatedAccount:
     $ref: './RelatedAccount.yml'
     description: subset of related account information
-  required: [id, quartzId, name, region, provider, date]
+required: [id, quartzId, name, region, provider, date]

--- a/src/unity/schemas/PaymentMethod.yml
+++ b/src/unity/schemas/PaymentMethod.yml
@@ -14,4 +14,4 @@ properties:
   defaultPaymentMethod:
     description: this the default payment method
     type: boolean
-  required: [cardType, cardNumber, expirationMonth, expirationYear]
+required: [cardType, cardNumber, expirationMonth, expirationYear]

--- a/src/unity/schemas/Region.yml
+++ b/src/unity/schemas/Region.yml
@@ -2,4 +2,4 @@ properties:
   title:
     type: string
     description: title of the region
-  required: [title]
+required: [title]

--- a/src/unity/schemas/RelatedAccount.yml
+++ b/src/unity/schemas/RelatedAccount.yml
@@ -11,10 +11,10 @@ properties:
     type: string
     description: type of the account
     enum:
-    - free
-    - cancelled
-    - pay_as_you_go
+      - free
+      - cancelled
+      - pay_as_you_go
   balance:
     type: number
     description: remaining balance on the account, nil if none
-  required: [id, email, type, balance]
+required: [id, email, type, balance]

--- a/src/unity/schemas/UsageVector.yml
+++ b/src/unity/schemas/UsageVector.yml
@@ -11,4 +11,4 @@ properties:
     description: key in flux response
     type: string
     example: 'storage_gb'
-  required: [name, unit, fluxKey]
+required: [name, unit, fluxKey]

--- a/src/unity/schemas/User.yml
+++ b/src/unity/schemas/User.yml
@@ -23,8 +23,8 @@ properties:
   role:
     type: string
     enum:
-    - member
-    - owner
+      - member
+      - owner
   links:
     type: object
     readOnly: true
@@ -34,4 +34,4 @@ properties:
         format: uri
     example:
       self: '/api/v2private/users/1'
-  required: [id, email, role]
+required: [id, email, role]


### PR DESCRIPTION
Previously generate types were setting `required` as an optional parameter rather than having the nested parameters be required.

In addition, the `enums` in the paths weren't listing an enum, but were rather simply saying that the parameter was a string