### PR TITLE
fix(unity): remove 404 for operator delete account

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -784,9 +784,6 @@ paths:
         '401':
           description: Unauthorized
           $ref: '#/components/responses/ServerError'
-        '404':
-          description: Account not found
-          $ref: '#/components/responses/ServerError'
         default:
           description: Unexpected error
           $ref: '#/components/responses/ServerError'

--- a/src/unity/paths/operator_accounts_accountId.yml
+++ b/src/unity/paths/operator_accounts_accountId.yml
@@ -29,9 +29,6 @@ get:
     '401':
       description: Unauthorized
       $ref: '../../common/responses/ServerError.yml'
-    '404':
-      description: Account not found
-      $ref: '../../common/responses/ServerError.yml'
     default:
       description: Unexpected error
       $ref: '../../common/responses/ServerError.yml'

--- a/src/unity/paths/operator_accounts_accountId.yml
+++ b/src/unity/paths/operator_accounts_accountId.yml
@@ -29,6 +29,9 @@ get:
     '401':
       description: Unauthorized
       $ref: '../../common/responses/ServerError.yml'
+    '404':
+      description: Account not found
+      $ref: '../../common/responses/ServerError.yml'
     default:
       description: Unexpected error
       $ref: '../../common/responses/ServerError.yml'
@@ -59,9 +62,6 @@ delete:
     '401':
       description: Unauthorized
       $ref: '../../common/responses/ServerError.yml'
-    '404':
-      description: Account not found
-      $ref: '../../common/responses/ServerError.yml'
-    'default':
+    default:
       description: Unexpected error
       $ref: '../../common/responses/ServerError.yml'


### PR DESCRIPTION
As part of [Quartz #4765](https://github.com/influxdata/quartz/issues/4765), `404` has been removed from error definitions. In current functionality, the lack of account doesn't make it impossible to return a `204` for the `DELETE` request, per @randycoulman. 