### PR TITLE
chore: add connection route

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -966,6 +966,34 @@ paths:
         default:
           description: Unexpected error
           $ref: '#/components/responses/ServerError'
+  /api/v2private/auth/connection:
+    get:
+      operationId: GetConnection
+      tags:
+        - Connection
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: query
+          name: email
+          schema:
+            type: string
+            format: email
+          required: true
+          description: The email to get connection for.
+      responses:
+        '200':
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: connection
+          description: Connection name as string
+        '204':
+          description: No connection for the specified email
+        default:
+          description: Unexpected error
+          $ref: '#/components/responses/ServerError'
+      summary: Get connection  for the specified email
 components:
   parameters:
     TraceSpan:

--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -966,7 +966,7 @@ paths:
         default:
           description: Unexpected error
           $ref: '#/components/responses/ServerError'
-  /api/v2private/auth/connection:
+  /api/v2/quartz/auth/connection:
     get:
       operationId: GetConnection
       tags:

--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -966,7 +966,7 @@ paths:
         default:
           description: Unexpected error
           $ref: '#/components/responses/ServerError'
-  /api/v2/quartz/auth/connection:
+  /auth/connection:
     get:
       operationId: GetConnection
       tags:

--- a/src/unity.yml
+++ b/src/unity.yml
@@ -61,6 +61,8 @@ paths:
     $ref: './unity/paths/operator_orgs_orgId.yml'
   '/operator/orgs/{orgId}/limits':
     $ref: './unity/paths/operator_orgs_orgId_limits.yml'
+  '/api/v2private/auth/connection':
+    $ref: './unity/paths/sso.yml'
 components:
   parameters:
     TraceSpan:

--- a/src/unity.yml
+++ b/src/unity.yml
@@ -61,7 +61,7 @@ paths:
     $ref: './unity/paths/operator_orgs_orgId.yml'
   '/operator/orgs/{orgId}/limits':
     $ref: './unity/paths/operator_orgs_orgId_limits.yml'
-  '/api/v2/quartz/auth/connection':
+  '/auth/connection':
     $ref: './unity/paths/sso.yml'
 components:
   parameters:

--- a/src/unity.yml
+++ b/src/unity.yml
@@ -61,7 +61,7 @@ paths:
     $ref: './unity/paths/operator_orgs_orgId.yml'
   '/operator/orgs/{orgId}/limits':
     $ref: './unity/paths/operator_orgs_orgId_limits.yml'
-  '/api/v2private/auth/connection':
+  '/api/v2/quartz/auth/connection':
     $ref: './unity/paths/sso.yml'
 components:
   parameters:

--- a/src/unity/paths/sso.yml
+++ b/src/unity/paths/sso.yml
@@ -1,0 +1,27 @@
+get:
+  operationId: GetConnection
+  tags:
+  - Connection
+  parameters:
+    - $ref: '../../common/parameters/TraceSpan.yml'
+    - in: query
+      name: email
+      schema:
+        type: string
+        format: email
+      required: true
+      description: The email to get connection for.
+  responses:
+    "200":
+      content:
+        text/plain:
+          schema:
+            type: string
+            example: connection
+      description: Connection name as string
+    "204":
+      description: No connection for the specified email
+    default:
+      description: Unexpected error
+      $ref: '../../common/responses/ServerError.yml'
+  summary: Get connection  for the specified email


### PR DESCRIPTION
Add a connection route so that we can provide it `email` parameter and retrieve its corresponding SSO connection.