### PR TITLE
chore: specify possible types for TelegrafPlugin

### DIFF
--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -10072,6 +10072,11 @@ components:
       properties:
         type:
           type: string
+          enum:
+            - inputs
+            - outputs
+            - aggregators
+            - processors
         name:
           type: string
         description:

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -9291,6 +9291,11 @@ components:
       properties:
         type:
           type: string
+          enum:
+            - inputs
+            - outputs
+            - aggregators
+            - processors
         name:
           type: string
         description:

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -10447,6 +10447,11 @@ components:
       properties:
         type:
           type: string
+          enum:
+            - inputs
+            - outputs
+            - aggregators
+            - processors
         name:
           type: string
         description:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -12158,6 +12158,11 @@ components:
         name:
           type: string
         type:
+          enum:
+          - inputs
+          - outputs
+          - aggregators
+          - processors
           type: string
       type: object
     TelegrafPlugins:

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -10660,6 +10660,11 @@ components:
         name:
           type: string
         type:
+          enum:
+          - inputs
+          - outputs
+          - aggregators
+          - processors
           type: string
       type: object
     TelegrafPlugins:

--- a/src/common/schemas/TelegrafPlugin.yml
+++ b/src/common/schemas/TelegrafPlugin.yml
@@ -2,6 +2,11 @@
   properties:
     type:
       type: string
+      enum:
+        - inputs
+        - outputs
+        - aggregators
+        - processors
     name:
       type: string
     description:


### PR DESCRIPTION
The type of TelegrafPlugin can be:

- inputs
- outputs
- aggregators
- processors