### PR TITLE
feat: add response code to managed functions invoke by id

### DIFF
--- a/contracts/managed-functions.yml
+++ b/contracts/managed-functions.yml
@@ -181,12 +181,15 @@ paths:
           style: form
           explode: true
       responses:
-        default:
+        '200':
           description: Response defined by function
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/FunctionHTTPResponseData'
+        default:
+          description: Unexpected error
+          $ref: '#/components/responses/ServerError'
     post:
       operationId: PostFunctionsIDInvoke
       tags:
@@ -204,12 +207,15 @@ paths:
             schema:
               $ref: '#/components/schemas/FunctionInvocationParams'
       responses:
-        default:
+        '200':
           description: Response defined by function
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/FunctionHTTPResponseData'
+        default:
+          description: Unexpected error
+          $ref: '#/components/responses/ServerError'
   '/poc-functions/{functionID}/runs':
     get:
       operationId: GetFunctionsIDRuns

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -3922,12 +3922,15 @@ paths:
           type: object
         style: form
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/FunctionHTTPResponseData'
           description: Response defined by function
+        default:
+          $ref: '#/components/responses/ServerError'
+          description: Unexpected error
       summary: Manually invoke a function with params in query
       tags:
       - Functions
@@ -3945,12 +3948,15 @@ paths:
             schema:
               $ref: '#/components/schemas/FunctionInvocationParams'
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/FunctionHTTPResponseData'
           description: Response defined by function
+        default:
+          $ref: '#/components/responses/ServerError'
+          description: Unexpected error
       summary: Manually invoke a function with params in request body
       tags:
       - Functions

--- a/contracts/svc/managed-functions.yml
+++ b/contracts/svc/managed-functions.yml
@@ -181,12 +181,15 @@ paths:
           style: form
           explode: true
       responses:
-        default:
+        '200':
           description: Response defined by function
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/FunctionHTTPResponseData'
+        default:
+          description: Unexpected error
+          $ref: '#/components/responses/ServerError'
     post:
       operationId: PostFunctionsIDInvoke
       tags:
@@ -204,12 +207,15 @@ paths:
             schema:
               $ref: '#/components/schemas/FunctionInvocationParams'
       responses:
-        default:
+        '200':
           description: Response defined by function
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/FunctionHTTPResponseData'
+        default:
+          description: Unexpected error
+          $ref: '#/components/responses/ServerError'
   '/functions/{functionID}/runs':
     get:
       operationId: GetFunctionsIDRuns

--- a/src/svc/managed-functions/paths/functions_functionID_invoke.yml
+++ b/src/svc/managed-functions/paths/functions_functionID_invoke.yml
@@ -17,12 +17,15 @@ get:
       style: form
       explode: true
   responses:
-    default:
+    '200':
       description: Response defined by function
       content:
         application/json:
           schema:
             $ref: '../schemas/FunctionHTTPResponseData.yml'
+    default:
+      description: Unexpected error
+      $ref: '../../../common/responses/ServerError.yml'
 post:
   operationId: PostFunctionsIDInvoke
   tags:
@@ -40,9 +43,12 @@ post:
         schema:
           $ref: '../schemas/FunctionInvocationParams.yml'
   responses:
-    default:
+    '200':
       description: Response defined by function
       content:
         application/json:
           schema:
             $ref: '../schemas/FunctionHTTPResponseData.yml'
+    default:
+      description: Unexpected error
+      $ref: '../../../common/responses/ServerError.yml'


### PR DESCRIPTION
Related to https://github.com/influxdata/influx-cli/issues/153

Adds a `200` response code designation to the `functions/{functionID}/invoke` path, with a default to being a server error.

This is being done to allow the CLI codegen to work properly for this path.