### PR TITLE
fix: corrections for v1 dbrp api definition

### DIFF
--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -11081,9 +11081,6 @@ components:
         orgID:
           type: string
           description: the organization ID that owns this mapping.
-        org:
-          type: string
-          description: the organization that owns this mapping.
         bucketID:
           type: string
           description: the bucket ID used as target for the translation.
@@ -11098,6 +11095,13 @@ components:
           description: Specify if this mapping represents the default retention policy for the database specificed.
         links:
           $ref: '#/components/schemas/Links'
+      required:
+        - id
+        - orgID
+        - bucketID
+        - database
+        - retention_policy
+        - default
     DBRPs:
       properties:
         content:
@@ -11141,6 +11145,7 @@ components:
       properties:
         content:
           $ref: '#/components/schemas/DBRP'
+          required: true
     SchemaType:
       type: string
       enum:

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -505,7 +505,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1dbrps~1%7BdbrpID%7D/get/responses/200/content/application~1json/schema'
+                type: object
+                properties:
+                  content:
+                    $ref: '#/components/schemas/DBRP'
         '400':
           description: if any of the IDs passed is invalid
           content:

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -315,8 +315,12 @@ paths:
         - $ref: '#/components/parameters/TraceSpan'
         - in: query
           name: orgID
-          required: true
           description: Specifies the organization ID to filter on
+          schema:
+            type: string
+        - in: query
+          name: org
+          description: Specifies the organization name to filter on
           schema:
             type: string
         - in: query
@@ -376,7 +380,31 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DBRP'
+              type: object
+              properties:
+                orgID:
+                  type: string
+                  description: the organization ID that owns this mapping.
+                org:
+                  type: string
+                  description: the organization that owns this mapping.
+                bucketID:
+                  type: string
+                  description: the bucket ID used as target for the translation.
+                database:
+                  type: string
+                  description: InfluxDB v1 database
+                retention_policy:
+                  type: string
+                  description: InfluxDB v1 retention policy
+                default:
+                  type: boolean
+                  description: Specify if this mapping represents the default retention policy for the database specificed.
+              required:
+                - orgID
+                - bucketID
+                - database
+                - retention_polcy
       responses:
         '201':
           description: Database retention policy mapping created
@@ -406,8 +434,12 @@ paths:
         - $ref: '#/components/parameters/TraceSpan'
         - in: query
           name: orgID
-          required: true
           description: Specifies the organization ID of the mapping
+          schema:
+            type: string
+        - in: query
+          name: org
+          description: Specifies the organization name of the mapping
           schema:
             type: string
         - in: path
@@ -422,7 +454,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DBRP'
+                type: object
+                properties:
+                  content:
+                    $ref: '#/components/schemas/DBRP'
         '400':
           description: if any of the IDs passed is invalid
           content:
@@ -451,8 +486,12 @@ paths:
         - $ref: '#/components/parameters/TraceSpan'
         - in: query
           name: orgID
-          required: true
           description: Specifies the organization ID of the mapping
+          schema:
+            type: string
+        - in: query
+          name: org
+          description: Specifies the organization name of the mapping
           schema:
             type: string
         - in: path
@@ -467,7 +506,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DBRP'
+                $ref: '#/paths/~1dbrps~1%7BdbrpID%7D/get/responses/200/content/application~1json/schema'
         '400':
           description: if any of the IDs passed is invalid
           content:
@@ -495,8 +534,12 @@ paths:
         - $ref: '#/components/parameters/TraceSpan'
         - in: query
           name: orgID
-          required: true
           description: Specifies the organization ID of the mapping
+          schema:
+            type: string
+        - in: query
+          name: org
+          description: Specifies the organization name of the mapping
           schema:
             type: string
         - in: path
@@ -11082,17 +11125,6 @@ components:
           description: Specify if this mapping represents the default retention policy for the database specificed.
         links:
           $ref: '#/components/schemas/Links'
-      oneOf:
-        - required:
-            - orgID
-            - bucketID
-            - database
-            - retention_policy
-        - required:
-            - org
-            - bucketID
-            - database
-            - retention_policy
     DBRPs:
       properties:
         content:
@@ -11101,16 +11133,11 @@ components:
             $ref: '#/components/schemas/DBRP'
     DBRPUpdate:
       properties:
-        database:
-          type: string
-          description: InfluxDB v1 database
         retention_policy:
           type: string
           description: InfluxDB v1 retention policy
         default:
           type: boolean
-        links:
-          $ref: '#/components/schemas/Links'
     SchemaType:
       type: string
       enum:

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -380,30 +380,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                orgID:
-                  type: string
-                  description: the organization ID that owns this mapping.
-                org:
-                  type: string
-                  description: the organization that owns this mapping.
-                bucketID:
-                  type: string
-                  description: the bucket ID used as target for the translation.
-                database:
-                  type: string
-                  description: InfluxDB v1 database
-                retention_policy:
-                  type: string
-                  description: InfluxDB v1 retention policy
-                default:
-                  type: boolean
-                  description: Specify if this mapping represents the default retention policy for the database specificed.
-              required:
-                - bucketID
-                - database
-                - retention_policy
+              $ref: '#/components/schemas/DBRPCreate'
       responses:
         '201':
           description: Database retention policy mapping created
@@ -453,10 +430,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  content:
-                    $ref: '#/components/schemas/DBRP'
+                $ref: '#/components/schemas/DBRPGet'
         '400':
           description: if any of the IDs passed is invalid
           content:
@@ -505,10 +479,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  content:
-                    $ref: '#/components/schemas/DBRP'
+                $ref: '#/components/schemas/DBRPGet'
         '400':
           description: if any of the IDs passed is invalid
           content:
@@ -11140,6 +11111,36 @@ components:
           description: InfluxDB v1 retention policy
         default:
           type: boolean
+    DBRPCreate:
+      type: object
+      properties:
+        orgID:
+          type: string
+          description: the organization ID that owns this mapping.
+        org:
+          type: string
+          description: the organization that owns this mapping.
+        bucketID:
+          type: string
+          description: the bucket ID used as target for the translation.
+        database:
+          type: string
+          description: InfluxDB v1 database
+        retention_policy:
+          type: string
+          description: InfluxDB v1 retention policy
+        default:
+          type: boolean
+          description: Specify if this mapping represents the default retention policy for the database specificed.
+      required:
+        - bucketID
+        - database
+        - retention_policy
+    DBRPGet:
+      type: object
+      properties:
+        content:
+          $ref: '#/components/schemas/DBRP'
     SchemaType:
       type: string
       enum:

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -401,10 +401,9 @@ paths:
                   type: boolean
                   description: Specify if this mapping represents the default retention policy for the database specificed.
               required:
-                - orgID
                 - bucketID
                 - database
-                - retention_polcy
+                - retention_policy
       responses:
         '201':
           description: Database retention policy mapping created

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -315,8 +315,12 @@ paths:
         - $ref: '#/components/parameters/TraceSpan'
         - in: query
           name: orgID
-          required: true
           description: Specifies the organization ID to filter on
+          schema:
+            type: string
+        - in: query
+          name: org
+          description: Specifies the organization name to filter on
           schema:
             type: string
         - in: query
@@ -376,7 +380,31 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DBRP'
+              type: object
+              properties:
+                orgID:
+                  type: string
+                  description: the organization ID that owns this mapping.
+                org:
+                  type: string
+                  description: the organization that owns this mapping.
+                bucketID:
+                  type: string
+                  description: the bucket ID used as target for the translation.
+                database:
+                  type: string
+                  description: InfluxDB v1 database
+                retention_policy:
+                  type: string
+                  description: InfluxDB v1 retention policy
+                default:
+                  type: boolean
+                  description: Specify if this mapping represents the default retention policy for the database specificed.
+              required:
+                - orgID
+                - bucketID
+                - database
+                - retention_polcy
       responses:
         '201':
           description: Database retention policy mapping created
@@ -406,8 +434,12 @@ paths:
         - $ref: '#/components/parameters/TraceSpan'
         - in: query
           name: orgID
-          required: true
           description: Specifies the organization ID of the mapping
+          schema:
+            type: string
+        - in: query
+          name: org
+          description: Specifies the organization name of the mapping
           schema:
             type: string
         - in: path
@@ -422,7 +454,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DBRP'
+                type: object
+                properties:
+                  content:
+                    $ref: '#/components/schemas/DBRP'
         '400':
           description: if any of the IDs passed is invalid
           content:
@@ -451,8 +486,12 @@ paths:
         - $ref: '#/components/parameters/TraceSpan'
         - in: query
           name: orgID
-          required: true
           description: Specifies the organization ID of the mapping
+          schema:
+            type: string
+        - in: query
+          name: org
+          description: Specifies the organization name of the mapping
           schema:
             type: string
         - in: path
@@ -467,7 +506,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DBRP'
+                $ref: '#/paths/~1dbrps~1%7BdbrpID%7D/get/responses/200/content/application~1json/schema'
         '400':
           description: if any of the IDs passed is invalid
           content:
@@ -495,8 +534,12 @@ paths:
         - $ref: '#/components/parameters/TraceSpan'
         - in: query
           name: orgID
-          required: true
           description: Specifies the organization ID of the mapping
+          schema:
+            type: string
+        - in: query
+          name: org
+          description: Specifies the organization name of the mapping
           schema:
             type: string
         - in: path
@@ -10301,17 +10344,6 @@ components:
           description: Specify if this mapping represents the default retention policy for the database specificed.
         links:
           $ref: '#/components/schemas/Links'
-      oneOf:
-        - required:
-            - orgID
-            - bucketID
-            - database
-            - retention_policy
-        - required:
-            - org
-            - bucketID
-            - database
-            - retention_policy
     DBRPs:
       properties:
         content:
@@ -10320,16 +10352,11 @@ components:
             $ref: '#/components/schemas/DBRP'
     DBRPUpdate:
       properties:
-        database:
-          type: string
-          description: InfluxDB v1 database
         retention_policy:
           type: string
           description: InfluxDB v1 retention policy
         default:
           type: boolean
-        links:
-          $ref: '#/components/schemas/Links'
     SchemaType:
       type: string
       enum:

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -505,7 +505,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1dbrps~1%7BdbrpID%7D/get/responses/200/content/application~1json/schema'
+                type: object
+                properties:
+                  content:
+                    $ref: '#/components/schemas/DBRP'
         '400':
           description: if any of the IDs passed is invalid
           content:

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -380,30 +380,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                orgID:
-                  type: string
-                  description: the organization ID that owns this mapping.
-                org:
-                  type: string
-                  description: the organization that owns this mapping.
-                bucketID:
-                  type: string
-                  description: the bucket ID used as target for the translation.
-                database:
-                  type: string
-                  description: InfluxDB v1 database
-                retention_policy:
-                  type: string
-                  description: InfluxDB v1 retention policy
-                default:
-                  type: boolean
-                  description: Specify if this mapping represents the default retention policy for the database specificed.
-              required:
-                - bucketID
-                - database
-                - retention_policy
+              $ref: '#/components/schemas/DBRPCreate'
       responses:
         '201':
           description: Database retention policy mapping created
@@ -453,10 +430,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  content:
-                    $ref: '#/components/schemas/DBRP'
+                $ref: '#/components/schemas/DBRPGet'
         '400':
           description: if any of the IDs passed is invalid
           content:
@@ -505,10 +479,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  content:
-                    $ref: '#/components/schemas/DBRP'
+                $ref: '#/components/schemas/DBRPGet'
         '400':
           description: if any of the IDs passed is invalid
           content:
@@ -10359,6 +10330,36 @@ components:
           description: InfluxDB v1 retention policy
         default:
           type: boolean
+    DBRPCreate:
+      type: object
+      properties:
+        orgID:
+          type: string
+          description: the organization ID that owns this mapping.
+        org:
+          type: string
+          description: the organization that owns this mapping.
+        bucketID:
+          type: string
+          description: the bucket ID used as target for the translation.
+        database:
+          type: string
+          description: InfluxDB v1 database
+        retention_policy:
+          type: string
+          description: InfluxDB v1 retention policy
+        default:
+          type: boolean
+          description: Specify if this mapping represents the default retention policy for the database specificed.
+      required:
+        - bucketID
+        - database
+        - retention_policy
+    DBRPGet:
+      type: object
+      properties:
+        content:
+          $ref: '#/components/schemas/DBRP'
     SchemaType:
       type: string
       enum:

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -10300,9 +10300,6 @@ components:
         orgID:
           type: string
           description: the organization ID that owns this mapping.
-        org:
-          type: string
-          description: the organization that owns this mapping.
         bucketID:
           type: string
           description: the bucket ID used as target for the translation.
@@ -10317,6 +10314,13 @@ components:
           description: Specify if this mapping represents the default retention policy for the database specificed.
         links:
           $ref: '#/components/schemas/Links'
+      required:
+        - id
+        - orgID
+        - bucketID
+        - database
+        - retention_policy
+        - default
     DBRPs:
       properties:
         content:
@@ -10360,6 +10364,7 @@ components:
       properties:
         content:
           $ref: '#/components/schemas/DBRP'
+          required: true
     SchemaType:
       type: string
       enum:

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -401,10 +401,9 @@ paths:
                   type: boolean
                   description: Specify if this mapping represents the default retention policy for the database specificed.
               required:
-                - orgID
                 - bucketID
                 - database
-                - retention_polcy
+                - retention_policy
       responses:
         '201':
           description: Database retention policy mapping created

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -315,8 +315,12 @@ paths:
         - $ref: '#/components/parameters/TraceSpan'
         - in: query
           name: orgID
-          required: true
           description: Specifies the organization ID to filter on
+          schema:
+            type: string
+        - in: query
+          name: org
+          description: Specifies the organization name to filter on
           schema:
             type: string
         - in: query
@@ -376,7 +380,31 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DBRP'
+              type: object
+              properties:
+                orgID:
+                  type: string
+                  description: the organization ID that owns this mapping.
+                org:
+                  type: string
+                  description: the organization that owns this mapping.
+                bucketID:
+                  type: string
+                  description: the bucket ID used as target for the translation.
+                database:
+                  type: string
+                  description: InfluxDB v1 database
+                retention_policy:
+                  type: string
+                  description: InfluxDB v1 retention policy
+                default:
+                  type: boolean
+                  description: Specify if this mapping represents the default retention policy for the database specificed.
+              required:
+                - orgID
+                - bucketID
+                - database
+                - retention_polcy
       responses:
         '201':
           description: Database retention policy mapping created
@@ -406,8 +434,12 @@ paths:
         - $ref: '#/components/parameters/TraceSpan'
         - in: query
           name: orgID
-          required: true
           description: Specifies the organization ID of the mapping
+          schema:
+            type: string
+        - in: query
+          name: org
+          description: Specifies the organization name of the mapping
           schema:
             type: string
         - in: path
@@ -422,7 +454,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DBRP'
+                type: object
+                properties:
+                  content:
+                    $ref: '#/components/schemas/DBRP'
         '400':
           description: if any of the IDs passed is invalid
           content:
@@ -451,8 +486,12 @@ paths:
         - $ref: '#/components/parameters/TraceSpan'
         - in: query
           name: orgID
-          required: true
           description: Specifies the organization ID of the mapping
+          schema:
+            type: string
+        - in: query
+          name: org
+          description: Specifies the organization name of the mapping
           schema:
             type: string
         - in: path
@@ -467,7 +506,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DBRP'
+                $ref: '#/paths/~1dbrps~1%7BdbrpID%7D/get/responses/200/content/application~1json/schema'
         '400':
           description: if any of the IDs passed is invalid
           content:
@@ -495,8 +534,12 @@ paths:
         - $ref: '#/components/parameters/TraceSpan'
         - in: query
           name: orgID
-          required: true
           description: Specifies the organization ID of the mapping
+          schema:
+            type: string
+        - in: query
+          name: org
+          description: Specifies the organization name of the mapping
           schema:
             type: string
         - in: path
@@ -11701,17 +11744,6 @@ components:
           description: Specify if this mapping represents the default retention policy for the database specificed.
         links:
           $ref: '#/components/schemas/Links'
-      oneOf:
-        - required:
-            - orgID
-            - bucketID
-            - database
-            - retention_policy
-        - required:
-            - org
-            - bucketID
-            - database
-            - retention_policy
     DBRPs:
       properties:
         content:
@@ -11720,16 +11752,11 @@ components:
             $ref: '#/components/schemas/DBRP'
     DBRPUpdate:
       properties:
-        database:
-          type: string
-          description: InfluxDB v1 database
         retention_policy:
           type: string
           description: InfluxDB v1 retention policy
         default:
           type: boolean
-        links:
-          $ref: '#/components/schemas/Links'
     SchemaType:
       type: string
       enum:

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -505,7 +505,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1dbrps~1%7BdbrpID%7D/get/responses/200/content/application~1json/schema'
+                type: object
+                properties:
+                  content:
+                    $ref: '#/components/schemas/DBRP'
         '400':
           description: if any of the IDs passed is invalid
           content:

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -380,30 +380,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                orgID:
-                  type: string
-                  description: the organization ID that owns this mapping.
-                org:
-                  type: string
-                  description: the organization that owns this mapping.
-                bucketID:
-                  type: string
-                  description: the bucket ID used as target for the translation.
-                database:
-                  type: string
-                  description: InfluxDB v1 database
-                retention_policy:
-                  type: string
-                  description: InfluxDB v1 retention policy
-                default:
-                  type: boolean
-                  description: Specify if this mapping represents the default retention policy for the database specificed.
-              required:
-                - bucketID
-                - database
-                - retention_policy
+              $ref: '#/components/schemas/DBRPCreate'
       responses:
         '201':
           description: Database retention policy mapping created
@@ -453,10 +430,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  content:
-                    $ref: '#/components/schemas/DBRP'
+                $ref: '#/components/schemas/DBRPGet'
         '400':
           description: if any of the IDs passed is invalid
           content:
@@ -505,10 +479,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  content:
-                    $ref: '#/components/schemas/DBRP'
+                $ref: '#/components/schemas/DBRPGet'
         '400':
           description: if any of the IDs passed is invalid
           content:
@@ -11759,6 +11730,36 @@ components:
           description: InfluxDB v1 retention policy
         default:
           type: boolean
+    DBRPCreate:
+      type: object
+      properties:
+        orgID:
+          type: string
+          description: the organization ID that owns this mapping.
+        org:
+          type: string
+          description: the organization that owns this mapping.
+        bucketID:
+          type: string
+          description: the bucket ID used as target for the translation.
+        database:
+          type: string
+          description: InfluxDB v1 database
+        retention_policy:
+          type: string
+          description: InfluxDB v1 retention policy
+        default:
+          type: boolean
+          description: Specify if this mapping represents the default retention policy for the database specificed.
+      required:
+        - bucketID
+        - database
+        - retention_policy
+    DBRPGet:
+      type: object
+      properties:
+        content:
+          $ref: '#/components/schemas/DBRP'
     SchemaType:
       type: string
       enum:

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -11700,9 +11700,6 @@ components:
         orgID:
           type: string
           description: the organization ID that owns this mapping.
-        org:
-          type: string
-          description: the organization that owns this mapping.
         bucketID:
           type: string
           description: the bucket ID used as target for the translation.
@@ -11717,6 +11714,13 @@ components:
           description: Specify if this mapping represents the default retention policy for the database specificed.
         links:
           $ref: '#/components/schemas/Links'
+      required:
+        - id
+        - orgID
+        - bucketID
+        - database
+        - retention_policy
+        - default
     DBRPs:
       properties:
         content:
@@ -11760,6 +11764,7 @@ components:
       properties:
         content:
           $ref: '#/components/schemas/DBRP'
+          required: true
     SchemaType:
       type: string
       enum:

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -401,10 +401,9 @@ paths:
                   type: boolean
                   description: Specify if this mapping represents the default retention policy for the database specificed.
               required:
-                - orgID
                 - bucketID
                 - database
-                - retention_polcy
+                - retention_policy
       responses:
         '201':
           description: Database retention policy mapping created

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -2113,7 +2113,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1dbrps~1%7BdbrpID%7D/get/responses/200/content/application~1json/schema'
+                properties:
+                  content:
+                    $ref: '#/components/schemas/DBRP'
+                type: object
           description: An updated mapping
         "400":
           content:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -1969,10 +1969,9 @@ paths:
                   description: InfluxDB v1 retention policy
                   type: string
               required:
-              - orgID
               - bucketID
               - database
-              - retention_polcy
+              - retention_policy
               type: object
         description: The database retention policy mapping to add
         required: true

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -1886,7 +1886,11 @@ paths:
       - description: Specifies the organization ID to filter on
         in: query
         name: orgID
-        required: true
+        schema:
+          type: string
+      - description: Specifies the organization name to filter on
+        in: query
+        name: org
         schema:
           type: string
       - description: Specifies the mapping ID to filter on
@@ -1944,7 +1948,32 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DBRP'
+              properties:
+                bucketID:
+                  description: the bucket ID used as target for the translation.
+                  type: string
+                database:
+                  description: InfluxDB v1 database
+                  type: string
+                default:
+                  description: Specify if this mapping represents the default retention
+                    policy for the database specificed.
+                  type: boolean
+                org:
+                  description: the organization that owns this mapping.
+                  type: string
+                orgID:
+                  description: the organization ID that owns this mapping.
+                  type: string
+                retention_policy:
+                  description: InfluxDB v1 retention policy
+                  type: string
+              required:
+              - orgID
+              - bucketID
+              - database
+              - retention_polcy
+              type: object
         description: The database retention policy mapping to add
         required: true
       responses:
@@ -1977,7 +2006,11 @@ paths:
       - description: Specifies the organization ID of the mapping
         in: query
         name: orgID
-        required: true
+        schema:
+          type: string
+      - description: Specifies the organization name of the mapping
+        in: query
+        name: org
         schema:
           type: string
       - description: The database retention policy mapping
@@ -2011,7 +2044,11 @@ paths:
       - description: Specifies the organization ID of the mapping
         in: query
         name: orgID
-        required: true
+        schema:
+          type: string
+      - description: Specifies the organization name of the mapping
+        in: query
+        name: org
         schema:
           type: string
       - description: The database retention policy mapping ID
@@ -2025,7 +2062,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DBRP'
+                properties:
+                  content:
+                    $ref: '#/components/schemas/DBRP'
+                type: object
           description: The database retention policy requested
         "400":
           content:
@@ -2049,7 +2089,11 @@ paths:
       - description: Specifies the organization ID of the mapping
         in: query
         name: orgID
-        required: true
+        schema:
+          type: string
+      - description: Specifies the organization name of the mapping
+        in: query
+        name: org
         schema:
           type: string
       - description: The database retention policy mapping.
@@ -2070,7 +2114,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DBRP'
+                $ref: '#/paths/~1dbrps~1%7BdbrpID%7D/get/responses/200/content/application~1json/schema'
           description: An updated mapping
         "400":
           content:
@@ -7929,17 +7973,6 @@ components:
         - type
         type: object
     DBRP:
-      oneOf:
-      - required:
-        - orgID
-        - bucketID
-        - database
-        - retention_policy
-      - required:
-        - org
-        - bucketID
-        - database
-        - retention_policy
       properties:
         bucketID:
           description: the bucket ID used as target for the translation.
@@ -7969,13 +8002,8 @@ components:
       type: object
     DBRPUpdate:
       properties:
-        database:
-          description: InfluxDB v1 database
-          type: string
         default:
           type: boolean
-        links:
-          $ref: '#/components/schemas/Links'
         retention_policy:
           description: InfluxDB v1 retention policy
           type: string

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -1948,31 +1948,7 @@ paths:
         content:
           application/json:
             schema:
-              properties:
-                bucketID:
-                  description: the bucket ID used as target for the translation.
-                  type: string
-                database:
-                  description: InfluxDB v1 database
-                  type: string
-                default:
-                  description: Specify if this mapping represents the default retention
-                    policy for the database specificed.
-                  type: boolean
-                org:
-                  description: the organization that owns this mapping.
-                  type: string
-                orgID:
-                  description: the organization ID that owns this mapping.
-                  type: string
-                retention_policy:
-                  description: InfluxDB v1 retention policy
-                  type: string
-              required:
-              - bucketID
-              - database
-              - retention_policy
-              type: object
+              $ref: '#/components/schemas/DBRPCreate'
         description: The database retention policy mapping to add
         required: true
       responses:
@@ -2061,10 +2037,7 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  content:
-                    $ref: '#/components/schemas/DBRP'
-                type: object
+                $ref: '#/components/schemas/DBRPGet'
           description: The database retention policy requested
         "400":
           content:
@@ -2113,10 +2086,7 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  content:
-                    $ref: '#/components/schemas/DBRP'
-                type: object
+                $ref: '#/components/schemas/DBRPGet'
           description: An updated mapping
         "400":
           content:
@@ -8001,6 +7971,37 @@ components:
         retention_policy:
           description: InfluxDB v1 retention policy
           type: string
+      type: object
+    DBRPCreate:
+      properties:
+        bucketID:
+          description: the bucket ID used as target for the translation.
+          type: string
+        database:
+          description: InfluxDB v1 database
+          type: string
+        default:
+          description: Specify if this mapping represents the default retention policy
+            for the database specificed.
+          type: boolean
+        org:
+          description: the organization that owns this mapping.
+          type: string
+        orgID:
+          description: the organization ID that owns this mapping.
+          type: string
+        retention_policy:
+          description: InfluxDB v1 retention policy
+          type: string
+      required:
+      - bucketID
+      - database
+      - retention_policy
+      type: object
+    DBRPGet:
+      properties:
+        content:
+          $ref: '#/components/schemas/DBRP'
       type: object
     DBRPUpdate:
       properties:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -7962,15 +7962,19 @@ components:
           type: string
         links:
           $ref: '#/components/schemas/Links'
-        org:
-          description: the organization that owns this mapping.
-          type: string
         orgID:
           description: the organization ID that owns this mapping.
           type: string
         retention_policy:
           description: InfluxDB v1 retention policy
           type: string
+      required:
+      - id
+      - orgID
+      - bucketID
+      - database
+      - retention_policy
+      - default
       type: object
     DBRPCreate:
       properties:
@@ -8002,6 +8006,7 @@ components:
       properties:
         content:
           $ref: '#/components/schemas/DBRP'
+          required: true
       type: object
     DBRPUpdate:
       properties:

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -1846,10 +1846,9 @@ paths:
                   description: InfluxDB v1 retention policy
                   type: string
               required:
-              - orgID
               - bucketID
               - database
-              - retention_polcy
+              - retention_policy
               type: object
         description: The database retention policy mapping to add
         required: true

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -1990,7 +1990,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1dbrps~1%7BdbrpID%7D/get/responses/200/content/application~1json/schema'
+                properties:
+                  content:
+                    $ref: '#/components/schemas/DBRP'
+                type: object
           description: An updated mapping
         "400":
           content:

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -7582,15 +7582,19 @@ components:
           type: string
         links:
           $ref: '#/components/schemas/Links'
-        org:
-          description: the organization that owns this mapping.
-          type: string
         orgID:
           description: the organization ID that owns this mapping.
           type: string
         retention_policy:
           description: InfluxDB v1 retention policy
           type: string
+      required:
+      - id
+      - orgID
+      - bucketID
+      - database
+      - retention_policy
+      - default
       type: object
     DBRPCreate:
       properties:
@@ -7622,6 +7626,7 @@ components:
       properties:
         content:
           $ref: '#/components/schemas/DBRP'
+          required: true
       type: object
     DBRPUpdate:
       properties:

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -1825,31 +1825,7 @@ paths:
         content:
           application/json:
             schema:
-              properties:
-                bucketID:
-                  description: the bucket ID used as target for the translation.
-                  type: string
-                database:
-                  description: InfluxDB v1 database
-                  type: string
-                default:
-                  description: Specify if this mapping represents the default retention
-                    policy for the database specificed.
-                  type: boolean
-                org:
-                  description: the organization that owns this mapping.
-                  type: string
-                orgID:
-                  description: the organization ID that owns this mapping.
-                  type: string
-                retention_policy:
-                  description: InfluxDB v1 retention policy
-                  type: string
-              required:
-              - bucketID
-              - database
-              - retention_policy
-              type: object
+              $ref: '#/components/schemas/DBRPCreate'
         description: The database retention policy mapping to add
         required: true
       responses:
@@ -1938,10 +1914,7 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  content:
-                    $ref: '#/components/schemas/DBRP'
-                type: object
+                $ref: '#/components/schemas/DBRPGet'
           description: The database retention policy requested
         "400":
           content:
@@ -1990,10 +1963,7 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  content:
-                    $ref: '#/components/schemas/DBRP'
-                type: object
+                $ref: '#/components/schemas/DBRPGet'
           description: An updated mapping
         "400":
           content:
@@ -7621,6 +7591,37 @@ components:
         retention_policy:
           description: InfluxDB v1 retention policy
           type: string
+      type: object
+    DBRPCreate:
+      properties:
+        bucketID:
+          description: the bucket ID used as target for the translation.
+          type: string
+        database:
+          description: InfluxDB v1 database
+          type: string
+        default:
+          description: Specify if this mapping represents the default retention policy
+            for the database specificed.
+          type: boolean
+        org:
+          description: the organization that owns this mapping.
+          type: string
+        orgID:
+          description: the organization ID that owns this mapping.
+          type: string
+        retention_policy:
+          description: InfluxDB v1 retention policy
+          type: string
+      required:
+      - bucketID
+      - database
+      - retention_policy
+      type: object
+    DBRPGet:
+      properties:
+        content:
+          $ref: '#/components/schemas/DBRP'
       type: object
     DBRPUpdate:
       properties:

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -1763,7 +1763,11 @@ paths:
       - description: Specifies the organization ID to filter on
         in: query
         name: orgID
-        required: true
+        schema:
+          type: string
+      - description: Specifies the organization name to filter on
+        in: query
+        name: org
         schema:
           type: string
       - description: Specifies the mapping ID to filter on
@@ -1821,7 +1825,32 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DBRP'
+              properties:
+                bucketID:
+                  description: the bucket ID used as target for the translation.
+                  type: string
+                database:
+                  description: InfluxDB v1 database
+                  type: string
+                default:
+                  description: Specify if this mapping represents the default retention
+                    policy for the database specificed.
+                  type: boolean
+                org:
+                  description: the organization that owns this mapping.
+                  type: string
+                orgID:
+                  description: the organization ID that owns this mapping.
+                  type: string
+                retention_policy:
+                  description: InfluxDB v1 retention policy
+                  type: string
+              required:
+              - orgID
+              - bucketID
+              - database
+              - retention_polcy
+              type: object
         description: The database retention policy mapping to add
         required: true
       responses:
@@ -1854,7 +1883,11 @@ paths:
       - description: Specifies the organization ID of the mapping
         in: query
         name: orgID
-        required: true
+        schema:
+          type: string
+      - description: Specifies the organization name of the mapping
+        in: query
+        name: org
         schema:
           type: string
       - description: The database retention policy mapping
@@ -1888,7 +1921,11 @@ paths:
       - description: Specifies the organization ID of the mapping
         in: query
         name: orgID
-        required: true
+        schema:
+          type: string
+      - description: Specifies the organization name of the mapping
+        in: query
+        name: org
         schema:
           type: string
       - description: The database retention policy mapping ID
@@ -1902,7 +1939,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DBRP'
+                properties:
+                  content:
+                    $ref: '#/components/schemas/DBRP'
+                type: object
           description: The database retention policy requested
         "400":
           content:
@@ -1926,7 +1966,11 @@ paths:
       - description: Specifies the organization ID of the mapping
         in: query
         name: orgID
-        required: true
+        schema:
+          type: string
+      - description: Specifies the organization name of the mapping
+        in: query
+        name: org
         schema:
           type: string
       - description: The database retention policy mapping.
@@ -1947,7 +1991,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DBRP'
+                $ref: '#/paths/~1dbrps~1%7BdbrpID%7D/get/responses/200/content/application~1json/schema'
           description: An updated mapping
         "400":
           content:
@@ -7549,17 +7593,6 @@ components:
         - type
         type: object
     DBRP:
-      oneOf:
-      - required:
-        - orgID
-        - bucketID
-        - database
-        - retention_policy
-      - required:
-        - org
-        - bucketID
-        - database
-        - retention_policy
       properties:
         bucketID:
           description: the bucket ID used as target for the translation.
@@ -7589,13 +7622,8 @@ components:
       type: object
     DBRPUpdate:
       properties:
-        database:
-          description: InfluxDB v1 database
-          type: string
         default:
           type: boolean
-        links:
-          $ref: '#/components/schemas/Links'
         retention_policy:
           description: InfluxDB v1 retention policy
           type: string

--- a/src/common/_schemas.yml
+++ b/src/common/_schemas.yml
@@ -452,5 +452,9 @@
       $ref: "./common/schemas/DBRPs.yml"
     DBRPUpdate:
       $ref: "./common/schemas/DBRPUpdate.yml"
+    DBRPCreate:
+      $ref: "./common/schemas/DBRPCreate.yml"
+    DBRPGet:
+      $ref: "./common/schemas/DBRPGet.yml"
     SchemaType:
       $ref: "./common/schemas/SchemaType.yml"

--- a/src/common/paths/dbrps.yml
+++ b/src/common/paths/dbrps.yml
@@ -7,8 +7,12 @@ get:
     - $ref: "../parameters/TraceSpan.yml"
     - in: query
       name: orgID
-      required: true
       description: Specifies the organization ID to filter on
+      schema:
+        type: string
+    - in: query
+      name: org
+      description: Specifies the organization name to filter on
       schema:
         type: string
     - in: query
@@ -68,7 +72,7 @@ post:
     content:
       application/json:
         schema:
-          $ref: "../schemas/DBRP.yml"
+          $ref: "../schemas/DBRPCreate.yml"
   responses:
     "201":
       description: Database retention policy mapping created

--- a/src/common/paths/dbrps_dbrpID.yml
+++ b/src/common/paths/dbrps_dbrpID.yml
@@ -76,7 +76,7 @@ patch:
       content:
         application/json:
           schema:
-            $ref: "../schemas/DBRPGet.yml"
+            $ref: "../schemas/DBRPUpdateResponse.yml"
     "404":
       description: The mapping was not found
       content:

--- a/src/common/paths/dbrps_dbrpID.yml
+++ b/src/common/paths/dbrps_dbrpID.yml
@@ -76,7 +76,7 @@ patch:
       content:
         application/json:
           schema:
-            $ref: "../schemas/DBRPUpdateResponse.yml"
+            $ref: "../schemas/DBRPGet.yml"
     "404":
       description: The mapping was not found
       content:

--- a/src/common/paths/dbrps_dbrpID.yml
+++ b/src/common/paths/dbrps_dbrpID.yml
@@ -7,8 +7,12 @@ get:
     - $ref: "../parameters/TraceSpan.yml"
     - in: query
       name: orgID
-      required: true
       description: Specifies the organization ID of the mapping
+      schema:
+        type: string
+    - in: query
+      name: org
+      description: Specifies the organization name of the mapping
       schema:
         type: string
     - in: path
@@ -23,7 +27,7 @@ get:
       content:
         application/json:
           schema:
-            $ref: "../schemas/DBRP.yml"
+            $ref: "../schemas/DBRPGet.yml"
     "400":
       description: if any of the IDs passed is invalid
       content:
@@ -52,8 +56,12 @@ patch:
     - $ref: "../parameters/TraceSpan.yml"
     - in: query
       name: orgID
-      required: true
       description: Specifies the organization ID of the mapping
+      schema:
+        type: string
+    - in: query
+      name: org
+      description: Specifies the organization name of the mapping
       schema:
         type: string
     - in: path
@@ -68,7 +76,7 @@ patch:
       content:
         application/json:
           schema:
-            $ref: "../schemas/DBRP.yml"
+            $ref: "../schemas/DBRPGet.yml"
     "404":
       description: The mapping was not found
       content:
@@ -96,8 +104,12 @@ delete:
     - $ref: "../parameters/TraceSpan.yml"
     - in: query
       name: orgID
-      required: true
       description: Specifies the organization ID of the mapping
+      schema:
+        type: string
+    - in: query
+      name: org
+      description: Specifies the organization name of the mapping
       schema:
         type: string
     - in: path

--- a/src/common/schemas/DBRP.yml
+++ b/src/common/schemas/DBRP.yml
@@ -24,14 +24,3 @@
       description: Specify if this mapping represents the default retention policy for the database specificed.
     links:
       $ref: "./Links.yml"
-  oneOf:
-    - required:
-      - orgID
-      - bucketID
-      - database
-      - retention_policy
-    - required:
-      - org
-      - bucketID
-      - database
-      - retention_policy

--- a/src/common/schemas/DBRP.yml
+++ b/src/common/schemas/DBRP.yml
@@ -7,9 +7,6 @@
     orgID:
       type: string
       description: the organization ID that owns this mapping.
-    org:
-      type: string
-      description: the organization that owns this mapping.
     bucketID:
       type: string
       description: the bucket ID used as target for the translation.
@@ -24,3 +21,10 @@
       description: Specify if this mapping represents the default retention policy for the database specificed.
     links:
       $ref: "./Links.yml"
+  required:
+    - id
+    - orgID
+    - bucketID
+    - database
+    - retention_policy
+    - default

--- a/src/common/schemas/DBRPCreate.yml
+++ b/src/common/schemas/DBRPCreate.yml
@@ -1,0 +1,26 @@
+type: object
+properties:
+  orgID:
+    type: string
+    description: the organization ID that owns this mapping.
+  org:
+    type: string
+    description: the organization that owns this mapping.
+  bucketID:
+    type: string
+    description: the bucket ID used as target for the translation.
+  database:
+    type: string
+    description: InfluxDB v1 database
+  retention_policy:
+    type: string
+    description: InfluxDB v1 retention policy
+  default:
+    type: boolean
+    description: Specify if this mapping represents the default retention policy for the database specificed.
+required:
+  - orgID
+  - bucketID
+  - database
+  - retention_polcy
+

--- a/src/common/schemas/DBRPCreate.yml
+++ b/src/common/schemas/DBRPCreate.yml
@@ -19,8 +19,6 @@ properties:
     type: boolean
     description: Specify if this mapping represents the default retention policy for the database specificed.
 required:
-  - orgID
   - bucketID
   - database
-  - retention_polcy
-
+  - retention_policy

--- a/src/common/schemas/DBRPGet.yml
+++ b/src/common/schemas/DBRPGet.yml
@@ -2,3 +2,4 @@
   properties:
     content:
       $ref: "./DBRP.yml"
+      required: true

--- a/src/common/schemas/DBRPGet.yml
+++ b/src/common/schemas/DBRPGet.yml
@@ -1,0 +1,4 @@
+  type: object
+  properties:
+    content:
+      $ref: "./DBRP.yml"

--- a/src/common/schemas/DBRPUpdate.yml
+++ b/src/common/schemas/DBRPUpdate.yml
@@ -1,11 +1,6 @@
   properties:
-    database:
-      type: string
-      description: InfluxDB v1 database
     retention_policy:
       type: string
       description: InfluxDB v1 retention policy
     default:
       type: boolean
-    links:
-      $ref: "./Links.yml"

--- a/src/common/schemas/DBRPUpdateResponse.yml
+++ b/src/common/schemas/DBRPUpdateResponse.yml
@@ -1,4 +1,0 @@
-  type: object
-  properties:
-    content:
-      $ref: "./DBRP.yml"

--- a/src/common/schemas/DBRPUpdateResponse.yml
+++ b/src/common/schemas/DBRPUpdateResponse.yml
@@ -1,0 +1,4 @@
+  type: object
+  properties:
+    content:
+      $ref: "./DBRP.yml"


### PR DESCRIPTION
Related to https://github.com/influxdata/influx-cli/issues/24

This PR updates the swagger definition with the `v1dbrps` endpoint to more accurately reflect its usage, and allow for CLI code to be generated off of the swagger spec.

There were generally some mismatches between the form of responses and the types of parameters needed from requests that are being corrected with this PR.