### PR TITLE
chore: remove useless RequestBody for `Retry a task run`

### DIFF
--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -4457,11 +4457,6 @@ paths:
       tags:
         - Tasks
       summary: Retry a task run
-      requestBody:
-        content:
-          application/json; charset=utf-8:
-            schema:
-              type: object
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -4457,11 +4457,6 @@ paths:
       tags:
         - Tasks
       summary: Retry a task run
-      requestBody:
-        content:
-          application/json; charset=utf-8:
-            schema:
-              type: object
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -4457,11 +4457,6 @@ paths:
       tags:
         - Tasks
       summary: Retry a task run
-      requestBody:
-        content:
-          application/json; charset=utf-8:
-            schema:
-              type: object
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -5885,11 +5885,6 @@ paths:
         required: true
         schema:
           type: string
-      requestBody:
-        content:
-          application/json; charset=utf-8:
-            schema:
-              type: object
       responses:
         "200":
           content:

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -5325,11 +5325,6 @@ paths:
         required: true
         schema:
           type: string
-      requestBody:
-        content:
-          application/json; charset=utf-8:
-            schema:
-              type: object
       responses:
         "200":
           content:

--- a/src/common/paths/tasks_taskID_runs_runID_retry.yml
+++ b/src/common/paths/tasks_taskID_runs_runID_retry.yml
@@ -3,11 +3,6 @@ post:
   tags:
     - Tasks
   summary: Retry a task run
-  requestBody:
-    content:
-      application/json; charset=utf-8:
-        schema:
-          type: object
   parameters:
     - $ref: "../parameters/TraceSpan.yml"
     - in: path


### PR DESCRIPTION
The request body for `Retry a task run` operation can be omitted. The server implementation only uses query parameters:

https://github.com/influxdata/influxdb/blob/00420fb54c79b9c3ce33b02fe5717a4365a32fe7/http/task_service.go#L1381.

And also the [OpenAPI](https://github.com/OpenAPITools/openapi-generator) generator generate useless model object with name `UNKNOWN_BASE_TYPE`.