### PR TITLE
fix: types for LatLonColumns to match the ones in giraffe

### DIFF
--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -9565,6 +9565,9 @@ components:
     LatLonColumns:
       description: Object type to define lat/lon columns
       type: object
+      required:
+        - lat
+        - lon
       properties:
         lat:
           $ref: '#/components/schemas/LatLonColumn'
@@ -9573,6 +9576,9 @@ components:
     LatLonColumn:
       description: Object type for key and column definitions
       type: object
+      required:
+        - key
+        - column
       properties:
         key:
           description: Key to determine whether the column is tag/field

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -8784,6 +8784,9 @@ components:
     LatLonColumns:
       description: Object type to define lat/lon columns
       type: object
+      required:
+        - lat
+        - lon
       properties:
         lat:
           $ref: '#/components/schemas/LatLonColumn'
@@ -8792,6 +8795,9 @@ components:
     LatLonColumn:
       description: Object type for key and column definitions
       type: object
+      required:
+        - key
+        - column
       properties:
         key:
           description: Key to determine whether the column is tag/field

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -10184,6 +10184,9 @@ components:
     LatLonColumns:
       description: Object type to define lat/lon columns
       type: object
+      required:
+        - lat
+        - lon
       properties:
         lat:
           $ref: '#/components/schemas/LatLonColumn'
@@ -10192,6 +10195,9 @@ components:
     LatLonColumn:
       description: Object type for key and column definitions
       type: object
+      required:
+        - key
+        - column
       properties:
         key:
           description: Key to determine whether the column is tag/field

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -9509,6 +9509,9 @@ components:
         key:
           description: Key to determine whether the column is tag/field
           type: string
+      required:
+      - key
+      - column
       type: object
     LatLonColumns:
       description: Object type to define lat/lon columns
@@ -9517,6 +9520,9 @@ components:
           $ref: '#/components/schemas/LatLonColumn'
         lon:
           $ref: '#/components/schemas/LatLonColumn'
+      required:
+      - lat
+      - lon
       type: object
     LesserThreshold:
       allOf:

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -8861,6 +8861,9 @@ components:
         key:
           description: Key to determine whether the column is tag/field
           type: string
+      required:
+      - key
+      - column
       type: object
     LatLonColumns:
       description: Object type to define lat/lon columns
@@ -8869,6 +8872,9 @@ components:
           $ref: '#/components/schemas/LatLonColumn'
         lon:
           $ref: '#/components/schemas/LatLonColumn'
+      required:
+      - lat
+      - lon
       type: object
     LesserThreshold:
       allOf:

--- a/src/common/schemas/LatLonColumn.yml
+++ b/src/common/schemas/LatLonColumn.yml
@@ -1,5 +1,6 @@
 description: Object type for key and column definitions
 type: object
+required: [key, column]
 properties:
   key:
     description: Key to determine whether the column is tag/field

--- a/src/common/schemas/LatLonColumns.yml
+++ b/src/common/schemas/LatLonColumns.yml
@@ -1,5 +1,6 @@
 description: Object type to define lat/lon columns
 type: object
+required: [lat, lon]
 properties:
   lat:
     $ref: './LatLonColumn.yml'


### PR DESCRIPTION
LatLonColumns' lat and lon properties are required in giraffe yet optional in openapi yml files. This fixes that issue 