### PR TITLE
chore: update response type

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -980,7 +980,7 @@ paths:
       responses:
         '200':
           content:
-            text/plain:
+            application/json:
               schema:
                 type: string
                 example: connection

--- a/src/unity/paths/sso.yml
+++ b/src/unity/paths/sso.yml
@@ -14,7 +14,7 @@ get:
   responses:
     "200":
       content:
-        text/plain:
+        application/json:
           schema:
             type: string
             example: connection


### PR DESCRIPTION
The response type for sso connection api request needs to be application/json even though the response is actually a JSON encoded string. So, we aren't going to have a schema instead we will have the response as `application/json` and the schema type will be `string`.