### PR TITLE
chore(unity): update user schema to match quartz api

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -1258,17 +1258,6 @@ components:
           description: the idpe id of the user
           readOnly: true
           type: string
-        quartzId:
-          description: the quartz id of the user
-          readOnly: true
-          type: number
-        onboardingState:
-          description: onboarding state of the user
-          type: string
-        sfdcContactId:
-          description: the sfdcContact id of the user
-          readOnly: true
-          type: string
         firstName:
           type: string
         lastName:
@@ -1277,17 +1266,10 @@ components:
           type: string
         role:
           $ref: '#/components/schemas/Role'
-        links:
-          type: object
-          readOnly: true
-          properties:
-            self:
-              type: string
-              format: uri
-          example:
-            self: /api/v2private/users/1
       required:
         - id
+        - firstName
+        - lastName
         - email
         - role
     Me:

--- a/src/unity/schemas/User.yml
+++ b/src/unity/schemas/User.yml
@@ -3,17 +3,6 @@ properties:
     description: the idpe id of the user
     readOnly: true
     type: string
-  quartzId:
-    description: the quartz id of the user
-    readOnly: true
-    type: number
-  onboardingState:
-    description: onboarding state of the user
-    type: string
-  sfdcContactId:
-    description: the sfdcContact id of the user
-    readOnly: true
-    type: string
   firstName:
     type: string
   lastName:
@@ -22,13 +11,4 @@ properties:
     type: string
   role:
     $ref: './Role.yml'
-  links:
-    type: object
-    readOnly: true
-    properties:
-      self:
-        type: string
-        format: uri
-    example:
-      self: '/api/v2private/users/1'
-required: [id, email, role]
+required: [id, firstName, lastName, email, role]


### PR DESCRIPTION
The schema for user looked like the response expected for the operator type user response rather than the regular users page user response. At this point, there is no api for the users in the unity swagger so rather than creating a OperatorUser and User, we just updated User since that schema is only being used by the `GET /orgs/{orgId}/users` endpoint.