### PR TITLE
feat(operator-orgs): Update operator/orgs GET to reflect api response

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -1574,12 +1574,12 @@ components:
         balance:
           type: number
           description: 'remaining balance on the account, nil if none'
-        updatedAt:
-          type: string
-          description: date of last update to account
         billingContact:
           $ref: '#/components/schemas/BillingContact'
           description: billing contact for the account
+        updatedAt:
+          type: string
+          description: date of last update to account
       required:
         - id
         - balance

--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -874,12 +874,6 @@ paths:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/Organization'
-                  - properties:
-                      account:
-                        description: organization's account
-                        $ref: '#/components/schemas/OperatorAccount'
-                  - required:
-                      - account
         '401':
           description: Unauthorized
           $ref: '#/components/responses/ServerError'
@@ -1584,7 +1578,8 @@ components:
         - id
         - balance
         - type
-        - billingContact
+        - deletable
+        - updatedAt
     OrgLimits:
       type: object
       properties:

--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -1580,6 +1580,7 @@ components:
         - type
         - deletable
         - updatedAt
+        - billingContact
     OrgLimits:
       type: object
       properties:

--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -1545,12 +1545,8 @@ components:
           description: date org was created
         account:
           $ref: '#/components/schemas/RelatedAccount'
-        billingContact:
-          $ref: '#/components/schemas/BillingContact'
-          description: billing contact for the account
       required:
         - account
-        - billingContact
         - id
         - idpeId
         - region
@@ -1565,21 +1561,30 @@ components:
       type: object
       properties:
         id:
-          type: string
-          description: account id
-        email:
-          type: string
-          description: email associated with the account
+          type: number
+          description: account id in quartz
         type:
           $ref: '#/components/schemas/AccountType'
+        zuoraAccountId:
+          type: string
+          description: Zuora ID associated with the account
+        deletable:
+          type: boolean
+          description: flag whether the account can be deleted or not
         balance:
           type: number
           description: 'remaining balance on the account, nil if none'
+        updatedAt:
+          type: string
+          description: date of last update to account
+        billingContact:
+          $ref: '#/components/schemas/BillingContact'
+          description: billing contact for the account
       required:
         - id
-        - email
-        - type
         - balance
+        - type
+        - billingContact
     OrgLimits:
       type: object
       properties:

--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -1559,12 +1559,6 @@ components:
           description: account id in quartz
         type:
           $ref: '#/components/schemas/AccountType'
-        zuoraAccountId:
-          type: string
-          description: Zuora ID associated with the account
-        deletable:
-          type: boolean
-          description: flag whether the account can be deleted or not
         balance:
           type: number
           description: 'remaining balance on the account, nil if none'
@@ -1578,9 +1572,7 @@ components:
         - id
         - balance
         - type
-        - deletable
         - updatedAt
-        - billingContact
     OrgLimits:
       type: object
       properties:

--- a/src/unity/paths/operator_orgs_orgId.yml
+++ b/src/unity/paths/operator_orgs_orgId.yml
@@ -20,11 +20,6 @@ get:
           schema:
             allOf:
               - $ref: '../schemas/Organization.yml'
-              - properties:
-                  account:
-                    description: organization's account
-                    $ref: '../schemas/OperatorAccount.yml'
-              - required: [account]
     '401':
       description: Unauthorized
       $ref: '../../common/responses/ServerError.yml'

--- a/src/unity/schemas/Organization.yml
+++ b/src/unity/schemas/Organization.yml
@@ -20,7 +20,4 @@ properties:
     description: date org was created
   account:
     $ref: './RelatedAccount.yml'
-  billingContact:
-    $ref: './BillingContact.yml'
-    description: billing contact for the account
-required: [account, billingContact, id, idpeId, region, provider, date]
+required: [account, id, idpeId, region, provider, date]

--- a/src/unity/schemas/RelatedAccount.yml
+++ b/src/unity/schemas/RelatedAccount.yml
@@ -21,4 +21,4 @@ properties:
   updatedAt:
     type: string
     description: date of last update to account
-required: [id, balance, type, billingContact]
+required: [id, balance, type, deletable, updatedAt]

--- a/src/unity/schemas/RelatedAccount.yml
+++ b/src/unity/schemas/RelatedAccount.yml
@@ -21,4 +21,4 @@ properties:
   updatedAt:
     type: string
     description: date of last update to account
-required: [id, balance, type, deletable, updatedAt]
+required: [id, balance, type, deletable, updatedAt, billingContact]

--- a/src/unity/schemas/RelatedAccount.yml
+++ b/src/unity/schemas/RelatedAccount.yml
@@ -2,14 +2,23 @@ description: Subset of Account data related to the organization
 type: object
 properties:
   id:
-    type: string
-    description: account id
-  email:
-    type: string
-    description: email associated with the account
+    type: number
+    description: account id in quartz
   type:
     $ref: './AccountType.yml'
+  zuoraAccountId:
+    type: string
+    description: Zuora ID associated with the account
+  deletable:
+    type: boolean
+    description: flag whether the account can be deleted or not
   balance:
     type: number
     description: remaining balance on the account, nil if none
-required: [id, email, type, balance]
+  billingContact:
+    $ref: './BillingContact.yml'
+    description: billing contact for the account
+  updatedAt:
+    type: string
+    description: date of last update to account
+required: [id, balance, type, billingContact]

--- a/src/unity/schemas/RelatedAccount.yml
+++ b/src/unity/schemas/RelatedAccount.yml
@@ -6,12 +6,6 @@ properties:
     description: account id in quartz
   type:
     $ref: './AccountType.yml'
-  zuoraAccountId:
-    type: string
-    description: Zuora ID associated with the account
-  deletable:
-    type: boolean
-    description: flag whether the account can be deleted or not
   balance:
     type: number
     description: remaining balance on the account, nil if none
@@ -21,4 +15,4 @@ properties:
   updatedAt:
     type: string
     description: date of last update to account
-required: [id, balance, type, deletable, updatedAt, billingContact]
+required: [id, balance, type, updatedAt]


### PR DESCRIPTION
As part of [#4767](https://github.com/influxdata/quartz/issues/4767) I found that the current api response does not line up to the swagger definition. This updates the swagger to be in line with the response.