### PR TITLE
fix: change static legend's hide property to show

### DIFF
--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -9568,7 +9568,7 @@ components:
         heightRatio:
           type: number
           format: float
-        hide:
+        show:
           type: boolean
         opacity:
           type: number

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -8787,7 +8787,7 @@ components:
         heightRatio:
           type: number
           format: float
-        hide:
+        show:
           type: boolean
         opacity:
           type: number

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -9943,7 +9943,7 @@ components:
         heightRatio:
           type: number
           format: float
-        hide:
+        show:
           type: boolean
         opacity:
           type: number

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -11825,7 +11825,7 @@ components:
         heightRatio:
           format: float
           type: number
-        hide:
+        show:
           type: boolean
         opacity:
           format: float

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -10354,7 +10354,7 @@ components:
         heightRatio:
           format: float
           type: number
-        hide:
+        show:
           type: boolean
         opacity:
           format: float

--- a/src/common/schemas/StaticLegend.yml
+++ b/src/common/schemas/StaticLegend.yml
@@ -6,7 +6,7 @@
     heightRatio:
       type: number
       format: float
-    hide:
+    show:
       type: boolean
     opacity:
       type: number


### PR DESCRIPTION
As part of https://github.com/influxdata/ui/issues/1666

On the backend, static legend's properties must always be tracked. For `hide` there are really 3 states: true, false, and not set.

This is different than on the frontend, where Giraffe sees a lack of a "static legend" object to mean that static legend is not desired. And static legend's hide property is for convenience; it is a way to temporarily hide the static legend without removing (and later rebuilding) the entire object. Thus it is the static legend object itself that is analogous to the backend's `hide` property -- and has 3 states: staticLegend.hide is true, staticLegend.hide is false, and the lack of staticLegend.

Thus, on the backend we should change `hide` to `show` to accurately reflect "not set" to be the same as false.