### PR TITLE
feat: add ping endpoint

### DIFF
--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -59,7 +59,7 @@ paths:
     servers:
       - url: ''
     get:
-      operationId: PostPing
+      operationId: GetPing
       summary: Checks the status of InfluxDB instance and version of InfluxDB.
       responses:
         '204':
@@ -74,7 +74,7 @@ paths:
                 type: integer
               description: The version of InfluxDB.
     head:
-      operationId: PostPing
+      operationId: HeadPing
       summary: Checks the status of InfluxDB instance and version of InfluxDB.
       responses:
         '204':

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -55,6 +55,39 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /ping:
+    servers:
+      - url: ''
+    get:
+      operationId: PostPing
+      summary: Checks the status of InfluxDB instance and version of InfluxDB.
+      responses:
+        '204':
+          description: OK
+          headers:
+            X-Influxdb-Build:
+              schema:
+                type: string
+              description: The type of InfluxDB build.
+            X-Influxdb-Version:
+              schema:
+                type: integer
+              description: The version of InfluxDB.
+    head:
+      operationId: PostPing
+      summary: Checks the status of InfluxDB instance and version of InfluxDB.
+      responses:
+        '204':
+          description: OK
+          headers:
+            X-Influxdb-Build:
+              schema:
+                type: string
+              description: The type of InfluxDB build.
+            X-Influxdb-Version:
+              schema:
+                type: integer
+              description: The version of InfluxDB.
   /:
     get:
       operationId: GetRoutes

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -59,7 +59,7 @@ paths:
     servers:
       - url: ''
     get:
-      operationId: PostPing
+      operationId: GetPing
       summary: Checks the status of InfluxDB instance and version of InfluxDB.
       responses:
         '204':
@@ -74,7 +74,7 @@ paths:
                 type: integer
               description: The version of InfluxDB.
     head:
-      operationId: PostPing
+      operationId: HeadPing
       summary: Checks the status of InfluxDB instance and version of InfluxDB.
       responses:
         '204':

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -55,6 +55,39 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /ping:
+    servers:
+      - url: ''
+    get:
+      operationId: PostPing
+      summary: Checks the status of InfluxDB instance and version of InfluxDB.
+      responses:
+        '204':
+          description: OK
+          headers:
+            X-Influxdb-Build:
+              schema:
+                type: string
+              description: The type of InfluxDB build.
+            X-Influxdb-Version:
+              schema:
+                type: integer
+              description: The version of InfluxDB.
+    head:
+      operationId: PostPing
+      summary: Checks the status of InfluxDB instance and version of InfluxDB.
+      responses:
+        '204':
+          description: OK
+          headers:
+            X-Influxdb-Build:
+              schema:
+                type: string
+              description: The type of InfluxDB build.
+            X-Influxdb-Version:
+              schema:
+                type: integer
+              description: The version of InfluxDB.
   /:
     get:
       operationId: GetRoutes

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -59,7 +59,7 @@ paths:
     servers:
       - url: ''
     get:
-      operationId: PostPing
+      operationId: GetPing
       summary: Checks the status of InfluxDB instance and version of InfluxDB.
       responses:
         '204':
@@ -74,7 +74,7 @@ paths:
                 type: integer
               description: The version of InfluxDB.
     head:
-      operationId: PostPing
+      operationId: HeadPing
       summary: Checks the status of InfluxDB instance and version of InfluxDB.
       responses:
         '204':

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -55,6 +55,39 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /ping:
+    servers:
+      - url: ''
+    get:
+      operationId: PostPing
+      summary: Checks the status of InfluxDB instance and version of InfluxDB.
+      responses:
+        '204':
+          description: OK
+          headers:
+            X-Influxdb-Build:
+              schema:
+                type: string
+              description: The type of InfluxDB build.
+            X-Influxdb-Version:
+              schema:
+                type: integer
+              description: The version of InfluxDB.
+    head:
+      operationId: PostPing
+      summary: Checks the status of InfluxDB instance and version of InfluxDB.
+      responses:
+        '204':
+          description: OK
+          headers:
+            X-Influxdb-Build:
+              schema:
+                type: string
+              description: The type of InfluxDB build.
+            X-Influxdb-Version:
+              schema:
+                type: integer
+              description: The version of InfluxDB.
   /:
     get:
       operationId: GetRoutes

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -3758,7 +3758,7 @@ paths:
       - Usage
   /ping:
     get:
-      operationId: PostPing
+      operationId: GetPing
       responses:
         "204":
           description: OK
@@ -3773,7 +3773,7 @@ paths:
                 type: integer
       summary: Checks the status of InfluxDB instance and version of InfluxDB.
     head:
-      operationId: PostPing
+      operationId: HeadPing
       responses:
         "204":
           description: OK

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -3756,6 +3756,39 @@ paths:
       summary: Retrieve usage for an organization
       tags:
       - Usage
+  /ping:
+    get:
+      operationId: PostPing
+      responses:
+        "204":
+          description: OK
+          headers:
+            X-Influxdb-Build:
+              description: The type of InfluxDB build.
+              schema:
+                type: string
+            X-Influxdb-Version:
+              description: The version of InfluxDB.
+              schema:
+                type: integer
+      summary: Checks the status of InfluxDB instance and version of InfluxDB.
+    head:
+      operationId: PostPing
+      responses:
+        "204":
+          description: OK
+          headers:
+            X-Influxdb-Build:
+              description: The type of InfluxDB build.
+              schema:
+                type: string
+            X-Influxdb-Version:
+              description: The version of InfluxDB.
+              schema:
+                type: integer
+      summary: Checks the status of InfluxDB instance and version of InfluxDB.
+    servers:
+    - url: ""
   /api/v2/poc-functions:
     get:
       operationId: GetFunctions

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -3576,7 +3576,7 @@ paths:
       - Secrets
   /ping:
     get:
-      operationId: PostPing
+      operationId: GetPing
       responses:
         "204":
           description: OK
@@ -3591,7 +3591,7 @@ paths:
                 type: integer
       summary: Checks the status of InfluxDB instance and version of InfluxDB.
     head:
-      operationId: PostPing
+      operationId: HeadPing
       responses:
         "204":
           description: OK

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -3574,6 +3574,39 @@ paths:
       summary: Delete secrets from an organization
       tags:
       - Secrets
+  /ping:
+    get:
+      operationId: PostPing
+      responses:
+        "204":
+          description: OK
+          headers:
+            X-Influxdb-Build:
+              description: The type of InfluxDB build.
+              schema:
+                type: string
+            X-Influxdb-Version:
+              description: The version of InfluxDB.
+              schema:
+                type: integer
+      summary: Checks the status of InfluxDB instance and version of InfluxDB.
+    head:
+      operationId: PostPing
+      responses:
+        "204":
+          description: OK
+          headers:
+            X-Influxdb-Build:
+              description: The type of InfluxDB build.
+              schema:
+                type: string
+            X-Influxdb-Version:
+              description: The version of InfluxDB.
+              schema:
+                type: integer
+      summary: Checks the status of InfluxDB instance and version of InfluxDB.
+    servers:
+    - url: ""
   /api/v2/query:
     post:
       operationId: PostQuery

--- a/scripts/reference.sh
+++ b/scripts/reference.sh
@@ -23,4 +23,8 @@ swagrag \
   -api-title "Complete InfluxDB OSS API" \
   > ${TCONTRACTS}/ref/oss.yml
 
+echo "Fixing /ping path"
+sed -i '' -e "s|^  /api/v2/ping|  /ping|" ${TCONTRACTS}/ref/cloud.yml
+sed -i '' -e "s|^  /api/v2/ping|  /ping|" ${TCONTRACTS}/ref/oss.yml
+
 diff -r ${CONTRACTS}/ref ${TCONTRACTS}/ref/

--- a/src/common/_paths.yml
+++ b/src/common/_paths.yml
@@ -2,6 +2,10 @@
     $ref: "./common/paths/signin.yml"
   /signout:
     $ref: "./common/paths/signout.yml"
+  /ping:
+    servers:
+      - url: ''
+    $ref: "./common/paths/ping.yml"
   /:
     $ref: "./common/paths/0slash.yml"
   /documents/templates:

--- a/src/common/paths/ping.yml
+++ b/src/common/paths/ping.yml
@@ -1,0 +1,30 @@
+get:
+  operationId: PostPing
+  summary: Checks the status of InfluxDB instance and version of InfluxDB.
+  responses:
+    '204':
+      description: OK
+      headers:
+        X-Influxdb-Build:
+          schema:
+            type: string
+          description: The type of InfluxDB build.
+        X-Influxdb-Version:
+          schema:
+            type: integer
+          description: The version of InfluxDB.
+head:
+  operationId: PostPing
+  summary: Checks the status of InfluxDB instance and version of InfluxDB.
+  responses:
+    '204':
+      description: OK
+      headers:
+        X-Influxdb-Build:
+          schema:
+            type: string
+          description: The type of InfluxDB build.
+        X-Influxdb-Version:
+          schema:
+            type: integer
+          description: The version of InfluxDB.

--- a/src/common/paths/ping.yml
+++ b/src/common/paths/ping.yml
@@ -1,5 +1,5 @@
 get:
-  operationId: PostPing
+  operationId: GetPing
   summary: Checks the status of InfluxDB instance and version of InfluxDB.
   responses:
     '204':
@@ -14,7 +14,7 @@ get:
             type: integer
           description: The version of InfluxDB.
 head:
-  operationId: PostPing
+  operationId: HeadPing
   summary: Checks the status of InfluxDB instance and version of InfluxDB.
   responses:
     '204':


### PR DESCRIPTION
The users of our client libraries (`java`, `python`, `ruby`, ...) wants to do three things with our libraries: `query`, `write` and check the status of InfluxDB.

The query and writes are fine, but the checking status by `/health` endpoint brings trouble because the mapping is different for `oss` and `cloud` version. For more info see - https://github.com/influxdata/influxdb/issues/19357

As a solution this PR expose the `/ping` endpoint which works correctly in OSS and also in Cloud.

- https://github.com/influxdata/influxdb-client-python/issues/211
- https://github.com/influxdata/influxdb-client-ruby/issues/56
- https://github.com/influxdata/influxdb/issues/19357
- https://github.com/influxdata/influxdb/pull/21723