### PR TITLE
chore: add `notebooks` permission resource

### DIFF
--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -732,6 +732,7 @@ components:
             - notificationEndpoints
             - checks
             - dbrp
+            - notebooks
         id:
           type: string
           nullable: true

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -11707,6 +11707,7 @@ components:
             - notificationEndpoints
             - checks
             - dbrp
+            - notebooks
         id:
           type: string
           nullable: true

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -9628,6 +9628,7 @@ components:
           - notificationEndpoints
           - checks
           - dbrp
+          - notebooks
           type: string
       required:
       - type

--- a/src/common/schemas/Resource.yml
+++ b/src/common/schemas/Resource.yml
@@ -22,6 +22,7 @@
         - notificationEndpoints
         - checks
         - dbrp
+        - notebooks
     id:
       type: string
       nullable: true


### PR DESCRIPTION
The InfluxDB OSS has also `notebooks` permission resource type:

https://github.com/influxdata/influxdb/blob/40897b9a98fe48834bf2a6a9469aae89f85a0d33/authz.go#L139