### PR TITLE
Split out enums for line-protocol error codes.

### DIFF
--- a/src/common/schemas/LineProtocolError.yml
+++ b/src/common/schemas/LineProtocolError.yml
@@ -1,15 +1,6 @@
   properties:
     code:
-      description: Code is the machine-readable error code.
-      readOnly: true
-      type: string
-      enum:
-        - internal error
-        - not found
-        - conflict
-        - invalid
-        - empty value
-        - unavailable
+      $ref: "./LineProtocolErrorCode.yml"
     message:
       readOnly: true
       description: Message is a human-readable message.

--- a/src/common/schemas/LineProtocolErrorCode.yml
+++ b/src/common/schemas/LineProtocolErrorCode.yml
@@ -1,0 +1,10 @@
+description: Code is the machine-readable error code.
+readOnly: true
+type: string
+enum:
+  - internal error
+  - not found
+  - conflict
+  - invalid
+  - empty value
+  - unavailable

--- a/src/common/schemas/LineProtocolLengthError.yml
+++ b/src/common/schemas/LineProtocolLengthError.yml
@@ -1,10 +1,6 @@
   properties:
     code:
-      description: Code is the machine-readable error code.
-      readOnly: true
-      type: string
-      enum:
-        - invalid
+      $ref: "./LineProtocolLengthErrorCode.yml"
     message:
       readOnly: true
       description: Message is a human-readable message.

--- a/src/common/schemas/LineProtocolLengthErrorCode.yml
+++ b/src/common/schemas/LineProtocolLengthErrorCode.yml
@@ -1,0 +1,5 @@
+description: Code is the machine-readable error code.
+readOnly: true
+type: string
+enum:
+  - invalid


### PR DESCRIPTION
This helps some codegen systems generate true enums.

I thought about reusing the existing `ErrorCode` enum, but the possible values weren't a 1:1 match.