### PR TITLE
fix: change legacy auth operationIds to include "Legacy"

### DIFF
--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -425,45 +425,45 @@ paths:
     servers:
       - url: /private
     get:
-      operationId: GetAuthorizations
+      operationId: GetLegacyAuthorizations
       tags:
         - Legacy Authorizations
-      summary: List all authorizations
+      summary: List all legacy authorizations
       parameters:
         - $ref: '#/paths/~1ready/get/parameters/0'
         - in: query
           name: userID
           schema:
             type: string
-          description: Only show authorizations that belong to a user ID.
+          description: Only show legacy authorizations that belong to a user ID.
         - in: query
           name: user
           schema:
             type: string
-          description: Only show authorizations that belong to a user name.
+          description: Only show legacy authorizations that belong to a user name.
         - in: query
           name: orgID
           schema:
             type: string
-          description: Only show authorizations that belong to an organization ID.
+          description: Only show legacy authorizations that belong to an organization ID.
         - in: query
           name: org
           schema:
             type: string
-          description: Only show authorizations that belong to a organization name.
+          description: Only show legacy authorizations that belong to a organization name.
         - in: query
           name: token
           schema:
             type: string
-          description: Only show authorizations with a specified token (auth name).
+          description: Only show legacy authorizations with a specified token (auth name).
         - in: query
           name: authID
           schema:
             type: string
-          description: Only show authorizations with a specified auth ID.
+          description: Only show legacy authorizations with a specified auth ID.
       responses:
         '200':
-          description: A list of authorizations
+          description: A list of legacy authorizations
           content:
             application/json:
               schema:
@@ -472,14 +472,14 @@ paths:
           description: Unexpected error
           $ref: '#/components/responses/ServerError'
     post:
-      operationId: PostAuthorizations
+      operationId: PostLegacyAuthorizations
       tags:
         - Legacy Authorizations
-      summary: Create an authorization
+      summary: Create a legacy authorization
       parameters:
         - $ref: '#/paths/~1ready/get/parameters/0'
       requestBody:
-        description: Authorization to create
+        description: Legacy authorization to create
         required: true
         content:
           application/json:
@@ -487,7 +487,7 @@ paths:
               $ref: '#/components/schemas/LegacyAuthorizationPostRequest'
       responses:
         '201':
-          description: Authorization created
+          description: Legacy authorization created
           content:
             application/json:
               schema:
@@ -502,10 +502,10 @@ paths:
     servers:
       - url: /private
     get:
-      operationId: GetAuthorizationsID
+      operationId: GetLegacyAuthorizationsID
       tags:
         - Legacy Authorizations
-      summary: Retrieve an authorization
+      summary: Retrieve a legacy authorization
       parameters:
         - $ref: '#/paths/~1ready/get/parameters/0'
         - in: path
@@ -513,10 +513,10 @@ paths:
           schema:
             type: string
           required: true
-          description: The ID of the authorization to get.
+          description: The ID of the legacy authorization to get.
       responses:
         '200':
-          description: Authorization details
+          description: Legacy authorization details
           content:
             application/json:
               schema:
@@ -525,12 +525,12 @@ paths:
           description: Unexpected error
           $ref: '#/components/responses/ServerError'
     patch:
-      operationId: PatchAuthorizationsID
+      operationId: PatchLegacyAuthorizationsID
       tags:
         - Legacy Authorizations
-      summary: Update an authorization to be active or inactive
+      summary: Update a legacy authorization to be active or inactive
       requestBody:
-        description: Authorization to update
+        description: Legacy authorization to update
         required: true
         content:
           application/json:
@@ -543,10 +543,10 @@ paths:
           schema:
             type: string
           required: true
-          description: The ID of the authorization to update.
+          description: The ID of the legacy authorization to update.
       responses:
         '200':
-          description: The active or inactie authorization
+          description: The active or inactive legacy authorization
           content:
             application/json:
               schema:
@@ -555,10 +555,10 @@ paths:
           description: Unexpected error
           $ref: '#/components/responses/ServerError'
     delete:
-      operationId: DeleteAuthorizationsID
+      operationId: DeleteLegacyAuthorizationsID
       tags:
         - Legacy Authorizations
-      summary: Delete an authorization
+      summary: Delete a legacy authorization
       parameters:
         - $ref: '#/paths/~1ready/get/parameters/0'
         - in: path
@@ -566,10 +566,10 @@ paths:
           schema:
             type: string
           required: true
-          description: The ID of the authorization to delete.
+          description: The ID of the legacy authorization to delete.
       responses:
         '204':
-          description: Authorization deleted
+          description: Legacy authorization deleted
         default:
           description: Unexpected error
           $ref: '#/components/responses/ServerError'
@@ -577,10 +577,10 @@ paths:
     servers:
       - url: /private
     post:
-      operationId: PostAuthorizationsIDPassword
+      operationId: PostLegacyAuthorizationsIDPassword
       tags:
         - Legacy Authorizations
-      summary: Set an authorization password
+      summary: Set a legacy authorization password
       parameters:
         - $ref: '#/paths/~1ready/get/parameters/0'
         - in: path
@@ -588,7 +588,7 @@ paths:
           schema:
             type: string
           required: true
-          description: The ID of the authorization to update.
+          description: The ID of the legacy authorization to update.
       requestBody:
         description: New password
         required: true
@@ -602,7 +602,7 @@ paths:
                 - password
       responses:
         '204':
-          description: Authorization password set
+          description: Legacy authorization password set
         default:
           description: Unexpected error
           $ref: '#/components/responses/ServerError'

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -5594,45 +5594,45 @@ paths:
     servers:
       - url: /private
     get:
-      operationId: GetAuthorizations
+      operationId: GetLegacyAuthorizations
       tags:
         - Legacy Authorizations
-      summary: List all authorizations
+      summary: List all legacy authorizations
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: query
           name: userID
           schema:
             type: string
-          description: Only show authorizations that belong to a user ID.
+          description: Only show legacy authorizations that belong to a user ID.
         - in: query
           name: user
           schema:
             type: string
-          description: Only show authorizations that belong to a user name.
+          description: Only show legacy authorizations that belong to a user name.
         - in: query
           name: orgID
           schema:
             type: string
-          description: Only show authorizations that belong to an organization ID.
+          description: Only show legacy authorizations that belong to an organization ID.
         - in: query
           name: org
           schema:
             type: string
-          description: Only show authorizations that belong to a organization name.
+          description: Only show legacy authorizations that belong to a organization name.
         - in: query
           name: token
           schema:
             type: string
-          description: Only show authorizations with a specified token (auth name).
+          description: Only show legacy authorizations with a specified token (auth name).
         - in: query
           name: authID
           schema:
             type: string
-          description: Only show authorizations with a specified auth ID.
+          description: Only show legacy authorizations with a specified auth ID.
       responses:
         '200':
-          description: A list of authorizations
+          description: A list of legacy authorizations
           content:
             application/json:
               schema:
@@ -5641,14 +5641,14 @@ paths:
           description: Unexpected error
           $ref: '#/components/responses/ServerError'
     post:
-      operationId: PostAuthorizations
+      operationId: PostLegacyAuthorizations
       tags:
         - Legacy Authorizations
-      summary: Create an authorization
+      summary: Create a legacy authorization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
       requestBody:
-        description: Authorization to create
+        description: Legacy authorization to create
         required: true
         content:
           application/json:
@@ -5656,7 +5656,7 @@ paths:
               $ref: '#/components/schemas/LegacyAuthorizationPostRequest'
       responses:
         '201':
-          description: Authorization created
+          description: Legacy authorization created
           content:
             application/json:
               schema:
@@ -5671,10 +5671,10 @@ paths:
     servers:
       - url: /private
     get:
-      operationId: GetAuthorizationsID
+      operationId: GetLegacyAuthorizationsID
       tags:
         - Legacy Authorizations
-      summary: Retrieve an authorization
+      summary: Retrieve a legacy authorization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -5682,10 +5682,10 @@ paths:
           schema:
             type: string
           required: true
-          description: The ID of the authorization to get.
+          description: The ID of the legacy authorization to get.
       responses:
         '200':
-          description: Authorization details
+          description: Legacy authorization details
           content:
             application/json:
               schema:
@@ -5694,12 +5694,12 @@ paths:
           description: Unexpected error
           $ref: '#/components/responses/ServerError'
     patch:
-      operationId: PatchAuthorizationsID
+      operationId: PatchLegacyAuthorizationsID
       tags:
         - Legacy Authorizations
-      summary: Update an authorization to be active or inactive
+      summary: Update a legacy authorization to be active or inactive
       requestBody:
-        description: Authorization to update
+        description: Legacy authorization to update
         required: true
         content:
           application/json:
@@ -5712,10 +5712,10 @@ paths:
           schema:
             type: string
           required: true
-          description: The ID of the authorization to update.
+          description: The ID of the legacy authorization to update.
       responses:
         '200':
-          description: The active or inactie authorization
+          description: The active or inactive legacy authorization
           content:
             application/json:
               schema:
@@ -5724,10 +5724,10 @@ paths:
           description: Unexpected error
           $ref: '#/components/responses/ServerError'
     delete:
-      operationId: DeleteAuthorizationsID
+      operationId: DeleteLegacyAuthorizationsID
       tags:
         - Legacy Authorizations
-      summary: Delete an authorization
+      summary: Delete a legacy authorization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -5735,10 +5735,10 @@ paths:
           schema:
             type: string
           required: true
-          description: The ID of the authorization to delete.
+          description: The ID of the legacy authorization to delete.
       responses:
         '204':
-          description: Authorization deleted
+          description: Legacy authorization deleted
         default:
           description: Unexpected error
           $ref: '#/components/responses/ServerError'
@@ -5746,10 +5746,10 @@ paths:
     servers:
       - url: /private
     post:
-      operationId: PostAuthorizationsIDPassword
+      operationId: PostLegacyAuthorizationsIDPassword
       tags:
         - Legacy Authorizations
-      summary: Set an authorization password
+      summary: Set a legacy authorization password
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -5757,7 +5757,7 @@ paths:
           schema:
             type: string
           required: true
-          description: The ID of the authorization to update.
+          description: The ID of the legacy authorization to update.
       requestBody:
         description: New password
         required: true
@@ -5767,7 +5767,7 @@ paths:
               $ref: '#/components/schemas/PasswordResetBody'
       responses:
         '204':
-          description: Authorization password set
+          description: Legacy authorization password set
         default:
           description: Unexpected error
           $ref: '#/components/responses/ServerError'

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -2480,35 +2480,38 @@ paths:
       - Labels
   /api/v2/legacy/authorizations:
     get:
-      operationId: GetAuthorizations
+      operationId: GetLegacyAuthorizations
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
-      - description: Only show authorizations that belong to a user ID.
+      - description: Only show legacy authorizations that belong to a user ID.
         in: query
         name: userID
         schema:
           type: string
-      - description: Only show authorizations that belong to a user name.
+      - description: Only show legacy authorizations that belong to a user name.
         in: query
         name: user
         schema:
           type: string
-      - description: Only show authorizations that belong to an organization ID.
+      - description: Only show legacy authorizations that belong to an organization
+          ID.
         in: query
         name: orgID
         schema:
           type: string
-      - description: Only show authorizations that belong to a organization name.
+      - description: Only show legacy authorizations that belong to a organization
+          name.
         in: query
         name: org
         schema:
           type: string
-      - description: Only show authorizations with a specified token (auth name).
+      - description: Only show legacy authorizations with a specified token (auth
+          name).
         in: query
         name: token
         schema:
           type: string
-      - description: Only show authorizations with a specified auth ID.
+      - description: Only show legacy authorizations with a specified auth ID.
         in: query
         name: authID
         schema:
@@ -2519,15 +2522,15 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Authorizations'
-          description: A list of authorizations
+          description: A list of legacy authorizations
         default:
           $ref: '#/components/responses/ServerError'
           description: Unexpected error
-      summary: List all authorizations
+      summary: List all legacy authorizations
       tags:
       - Legacy Authorizations
     post:
-      operationId: PostAuthorizations
+      operationId: PostLegacyAuthorizations
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
       requestBody:
@@ -2535,7 +2538,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/LegacyAuthorizationPostRequest'
-        description: Authorization to create
+        description: Legacy authorization to create
         required: true
       responses:
         "201":
@@ -2543,24 +2546,24 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Authorization'
-          description: Authorization created
+          description: Legacy authorization created
         "400":
           $ref: '#/components/responses/ServerError'
           description: Invalid request
         default:
           $ref: '#/components/responses/ServerError'
           description: Unexpected error
-      summary: Create an authorization
+      summary: Create a legacy authorization
       tags:
       - Legacy Authorizations
     servers:
     - url: /private
   /api/v2/legacy/authorizations/{authID}:
     delete:
-      operationId: DeleteAuthorizationsID
+      operationId: DeleteLegacyAuthorizationsID
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
-      - description: The ID of the authorization to delete.
+      - description: The ID of the legacy authorization to delete.
         in: path
         name: authID
         required: true
@@ -2568,18 +2571,18 @@ paths:
           type: string
       responses:
         "204":
-          description: Authorization deleted
+          description: Legacy authorization deleted
         default:
           $ref: '#/components/responses/ServerError'
           description: Unexpected error
-      summary: Delete an authorization
+      summary: Delete a legacy authorization
       tags:
       - Legacy Authorizations
     get:
-      operationId: GetAuthorizationsID
+      operationId: GetLegacyAuthorizationsID
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
-      - description: The ID of the authorization to get.
+      - description: The ID of the legacy authorization to get.
         in: path
         name: authID
         required: true
@@ -2591,18 +2594,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Authorization'
-          description: Authorization details
+          description: Legacy authorization details
         default:
           $ref: '#/components/responses/ServerError'
           description: Unexpected error
-      summary: Retrieve an authorization
+      summary: Retrieve a legacy authorization
       tags:
       - Legacy Authorizations
     patch:
-      operationId: PatchAuthorizationsID
+      operationId: PatchLegacyAuthorizationsID
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
-      - description: The ID of the authorization to update.
+      - description: The ID of the legacy authorization to update.
         in: path
         name: authID
         required: true
@@ -2613,7 +2616,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/AuthorizationUpdateRequest'
-        description: Authorization to update
+        description: Legacy authorization to update
         required: true
       responses:
         "200":
@@ -2621,21 +2624,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Authorization'
-          description: The active or inactie authorization
+          description: The active or inactive legacy authorization
         default:
           $ref: '#/components/responses/ServerError'
           description: Unexpected error
-      summary: Update an authorization to be active or inactive
+      summary: Update a legacy authorization to be active or inactive
       tags:
       - Legacy Authorizations
     servers:
     - url: /private
   /api/v2/legacy/authorizations/{authID}/password:
     post:
-      operationId: PostAuthorizationsIDPassword
+      operationId: PostLegacyAuthorizationsIDPassword
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
-      - description: The ID of the authorization to update.
+      - description: The ID of the legacy authorization to update.
         in: path
         name: authID
         required: true
@@ -2650,11 +2653,11 @@ paths:
         required: true
       responses:
         "204":
-          description: Authorization password set
+          description: Legacy authorization password set
         default:
           $ref: '#/components/responses/ServerError'
           description: Unexpected error
-      summary: Set an authorization password
+      summary: Set a legacy authorization password
       tags:
       - Legacy Authorizations
     servers:

--- a/src/oss/paths/legacy_authorizations.yml
+++ b/src/oss/paths/legacy_authorizations.yml
@@ -1,43 +1,43 @@
 get:
-  operationId: GetAuthorizations
+  operationId: GetLegacyAuthorizations
   tags:
     - Legacy Authorizations
-  summary: List all authorizations
+  summary: List all legacy authorizations
   parameters:
     - $ref: "../../common/parameters/TraceSpan.yml"
     - in: query
       name: userID
       schema:
         type: string
-      description: Only show authorizations that belong to a user ID.
+      description: Only show legacy authorizations that belong to a user ID.
     - in: query
       name: user
       schema:
         type: string
-      description: Only show authorizations that belong to a user name.
+      description: Only show legacy authorizations that belong to a user name.
     - in: query
       name: orgID
       schema:
         type: string
-      description: Only show authorizations that belong to an organization ID.
+      description: Only show legacy authorizations that belong to an organization ID.
     - in: query
       name: org
       schema:
         type: string
-      description: Only show authorizations that belong to a organization name.
+      description: Only show legacy authorizations that belong to a organization name.
     - in: query
       name: token
       schema:
         type: string
-      description: Only show authorizations with a specified token (auth name).
+      description: Only show legacy authorizations with a specified token (auth name).
     - in: query
       name: authID
       schema:
         type: string
-      description: Only show authorizations with a specified auth ID.
+      description: Only show legacy authorizations with a specified auth ID.
   responses:
     "200":
-      description: A list of authorizations
+      description: A list of legacy authorizations
       content:
         application/json:
           schema:
@@ -46,14 +46,14 @@ get:
       description: Unexpected error
       $ref: '../../common/responses/ServerError.yml'
 post:
-  operationId: PostAuthorizations
+  operationId: PostLegacyAuthorizations
   tags:
     - Legacy Authorizations
-  summary: Create an authorization
+  summary: Create a legacy authorization
   parameters:
     - $ref: "../../common/parameters/TraceSpan.yml"
   requestBody:
-    description: Authorization to create
+    description: Legacy authorization to create
     required: true
     content:
       application/json:
@@ -61,7 +61,7 @@ post:
           $ref: "../../oss/schemas/LegacyAuthorizationPostRequest.yml"
   responses:
     "201":
-      description: Authorization created
+      description: Legacy authorization created
       content:
         application/json:
           schema:

--- a/src/oss/paths/legacy_authorizations_authID.yml
+++ b/src/oss/paths/legacy_authorizations_authID.yml
@@ -1,8 +1,8 @@
 get:
-  operationId: GetAuthorizationsID
+  operationId: GetLegacyAuthorizationsID
   tags:
     - Legacy Authorizations
-  summary: Retrieve an authorization
+  summary: Retrieve a legacy authorization
   parameters:
     - $ref: "../../common/parameters/TraceSpan.yml"
     - in: path
@@ -10,10 +10,10 @@ get:
       schema:
         type: string
       required: true
-      description: The ID of the authorization to get.
+      description: The ID of the legacy authorization to get.
   responses:
     "200":
-      description: Authorization details
+      description: Legacy authorization details
       content:
         application/json:
           schema:
@@ -22,12 +22,12 @@ get:
       description: Unexpected error
       $ref: '../../common/responses/ServerError.yml'
 patch:
-  operationId: PatchAuthorizationsID
+  operationId: PatchLegacyAuthorizationsID
   tags:
     - Legacy Authorizations
-  summary: Update an authorization to be active or inactive
+  summary: Update a legacy authorization to be active or inactive
   requestBody:
-    description: Authorization to update
+    description: Legacy authorization to update
     required: true
     content:
       application/json:
@@ -40,10 +40,10 @@ patch:
       schema:
         type: string
       required: true
-      description: The ID of the authorization to update.
+      description: The ID of the legacy authorization to update.
   responses:
     "200":
-      description: The active or inactie authorization
+      description: The active or inactive legacy authorization
       content:
         application/json:
           schema:
@@ -52,10 +52,10 @@ patch:
       description: Unexpected error
       $ref: '../../common/responses/ServerError.yml'
 delete:
-  operationId: DeleteAuthorizationsID
+  operationId: DeleteLegacyAuthorizationsID
   tags:
     - Legacy Authorizations
-  summary: Delete an authorization
+  summary: Delete a legacy authorization
   parameters:
     - $ref: "../../common/parameters/TraceSpan.yml"
     - in: path
@@ -63,10 +63,10 @@ delete:
       schema:
         type: string
       required: true
-      description: The ID of the authorization to delete.
+      description: The ID of the legacy authorization to delete.
   responses:
     "204":
-      description: Authorization deleted
+      description: Legacy authorization deleted
     default:
       description: Unexpected error
       $ref: '../../common/responses/ServerError.yml'

--- a/src/oss/paths/legacy_authorizations_authID_password.yml
+++ b/src/oss/paths/legacy_authorizations_authID_password.yml
@@ -1,8 +1,8 @@
 post:
-  operationId: PostAuthorizationsIDPassword
+  operationId: PostLegacyAuthorizationsIDPassword
   tags:
     - Legacy Authorizations
-  summary: Set an authorization password
+  summary: Set a legacy authorization password
   parameters:
     - $ref: "../../common/parameters/TraceSpan.yml"
     - in: path
@@ -10,7 +10,7 @@ post:
       schema:
         type: string
       required: true
-      description: The ID of the authorization to update.
+      description: The ID of the legacy authorization to update.
   requestBody:
     description: New password
     required: true
@@ -20,7 +20,7 @@ post:
           $ref: "../../common/schemas/PasswordResetBody.yml"
   responses:
     "204":
-      description: Authorization password set
+      description: Legacy authorization password set
     default:
       description: Unexpected error
       $ref: '../../common/responses/ServerError.yml'


### PR DESCRIPTION
Fixes an issue when including both legacy and non-legacy auth paths where it would give repeated operationId errors.