### PR TITLE
fix: v1 auth taking password as query instead of requestBody

### DIFF
--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -576,8 +576,8 @@ paths:
   '/legacy/authorizations/{authID}/password':
     servers:
       - url: /private
-    patch:
-      operationId: SetAuthorizationsIDPassword
+    post:
+      operationId: PostAuthorizationsIDPassword
       tags:
         - Legacy Authorizations
       summary: Set an authorization password
@@ -589,12 +589,17 @@ paths:
             type: string
           required: true
           description: The ID of the authorization to update.
-        - in: query
-          name: password
-          schema:
-            type: string
-          required: true
-          description: The new password for the authorization.
+      requestBody:
+        description: New password
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                password:
+                  type: string
+              required:
+                - password
       responses:
         '204':
           description: Authorization password set

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -5745,8 +5745,8 @@ paths:
   '/legacy/authorizations/{authID}/password':
     servers:
       - url: /private
-    patch:
-      operationId: SetAuthorizationsIDPassword
+    post:
+      operationId: PostAuthorizationsIDPassword
       tags:
         - Legacy Authorizations
       summary: Set an authorization password
@@ -5758,12 +5758,13 @@ paths:
             type: string
           required: true
           description: The ID of the authorization to update.
-        - in: query
-          name: password
-          schema:
-            type: string
-          required: true
-          description: The new password for the authorization.
+      requestBody:
+        description: New password
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PasswordResetBody'
       responses:
         '204':
           description: Authorization password set

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -2631,8 +2631,8 @@ paths:
     servers:
     - url: /private
   /api/v2/legacy/authorizations/{authID}/password:
-    patch:
-      operationId: SetAuthorizationsIDPassword
+    post:
+      operationId: PostAuthorizationsIDPassword
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
       - description: The ID of the authorization to update.
@@ -2641,12 +2641,13 @@ paths:
         required: true
         schema:
           type: string
-      - description: The new password for the authorization.
-        in: query
-        name: password
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PasswordResetBody'
+        description: New password
         required: true
-        schema:
-          type: string
       responses:
         "204":
           description: Authorization password set

--- a/src/oss/paths/legacy_authorizations_authID_password.yml
+++ b/src/oss/paths/legacy_authorizations_authID_password.yml
@@ -1,5 +1,5 @@
-patch:
-  operationId: SetAuthorizationsIDPassword
+post:
+  operationId: PostAuthorizationsIDPassword
   tags:
     - Legacy Authorizations
   summary: Set an authorization password
@@ -11,12 +11,13 @@ patch:
         type: string
       required: true
       description: The ID of the authorization to update.
-    - in: query
-      name: password
-      schema:
-        type: string
-      required: true
-      description: The new password for the authorization.
+  requestBody:
+    description: New password
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: "../../common/schemas/PasswordResetBody.yml"
   responses:
     "204":
       description: Authorization password set


### PR DESCRIPTION
Fixes the V1 Auth password parameter being a query parameter instead of a request body. Also fixes it using `patch` instead of `post`