### PR TITLE
Fix schema for template-export request

### DIFF
--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -7027,18 +7027,20 @@ components:
                     items:
                       $ref: '#/components/schemas/TemplateKind'
         resources:
-          type: object
-          properties:
-            id:
-              type: string
-            kind:
-              $ref: '#/components/schemas/TemplateKind'
-            name:
-              type: string
-              description: 'if defined with id, name is used for resource exported by id. if defined independently, resources strictly matching name are exported'
-          required:
-            - id
-            - kind
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              kind:
+                $ref: '#/components/schemas/TemplateKind'
+              name:
+                type: string
+                description: 'if defined with id, name is used for resource exported by id. if defined independently, resources strictly matching name are exported'
+            required:
+              - id
+              - kind
     TemplateExportByName:
       type: object
       properties:
@@ -7063,15 +7065,17 @@ components:
                     items:
                       $ref: '#/components/schemas/TemplateKind'
         resources:
-          type: object
-          properties:
-            kind:
-              $ref: '#/components/schemas/TemplateKind'
-            name:
-              type: string
-          required:
-            - name
-            - kind
+          type: array
+          items:
+            type: object
+            properties:
+              kind:
+                $ref: '#/components/schemas/TemplateKind'
+              name:
+                type: string
+            required:
+              - name
+              - kind
     Template:
       type: array
       items:

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -6246,18 +6246,20 @@ components:
                     items:
                       $ref: '#/components/schemas/TemplateKind'
         resources:
-          type: object
-          properties:
-            id:
-              type: string
-            kind:
-              $ref: '#/components/schemas/TemplateKind'
-            name:
-              type: string
-              description: 'if defined with id, name is used for resource exported by id. if defined independently, resources strictly matching name are exported'
-          required:
-            - id
-            - kind
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              kind:
+                $ref: '#/components/schemas/TemplateKind'
+              name:
+                type: string
+                description: 'if defined with id, name is used for resource exported by id. if defined independently, resources strictly matching name are exported'
+            required:
+              - id
+              - kind
     TemplateExportByName:
       type: object
       properties:
@@ -6282,15 +6284,17 @@ components:
                     items:
                       $ref: '#/components/schemas/TemplateKind'
         resources:
-          type: object
-          properties:
-            kind:
-              $ref: '#/components/schemas/TemplateKind'
-            name:
-              type: string
-          required:
-            - name
-            - kind
+          type: array
+          items:
+            type: object
+            properties:
+              kind:
+                $ref: '#/components/schemas/TemplateKind'
+              name:
+                type: string
+            required:
+              - name
+              - kind
     Template:
       type: array
       items:

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -7646,18 +7646,20 @@ components:
                     items:
                       $ref: '#/components/schemas/TemplateKind'
         resources:
-          type: object
-          properties:
-            id:
-              type: string
-            kind:
-              $ref: '#/components/schemas/TemplateKind'
-            name:
-              type: string
-              description: 'if defined with id, name is used for resource exported by id. if defined independently, resources strictly matching name are exported'
-          required:
-            - id
-            - kind
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              kind:
+                $ref: '#/components/schemas/TemplateKind'
+              name:
+                type: string
+                description: 'if defined with id, name is used for resource exported by id. if defined independently, resources strictly matching name are exported'
+            required:
+              - id
+              - kind
     TemplateExportByName:
       type: object
       properties:
@@ -7682,15 +7684,17 @@ components:
                     items:
                       $ref: '#/components/schemas/TemplateKind'
         resources:
-          type: object
-          properties:
-            kind:
-              $ref: '#/components/schemas/TemplateKind'
-            name:
-              type: string
-          required:
-            - name
-            - kind
+          type: array
+          items:
+            type: object
+            properties:
+              kind:
+                $ref: '#/components/schemas/TemplateKind'
+              name:
+                type: string
+            required:
+              - name
+              - kind
     Template:
       type: array
       items:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -12438,20 +12438,22 @@ components:
             type: object
           type: array
         resources:
-          properties:
-            id:
-              type: string
-            kind:
-              $ref: '#/components/schemas/TemplateKind'
-            name:
-              description: if defined with id, name is used for resource exported
-                by id. if defined independently, resources strictly matching name
-                are exported
-              type: string
-          required:
-          - id
-          - kind
-          type: object
+          items:
+            properties:
+              id:
+                type: string
+              kind:
+                $ref: '#/components/schemas/TemplateKind'
+              name:
+                description: if defined with id, name is used for resource exported
+                  by id. if defined independently, resources strictly matching name
+                  are exported
+                type: string
+            required:
+            - id
+            - kind
+            type: object
+          type: array
         stackID:
           type: string
       type: object
@@ -12476,15 +12478,17 @@ components:
             type: object
           type: array
         resources:
-          properties:
-            kind:
-              $ref: '#/components/schemas/TemplateKind'
-            name:
-              type: string
-          required:
-          - name
-          - kind
-          type: object
+          items:
+            properties:
+              kind:
+                $ref: '#/components/schemas/TemplateKind'
+              name:
+                type: string
+            required:
+            - name
+            - kind
+            type: object
+          type: array
         stackID:
           type: string
       type: object

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -11383,20 +11383,22 @@ components:
             type: object
           type: array
         resources:
-          properties:
-            id:
-              type: string
-            kind:
-              $ref: '#/components/schemas/TemplateKind'
-            name:
-              description: if defined with id, name is used for resource exported
-                by id. if defined independently, resources strictly matching name
-                are exported
-              type: string
-          required:
-          - id
-          - kind
-          type: object
+          items:
+            properties:
+              id:
+                type: string
+              kind:
+                $ref: '#/components/schemas/TemplateKind'
+              name:
+                description: if defined with id, name is used for resource exported
+                  by id. if defined independently, resources strictly matching name
+                  are exported
+                type: string
+            required:
+            - id
+            - kind
+            type: object
+          type: array
         stackID:
           type: string
       type: object
@@ -11421,15 +11423,17 @@ components:
             type: object
           type: array
         resources:
-          properties:
-            kind:
-              $ref: '#/components/schemas/TemplateKind'
-            name:
-              type: string
-          required:
-          - name
-          - kind
-          type: object
+          items:
+            properties:
+              kind:
+                $ref: '#/components/schemas/TemplateKind'
+              name:
+                type: string
+            required:
+            - name
+            - kind
+            type: object
+          type: array
         stackID:
           type: string
       type: object

--- a/src/common/schemas/Template.yml
+++ b/src/common/schemas/Template.yml
@@ -1,15 +1,3 @@
   type: array
   items:
-    type: object
-    properties:
-      apiVersion:
-        type: string
-      kind:
-        $ref: "./TemplateKind.yml"
-      meta:
-        type: object
-        properties:
-          name:
-            type: string
-      spec:
-        type: object
+    $ref: "./TemplateEntry.yml"

--- a/src/common/schemas/TemplateEntry.yml
+++ b/src/common/schemas/TemplateEntry.yml
@@ -1,0 +1,13 @@
+type: object
+properties:
+  apiVersion:
+    type: string
+  kind:
+    $ref: "./TemplateKind.yml"
+  meta:
+    type: object
+    properties:
+      name:
+        type: string
+  spec:
+    type: object

--- a/src/common/schemas/TemplateExportByID.yml
+++ b/src/common/schemas/TemplateExportByID.yml
@@ -21,13 +21,15 @@
                 items:
                   $ref: "./TemplateKind.yml"
     resources:
-      type: object
-      properties:
-        id:
-          type: string
-        kind:
-          $ref: "./TemplateKind.yml"
-        name:
-          type: string
-          description: "if defined with id, name is used for resource exported by id. if defined independently, resources strictly matching name are exported"
-      required: [id, kind]
+      type: array
+      items:
+        type: object
+        properties:
+          id:
+            type: string
+          kind:
+            $ref: "./TemplateKind.yml"
+          name:
+            type: string
+            description: "if defined with id, name is used for resource exported by id. if defined independently, resources strictly matching name are exported"
+        required: [id, kind]

--- a/src/common/schemas/TemplateExportByName.yml
+++ b/src/common/schemas/TemplateExportByName.yml
@@ -21,10 +21,12 @@
                 items:
                   $ref: "./TemplateKind.yml"
     resources:
-      type: object
-      properties:
-        kind:
-          $ref: "./TemplateKind.yml"
-        name:
-          type: string
-      required: [name, kind]
+      type: array
+      items:
+        type: object
+        properties:
+          kind:
+            $ref: "./TemplateKind.yml"
+          name:
+            type: string
+        required: [name, kind]


### PR DESCRIPTION
The API said the `resources` field of template-export request bodies should be an `object`, but both [OSS](https://github.com/influxdata/influxdb/blob/master/pkger/http_server_template.go#L74) and [Cloud](https://github.com/influxdata/idpe/blob/e4b817915e56e71fa558bb875699b147f5c70811/influxdbv2/pkger/http_server_template.go#L73) expect it to be an array of objects.