### PR TITLE
fix(unity): Remove 404 from Operator delete user api definition

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -820,9 +820,6 @@ paths:
         '401':
           description: Unauthorized
           $ref: '#/components/responses/ServerError'
-        '404':
-          description: Account/User not found
-          $ref: '#/components/responses/ServerError'
         default:
           description: Unexpected error
           $ref: '#/components/responses/ServerError'

--- a/src/unity/paths/operator_accounts_accountId_users_userId.yml
+++ b/src/unity/paths/operator_accounts_accountId_users_userId.yml
@@ -30,9 +30,6 @@ delete:
     '401':
       description: Unauthorized
       $ref: '../../common/responses/ServerError.yml'
-    '404':
-      description: Account/User not found
-      $ref: '../../common/responses/ServerError.yml'
     'default':
       description: Unexpected error
       $ref: '../../common/responses/ServerError.yml'


### PR DESCRIPTION
As noted in [Quartz #4766](https://github.com/influxdata/quartz/issues/4766), the `404` error for users that don't exist/already deleted is being removed. API will simply return `204` if either of those cases are encountered.