### PR TITLE
fix: id of NotificationRuleBase is not required

### DIFF
--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -11850,7 +11850,6 @@ components:
     NotificationRuleBase:
       type: object
       required:
-        - id
         - orgID
         - status
         - name

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -11070,7 +11070,6 @@ components:
     NotificationRuleBase:
       type: object
       required:
-        - id
         - orgID
         - status
         - name

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -11582,7 +11582,6 @@ components:
     NotificationRuleBase:
       type: object
       required:
-        - id
         - orgID
         - status
         - name

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -10956,7 +10956,6 @@ components:
           readOnly: true
           type: string
       required:
-      - id
       - orgID
       - status
       - name

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -9108,7 +9108,6 @@ components:
           readOnly: true
           type: string
       required:
-      - id
       - orgID
       - status
       - name

--- a/src/common/schemas/NotificationRuleBase.yml
+++ b/src/common/schemas/NotificationRuleBase.yml
@@ -1,6 +1,5 @@
   type: object
   required:
-    - id
     - orgID
     - status
     - name


### PR DESCRIPTION
The `id` of `NotificationRuleBase` should not be required property.

 The `NotificationRuleBase` schema is also used for creating `NotificationRules` via inheritance.

https://github.com/influxdata/openapi/blob/1c8992412d666deec3522c5dae6dedec85c294e4/src/common/paths/notificationRules.yml#L41

PostNotificationRule > NotificationRuleDiscriminator > SlackNotificationRule > NotificationRuleBase