### PR TITLE
chore(unity): add error definitions for /marketplace

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -910,18 +910,6 @@ components:
             - gcm
             - azure
           example: gcm
-        subscriberId:
-          type: string
-          description: this is the user's ID for the marketplace subscription
-        status:
-          type: string
-          description: the status of the marketplace subscription
-          enum:
-            - pending
-            - subscribed
-            - unsubscribed
-            - failed
-          example: pending
         url:
           description: link to marketplace
           type: string

--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -104,6 +104,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Marketplace'
+        '401':
+          description: Not Authorized or Invalid Session
+          $ref: '#/components/responses/ServerError'
+        '404':
+          description: Marketplace not found
+          $ref: '#/components/responses/ServerError'
         default:
           description: Unexpected error
           $ref: '#/components/responses/ServerError'

--- a/src/unity/paths/marketplace.yml
+++ b/src/unity/paths/marketplace.yml
@@ -9,6 +9,12 @@ get:
         application/json:
           schema:
             $ref: '../schemas/Marketplace.yml'
+    '401':
+      description: Not Authorized or Invalid Session
+      $ref: '../../common/responses/ServerError.yml'
+    '404':
+      description: Marketplace not found
+      $ref: '../../common/responses/ServerError.yml'
     default:
       description: Unexpected error
       $ref: '../../common/responses/ServerError.yml'

--- a/src/unity/schemas/Marketplace.yml
+++ b/src/unity/schemas/Marketplace.yml
@@ -8,14 +8,6 @@ properties:
     type: string
     enum: [aws, gcm, azure]
     example: gcm
-  subscriberId:
-    type: string
-    description: this is the user's ID for the marketplace subscription
-  status:
-    type: string
-    description: the status of the marketplace subscription
-    enum: [pending, subscribed, unsubscribed, failed]
-    example: pending
   url:
     description: link to marketplace
     type: string


### PR DESCRIPTION
Remove `status` and `subscriberId` since they are relevant to the marketplace subscription and not the marketplace.
Add error definitions for `GET /marketplace`