### PR TITLE
chore: updating the strictness of invites

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -1115,7 +1115,6 @@ components:
           format: date-time
           type: string
       required:
-        - id
         - email
         - role
     Invites:

--- a/src/unity/schemas/Invite.yml
+++ b/src/unity/schemas/Invite.yml
@@ -15,4 +15,4 @@ properties:
     readOnly: true
     format: date-time
     type: string
-required: [id, email, role]
+required: [email, role]


### PR DESCRIPTION
The reason we aren't making the `id` property required is because when we create the invite, the ID hasn't been generated yet