### PR TITLE
fix(unity): update requirements and schema for `PUT billing/contact`

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -1065,7 +1065,7 @@ components:
           type: string
           description: subdivision
         postalCode:
-          type: number
+          type: string
           description: postal code of billing contact
       required:
         - companyName
@@ -1073,7 +1073,6 @@ components:
         - firstName
         - lastName
         - country
-        - street1
         - city
         - postalCode
     BillingNotifySettings:

--- a/src/unity/schemas/BillingContact.yml
+++ b/src/unity/schemas/BillingContact.yml
@@ -27,7 +27,7 @@ properties:
     type: string
     description: subdivision
   postalCode:
-    type: number
+    type: string
     description: postal code of billing contact
 required:
-  [companyName, email, firstName, lastName, country, street1, city, postalCode]
+  [companyName, email, firstName, lastName, country, city, postalCode]


### PR DESCRIPTION
Update the Unity swagger for `PUT billing/contact` to remove requirement for `street1` in request body and changed type for `postalCode` from `number` to `string` because not all postal codes are comprised solely of numbers.