### PR TITLE
Add specs for OSS 2.1 backup APIs

### DIFF
--- a/src/oss/paths/backup_metadata.yml
+++ b/src/oss/paths/backup_metadata.yml
@@ -1,0 +1,37 @@
+get:
+  operationId: GetBackupMetadata
+  tags:
+    - Backup
+  summary: Download snapshot of all metadata in the server
+  parameters:
+    - $ref: "../../common/parameters/TraceSpan.yml"
+    - in: header
+      name: Accept-Encoding
+      description: The Accept-Encoding request HTTP header advertises which content encoding, usually a compression algorithm, the client is able to understand.
+      schema:
+        type: string
+        description: Specifies that the query response in the body should be encoded with gzip or not encoded with identity.
+        default: identity
+        enum:
+          - gzip
+          - identity
+  responses:
+    "200":
+      description: Snapshot of metadata
+      headers:
+        Content-Encoding:
+          description: The Content-Encoding entity header is used to compress the media-type.  When present, its value indicates which encodings were applied to the entity-body
+          schema:
+            type: string
+            description: Specifies that the response in the body is encoded with gzip or not encoded with identity.
+            default: identity
+            enum:
+              - gzip
+              - identity
+      content:
+        multipart/mixed:
+          schema:
+            $ref: "../schemas/MetadataBackup.yml"
+    default:
+      description: Unexpected error
+      $ref: '../../common/responses/ServerError.yml'

--- a/src/oss/paths/backup_shards_shardID.yml
+++ b/src/oss/paths/backup_shards_shardID.yml
@@ -24,19 +24,22 @@ get:
     - in: query
       name: since
       description: Earliest time to include in the snapshot. RFC3339 format.
-      format: date-time
+      schema:
+        type: string
+        format: date-time
   responses:
     "200":
       description: TSM snapshot.
-      Content-Encoding:
-        description: The Content-Encoding entity header is used to compress the media-type.  When present, its value indicates which encodings were applied to the entity-body
-        schema:
-          type: string
-          description: Specifies that the response in the body is encoded with gzip or not encoded with identity.
-          default: identity
-          enum:
-            - gzip
-            - identity
+      headers:
+        Content-Encoding:
+          description: The Content-Encoding entity header is used to compress the media-type.  When present, its value indicates which encodings were applied to the entity-body
+          schema:
+            type: string
+            description: Specifies that the response in the body is encoded with gzip or not encoded with identity.
+            default: identity
+            enum:
+              - gzip
+              - identity
       content:
         application/octet-stream:
           schema:

--- a/src/oss/paths/backup_shards_shardID.yml
+++ b/src/oss/paths/backup_shards_shardID.yml
@@ -18,7 +18,8 @@ get:
     - in: path
       name: shardID
       schema:
-        type: integer
+        type: number
+        format: int64
       required: true
       description: The shard ID.
     - in: query

--- a/src/oss/paths/backup_shards_shardID.yml
+++ b/src/oss/paths/backup_shards_shardID.yml
@@ -1,0 +1,47 @@
+get:
+  operationId: GetBackupShardId
+  tags:
+    - Backup
+  summary: Download snapshot of all TSM data in a shard
+  parameters:
+    - $ref: "../../common/parameters/TraceSpan.yml"
+    - in: header
+      name: Accept-Encoding
+      description: The Accept-Encoding request HTTP header advertises which content encoding, usually a compression algorithm, the client is able to understand.
+      schema:
+        type: string
+        description: Specifies that the query response in the body should be encoded with gzip or not encoded with identity.
+        default: identity
+        enum:
+          - gzip
+          - identity
+    - in: path
+      name: shardID
+      schema:
+        type: integer
+      required: true
+      description: The shard ID.
+    - in: query
+      name: since
+      description: Earliest time to include in the snapshot. RFC3339 format.
+      format: date-time
+  responses:
+    "200":
+      description: TSM snapshot.
+      Content-Encoding:
+        description: The Content-Encoding entity header is used to compress the media-type.  When present, its value indicates which encodings were applied to the entity-body
+        schema:
+          type: string
+          description: Specifies that the response in the body is encoded with gzip or not encoded with identity.
+          default: identity
+          enum:
+            - gzip
+            - identity
+      content:
+        application/octet-stream:
+          schema:
+            type: string
+            format: binary
+    default:
+      description: Unexpected error
+      $ref: '../../common/responses/ServerError.yml'

--- a/src/oss/schemas/MetadataBackup.yml
+++ b/src/oss/schemas/MetadataBackup.yml
@@ -1,0 +1,11 @@
+type: object
+properties:
+  boltdb:
+    type: string
+    format: binary
+  sqlite:
+    type: string
+    format: binary
+  shards:
+    $ref: "./ShardMetadataManifest.yml"
+required: [boltdb, sqlite, shards]

--- a/src/oss/schemas/ShardMetadataManifest.yml
+++ b/src/oss/schemas/ShardMetadataManifest.yml
@@ -1,0 +1,13 @@
+type: object
+properties:
+  organizationID:
+    type: string
+  organizationName:
+    type: string
+  bucketID:
+    type: string
+  bucketName:
+    type: string
+  shardID:
+    type: integer
+required: [organizationID, organizationName, bucketID, bucketName, shardID]

--- a/src/oss/schemas/ShardMetadataManifests.yml
+++ b/src/oss/schemas/ShardMetadataManifests.yml
@@ -1,0 +1,3 @@
+type: array
+items:
+  $ref: "./ShardMetadataManifest.yml"


### PR DESCRIPTION
Closes #96

There are 2 routes here:
* `backup_metadata.yml` describes a new route we plan to implement for OSS 2.1
* `backup_shards_shardID.yml` describes an existing route in OSS 2.0.x that we plan to keep

I haven't added either to `src/oss.yml` yet because we haven't implemented the new API. I wanted to merge this first so we could work on the CLI pieces in parallel.