### PR TITLE
revert: "chore: specify possible types for TelegrafPlugin"

### DIFF
--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -10072,11 +10072,6 @@ components:
       properties:
         type:
           type: string
-          enum:
-            - inputs
-            - outputs
-            - aggregators
-            - processors
         name:
           type: string
         description:

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -9291,11 +9291,6 @@ components:
       properties:
         type:
           type: string
-          enum:
-            - inputs
-            - outputs
-            - aggregators
-            - processors
         name:
           type: string
         description:

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -10447,11 +10447,6 @@ components:
       properties:
         type:
           type: string
-          enum:
-            - inputs
-            - outputs
-            - aggregators
-            - processors
         name:
           type: string
         description:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -12158,11 +12158,6 @@ components:
         name:
           type: string
         type:
-          enum:
-          - inputs
-          - outputs
-          - aggregators
-          - processors
           type: string
       type: object
     TelegrafPlugins:

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -10660,11 +10660,6 @@ components:
         name:
           type: string
         type:
-          enum:
-          - inputs
-          - outputs
-          - aggregators
-          - processors
           type: string
       type: object
     TelegrafPlugins:

--- a/src/common/schemas/TelegrafPlugin.yml
+++ b/src/common/schemas/TelegrafPlugin.yml
@@ -2,11 +2,6 @@
   properties:
     type:
       type: string
-      enum:
-        - inputs
-        - outputs
-        - aggregators
-        - processors
     name:
       type: string
     description:


### PR DESCRIPTION
Reverts influxdata/openapi#116

This PR is reverting a telegraf plugin type definition since there's a discrepancy between the UI declared type and the new contract definition that's leaving a bit of confusion surrounding which source of truth needs to be updated (the yaml to accommodate the UI-declared types or the UI to conform to new API changes as per the above yaml changes).