### PR TITLE
feat(unity): update invoice to have id instead of filesId

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -1264,6 +1264,9 @@ components:
         - fluxKey
     Invoice:
       properties:
+        id:
+          description: id of the invoice
+          type: string
         status:
           description: status of the invoice
           readOnly: true
@@ -1276,14 +1279,11 @@ components:
           description: date of invoice
           readOnly: true
           type: string
-        filesId:
-          description: id of the invoice file
-          type: string
       required:
+        - id
         - status
         - amount
         - targetDate
-        - filesId
     Invoices:
       type: array
       items:

--- a/src/unity/schemas/Invoice.yml
+++ b/src/unity/schemas/Invoice.yml
@@ -1,4 +1,7 @@
 properties:
+  id:
+    description: id of the invoice
+    type: string
   status:
     description: status of the invoice
     readOnly: true
@@ -11,7 +14,4 @@ properties:
     description: date of invoice
     readOnly: true
     type: string
-  filesId:
-    description: id of the invoice file
-    type: string
-required: [status, amount, targetDate, filesId]
+required: [id, status, amount, targetDate]


### PR DESCRIPTION
To fix a bug involving invoices, the api needs to use the id of the invoice rather than the id of the invoice pdf file.