### PR TITLE
chore: updating the strictness of NotificationRuleBase

### DIFF
--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -11366,7 +11366,6 @@ components:
         - orgID
         - status
         - name
-        - tagRules
         - statusRules
         - endpointID
       properties:

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -10586,7 +10586,6 @@ components:
         - orgID
         - status
         - name
-        - tagRules
         - statusRules
         - endpointID
       properties:

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -11098,7 +11098,6 @@ components:
         - orgID
         - status
         - name
-        - tagRules
         - statusRules
         - endpointID
       properties:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -10959,7 +10959,6 @@ components:
       - orgID
       - status
       - name
-      - tagRules
       - statusRules
       - endpointID
       type: object

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -9111,7 +9111,6 @@ components:
       - orgID
       - status
       - name
-      - tagRules
       - statusRules
       - endpointID
       type: object

--- a/src/common/schemas/NotificationRuleBase.yml
+++ b/src/common/schemas/NotificationRuleBase.yml
@@ -3,7 +3,6 @@
     - orgID
     - status
     - name
-    - tagRules
     - statusRules
     - endpointID
   properties:


### PR DESCRIPTION
If the NotificationRule is created without `tagRules`:

```console
-> POST
-> /api/v2/notificationRules
{
	"type": "slack",
	"messageTemplate": "${ r._message }",
	"endpointID": "0794dbceee052000",
	"orgID": "e528f835bc53a6ec",
	"status": "active",
	"name": "Critical status to Slack_2021-05-25 14:13:37.518816",
	"every": "10s",
	"offset": "0s",
	"tagRules": [],
	"statusRules": [{
		"currentLevel": "CRIT"
	}]
}
```

the response doesn't contains `tagRules` tag:

```console
<- 201 Created
{
	"id": "0794dbcef03f9000",
	"name": "Critical status to Slack_2021-05-25 14:13:37.518816",
	"endpointID": "0794dbceee052000",
	"orgID": "e528f835bc53a6ec",
	"ownerID": "0794db2e1f852000",
	"every": "10s",
	"offset": "0s",
	"runbookLink": "",
	"statusRules": [{
		"currentLevel": "CRIT",
		"previousLevel": null
	}],
	"createdAt": "2021-05-25T12:13:37.600823846Z",
	"updatedAt": "2021-05-25T12:13:37.600823846Z",
	"channel": "",
	"messageTemplate": "${ r._message }",
	"type": "slack",
	"labels": [],
	"links": {
		"self": "/api/v2/notificationRules/0794dbcef03f9000",
		"labels": "/api/v2/notificationRules/0794dbcef03f9000/labels",
		"members": "/api/v2/notificationRules/0794dbcef03f9000/members",
		"owners": "/api/v2/notificationRules/0794dbcef03f9000/owners",
		"query": "/api/v2/notificationRules/0794dbcef03f9000/query"
	},
	"status": "active",
	"latestCompleted": "2021-05-25T12:13:37Z",
	"latestScheduled": "2021-05-25T12:13:37Z"
}
```

so the `tagRules` should not be required property.