### PR TITLE
fix: actually run test to verify reference contract was generated

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,16 @@ jobs:
       - run:
           name: Ensure compiled contracts match
           command: sh /root/project/scripts/test.sh
+  test-reference-contracts:
+    docker:
+      - image: "quay.io/influxdb/swagrag-ci"
+    environment:
+      CONTRACTS: /tmp/ref
+    steps:
+      - checkout
+      - run:
+          name: Ensure reference contracts match
+          command: sh /root/project/scripts/reference.sh
   lint-yamls:
     docker:
       - image: "cimg/base:2021.04"
@@ -34,4 +44,5 @@ workflows:
     jobs:
       - test-oats
       - test-contracts
+      - test-reference-contracts
       - lint-yamls

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,13 +21,14 @@ jobs:
   test-reference-contracts:
     docker:
       - image: "quay.io/influxdb/swagrag-ci"
-    environment:
-      CONTRACTS: /tmp/ref
     steps:
       - checkout
       - run:
           name: Ensure reference contracts match
           command: sh /root/project/scripts/reference.sh
+          environment:
+            TCONTRACTS: '/tmp/contracts'
+            CONTRACTS: '/root/project/contracts'
   lint-yamls:
     docker:
       - image: "cimg/base:2021.04"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: generate
 generate:
 	docker run --rm -v ${PWD}:/openapi quay.io/influxdb/swagger-cli sh /openapi/scripts/generate.sh
-	./scripts/reference.sh
+	docker run --rm -v ${PWD}:/openapi quay.io/influxdb/swagrag-ci sh /openapi/scripts/reference.sh
 
 .PHONY: generate-svc
 generate-svc:
@@ -13,7 +13,7 @@ generate-all: generate generate-svc
 .PHONY: test
 test:
 	docker run --rm -v ${PWD}:/openapi quay.io/influxdb/swagger-cli sh /openapi/scripts/test.sh
-	CONTRACTS=/tmp/ref bash scripts/reference.sh && diff -r /tmp/ref contracts/ref/
+	docker run --rm -e CONTRACTS=/tmp/ref -v ${PWD}:/openapi quay.io/influxdb/swagrag-ci sh /openapi/scripts/reference.sh
 
 .PHONY: test-oats
 test-oats:
@@ -45,8 +45,7 @@ publish-docker: publish-oats publish-swagger
 publish-docker-ci:
 	docker build -t quay.io/influxdb/swagger-cli-ci -f scripts/ci-swagger-cli.dockerfile .
 	docker build -t quay.io/influxdb/oats-ci -f scripts/ci-oats.dockerfile .
+	docker build -t quay.io/influxdb/swagrag-ci -f scripts/ci-swagrag.dockerfile .
 	docker push quay.io/influxdb/swagger-cli-ci
 	docker push quay.io/influxdb/oats-ci
-
-.PHONY: publish-docker
-publish-docker: publish-oats publish-swagger
+	docker push quay.io/influxdb/swagrag-ci

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ generate-all: generate generate-svc
 .PHONY: test
 test:
 	docker run --rm -v ${PWD}:/openapi quay.io/influxdb/swagger-cli sh /openapi/scripts/test.sh
-	docker run --rm -e CONTRACTS=/tmp/ref -v ${PWD}:/openapi quay.io/influxdb/swagrag-ci sh /openapi/scripts/reference.sh
+	docker run --rm -e TCONTRACTS=/tmp/contracts -v ${PWD}:/openapi quay.io/influxdb/swagrag-ci sh /openapi/scripts/reference.sh
 
 .PHONY: test-oats
 test-oats:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -11825,13 +11825,13 @@ components:
         heightRatio:
           format: float
           type: number
-        show:
-          type: boolean
         opacity:
           format: float
           type: number
         orientationThreshold:
           type: integer
+        show:
+          type: boolean
         valueAxis:
           type: string
         widthRatio:

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -10354,13 +10354,13 @@ components:
         heightRatio:
           format: float
           type: number
-        show:
-          type: boolean
         opacity:
           format: float
           type: number
         orientationThreshold:
           type: integer
+        show:
+          type: boolean
         valueAxis:
           type: string
         widthRatio:

--- a/scripts/ci-swagrag.dockerfile
+++ b/scripts/ci-swagrag.dockerfile
@@ -1,0 +1,5 @@
+FROM alpine
+
+RUN apk add --no-cache git
+
+COPY --from=docker.io/glinton/swagrag /swagrag /bin/swagrag

--- a/scripts/oats.dockerfile
+++ b/scripts/oats.dockerfile
@@ -1,4 +1,4 @@
-FROM node:15.12-alpine
+FROM node:16-alpine
 
 WORKDIR /src
 RUN mkdir -p /src

--- a/scripts/reference.sh
+++ b/scripts/reference.sh
@@ -1,25 +1,26 @@
 #!/bin/sh
 
-CONTRACTS=${CONTRACTS:-/openapi/contracts/ref}
+CONTRACTS=${CONTRACTS:-/openapi/contracts}
+TCONTRACTS=${TCONTRACTS:-/openapi/contracts}
 
-mkdir -p $CONTRACTS
+mkdir -p $TCONTRACTS/ref
 
 echo "Aggregating cloud swaggers"
 swagrag \
-  -file /openapi/contracts/priv/cloud-priv.yml \
-  -file /openapi/contracts/cloud.yml \
-  -file /openapi/contracts/priv/annotationd.yml \
-  -file /openapi/contracts/priv/flowd.yml \
-  -file /openapi/contracts/mapsd.yml \
-  -file /openapi/contracts/managed-functions.yml \
+  -file ${CONTRACTS}/priv/cloud-priv.yml \
+  -file ${CONTRACTS}/cloud.yml \
+  -file ${CONTRACTS}/priv/annotationd.yml \
+  -file ${CONTRACTS}/priv/flowd.yml \
+  -file ${CONTRACTS}/mapsd.yml \
+  -file ${CONTRACTS}/managed-functions.yml \
   -api-title "Complete InfluxDB Cloud API" \
-  > ${CONTRACTS}/cloud.yml
+  > ${TCONTRACTS}/ref/cloud.yml
 
 echo "Aggregating oss swaggers"
 swagrag \
-  -file /openapi/contracts/oss.yml \
-  -file /openapi/contracts/mapsd.yml \
+  -file ${CONTRACTS}/oss.yml \
+  -file ${CONTRACTS}/mapsd.yml \
   -api-title "Complete InfluxDB OSS API" \
-  > ${CONTRACTS}/oss.yml
+  > ${TCONTRACTS}/ref/oss.yml
 
-diff -r ${CONTRACTS} /openapi/contracts/ref/
+diff -r ${CONTRACTS}/ref ${TCONTRACTS}/ref/

--- a/scripts/reference.sh
+++ b/scripts/reference.sh
@@ -1,13 +1,11 @@
-#!/bin/bash
+#!/bin/sh
 
-CONTRACTS=${CONTRACTS:-contracts/ref}
+CONTRACTS=${CONTRACTS:-/openapi/contracts/ref}
 
 mkdir -p $CONTRACTS
 
 echo "Aggregating cloud swaggers"
-docker run \
-  --rm \
-  -v ${PWD}:/openapi docker.io/glinton/swagrag \
+swagrag \
   -file /openapi/contracts/priv/cloud-priv.yml \
   -file /openapi/contracts/cloud.yml \
   -file /openapi/contracts/priv/annotationd.yml \
@@ -18,10 +16,10 @@ docker run \
   > ${CONTRACTS}/cloud.yml
 
 echo "Aggregating oss swaggers"
-docker run \
-  --rm \
-  -v ${PWD}:/openapi docker.io/glinton/swagrag \
+swagrag \
   -file /openapi/contracts/oss.yml \
   -file /openapi/contracts/mapsd.yml \
   -api-title "Complete InfluxDB OSS API" \
   > ${CONTRACTS}/oss.yml
+
+diff -r ${CONTRACTS} /openapi/contracts/ref/

--- a/scripts/swagger-cli.dockerfile
+++ b/scripts/swagger-cli.dockerfile
@@ -1,6 +1,5 @@
-FROM alpine AS base
+FROM node:16-alpine
 
-RUN apk add --no-cache nodejs-current npm git
 RUN npm set progress=false && npm config set depth 0
 RUN npm install --only=production -g swagger-cli
 


### PR DESCRIPTION
previously, the circle tests were assumed to be using `make test` to verify the reference contracts were in sync, this adds a step in the circle job to validate ref contracts.