### PR TITLE
fix: revert "chore: add notebooks permission resource (#108)"

### DIFF
--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -1456,7 +1456,6 @@ components:
             - notificationEndpoints
             - checks
             - dbrp
-            - notebooks
         id:
           type: string
           nullable: true

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -11584,7 +11584,6 @@ components:
             - notificationEndpoints
             - checks
             - dbrp
-            - notebooks
         id:
           type: string
           nullable: true

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -9643,7 +9643,6 @@ components:
           - notificationEndpoints
           - checks
           - dbrp
-          - notebooks
           type: string
       required:
       - type

--- a/src/common/schemas/Resource.yml
+++ b/src/common/schemas/Resource.yml
@@ -22,7 +22,6 @@
         - notificationEndpoints
         - checks
         - dbrp
-        - notebooks
     id:
       type: string
       nullable: true


### PR DESCRIPTION
This reverts commit dab6384fb7108f8cee396cc9d187870c3b0381ea because notebooks/flows is intended to be accessible only via a session (this definition is used by the ui for token generation)