### PR TITLE
chore: remove typo error code from annotations api

### DIFF
--- a/contracts/priv/annotationd.yml
+++ b/contracts/priv/annotationd.yml
@@ -50,8 +50,6 @@ paths:
           $ref: '#/components/responses/ServerError'
         '401':
           $ref: '#/components/responses/ServerError'
-        '404':
-          $ref: '#/components/responses/ServerError'
         '500':
           $ref: '#/components/responses/ServerError'
     delete:
@@ -193,8 +191,6 @@ paths:
         '400':
           $ref: '#/components/responses/ServerError'
         '401':
-          $ref: '#/components/responses/ServerError'
-        '404':
           $ref: '#/components/responses/ServerError'
         '500':
           $ref: '#/components/responses/ServerError'

--- a/contracts/priv/annotationd.yml
+++ b/contracts/priv/annotationd.yml
@@ -30,8 +30,6 @@ paths:
           $ref: '#/components/responses/ServerError'
         '401':
           $ref: '#/components/responses/ServerError'
-        '404':
-          $ref: '#/components/responses/ServerError'
         '500':
           $ref: '#/components/responses/ServerError'
     get:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -6408,8 +6408,6 @@ paths:
           $ref: '#/components/responses/ServerError'
         "401":
           $ref: '#/components/responses/ServerError'
-        "404":
-          $ref: '#/components/responses/ServerError'
         "500":
           $ref: '#/components/responses/ServerError'
       summary: Create annotations
@@ -11825,13 +11823,13 @@ components:
         heightRatio:
           format: float
           type: number
-        show:
-          type: boolean
         opacity:
           format: float
           type: number
         orientationThreshold:
           type: integer
+        show:
+          type: boolean
         valueAxis:
           type: string
         widthRatio:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -6380,8 +6380,6 @@ paths:
           $ref: '#/components/responses/ServerError'
         "401":
           $ref: '#/components/responses/ServerError'
-        "404":
-          $ref: '#/components/responses/ServerError'
         "500":
           $ref: '#/components/responses/ServerError'
       summary: List annotations
@@ -6884,8 +6882,6 @@ paths:
         "400":
           $ref: '#/components/responses/ServerError'
         "401":
-          $ref: '#/components/responses/ServerError'
-        "404":
           $ref: '#/components/responses/ServerError'
         "500":
           $ref: '#/components/responses/ServerError'

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -10354,13 +10354,13 @@ components:
         heightRatio:
           format: float
           type: number
-        show:
-          type: boolean
         opacity:
           format: float
           type: number
         orientationThreshold:
           type: integer
+        show:
+          type: boolean
         valueAxis:
           type: string
         widthRatio:

--- a/contracts/svc/annotationd.yml
+++ b/contracts/svc/annotationd.yml
@@ -50,8 +50,6 @@ paths:
           $ref: '#/components/responses/ServerError'
         '401':
           $ref: '#/components/responses/ServerError'
-        '404':
-          $ref: '#/components/responses/ServerError'
         '500':
           $ref: '#/components/responses/ServerError'
     delete:
@@ -193,8 +191,6 @@ paths:
         '400':
           $ref: '#/components/responses/ServerError'
         '401':
-          $ref: '#/components/responses/ServerError'
-        '404':
           $ref: '#/components/responses/ServerError'
         '500':
           $ref: '#/components/responses/ServerError'

--- a/contracts/svc/annotationd.yml
+++ b/contracts/svc/annotationd.yml
@@ -30,8 +30,6 @@ paths:
           $ref: '#/components/responses/ServerError'
         '401':
           $ref: '#/components/responses/ServerError'
-        '404':
-          $ref: '#/components/responses/ServerError'
         '500':
           $ref: '#/components/responses/ServerError'
     get:

--- a/src/svc/annotationd/paths/annotations.yml
+++ b/src/svc/annotationd/paths/annotations.yml
@@ -42,8 +42,6 @@ get:
       $ref: "../../../common/responses/ServerError.yml"
     '401':
       $ref: "../../../common/responses/ServerError.yml"
-    '404':
-      $ref: "../../../common/responses/ServerError.yml"
     '500':
       $ref: "../../../common/responses/ServerError.yml"
 delete:

--- a/src/svc/annotationd/paths/annotations.yml
+++ b/src/svc/annotationd/paths/annotations.yml
@@ -22,8 +22,6 @@ post:
       $ref: "../../../common/responses/ServerError.yml"
     '401':
       $ref: "../../../common/responses/ServerError.yml"
-    '404':
-      $ref: "../../../common/responses/ServerError.yml"
     '500':
       $ref: "../../../common/responses/ServerError.yml"
 get:

--- a/src/svc/annotationd/paths/streams.yml
+++ b/src/svc/annotationd/paths/streams.yml
@@ -40,8 +40,6 @@ get:
       $ref: "../../../common/responses/ServerError.yml"
     '401':
       $ref: "../../../common/responses/ServerError.yml"
-    '404':
-      $ref: "../../../common/responses/ServerError.yml"
     '500':
       $ref: "../../../common/responses/ServerError.yml"
 delete:


### PR DESCRIPTION
closes #111

The 404 when listing may or may not be desired, but i won't remove it unless someone feels we should just return an empty slice. currently a 404 will be returned when the filter parameters result in 0 annotations/streams being found (for `/annotations` and `/streams`