### PR TITLE
chore: Query params as a dictionary

### DIFF
--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -6717,6 +6717,7 @@ components:
             - flux
         params:
           type: object
+          additionalProperties: true
           description: |
             Enumeration of key/value pairs that respresent parameters to be injected into query (can only specify either this field or extern and not both)
         dialect:

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -5937,6 +5937,7 @@ components:
             - flux
         params:
           type: object
+          additionalProperties: true
           description: |
             Enumeration of key/value pairs that respresent parameters to be injected into query (can only specify either this field or extern and not both)
         dialect:

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -6449,6 +6449,7 @@ components:
             - flux
         params:
           type: object
+          additionalProperties: true
           description: |
             Enumeration of key/value pairs that respresent parameters to be injected into query (can only specify either this field or extern and not both)
         dialect:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -11714,6 +11714,7 @@ components:
           format: date-time
           type: string
         params:
+          additionalProperties: true
           description: |
             Enumeration of key/value pairs that respresent parameters to be injected into query (can only specify either this field or extern and not both)
           type: object

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -9494,6 +9494,7 @@ components:
           format: date-time
           type: string
         params:
+          additionalProperties: true
           description: |
             Enumeration of key/value pairs that respresent parameters to be injected into query (can only specify either this field or extern and not both)
           type: object

--- a/src/common/schemas/Query.yml
+++ b/src/common/schemas/Query.yml
@@ -15,6 +15,7 @@
         - flux
     params:
       type: object
+      additionalProperties: true
       description: >
           Enumeration of key/value pairs that respresent parameters to be
           injected into query (can only specify either this field or extern and not both)


### PR DESCRIPTION
Define `Query params` as a dictionary.

- https://swagger.io/docs/specification/data-models/dictionaries/