### PR TITLE
feat(unity): Add route for `DELETE /account`

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -29,6 +29,27 @@ paths:
         default:
           description: Unexpected error
           $ref: '#/components/responses/ServerError'
+  /account:
+    delete:
+      operationId: DeleteAccount
+      summary: Self-delete account
+      requestBody:
+        content:
+          application/json; charset=utf-8:
+            schema:
+              type: object
+      responses:
+        '204':
+          description: Account deleted
+        '401':
+          description: Unauthorized/Account doesn't exist
+          $ref: '#/components/responses/ServerError'
+        '405':
+          description: Account is not deletable
+          $ref: '#/components/responses/ServerError'
+        default:
+          description: Unexpected error
+          $ref: '#/components/responses/ServerError'
   /billing:
     get:
       operationId: GetBilling

--- a/src/unity.yml
+++ b/src/unity.yml
@@ -7,6 +7,8 @@ servers:
 paths:
   '/me':
     $ref: './unity/paths/me.yml'
+  '/account':
+    $ref: './unity/paths/account.yml'
   '/billing':
     $ref: './unity/paths/billing.yml'
   '/marketplace':

--- a/src/unity/paths/account.yml
+++ b/src/unity/paths/account.yml
@@ -1,0 +1,20 @@
+delete:
+      operationId: DeleteAccount
+      summary: Self-delete account
+      requestBody:
+        content:
+          application/json; charset=utf-8:
+            schema:
+              type: object
+      responses:
+        '204':
+          description: Account deleted
+        '401':
+          description: Unauthorized/Account doesn't exist
+          $ref: '../../common/responses/ServerError.yml'
+        '405':
+          description: Account is not deletable
+          $ref: '../../common/responses/ServerError.yml'
+        default:
+          description: Unexpected error
+          $ref: '../../common/responses/ServerError.yml'


### PR DESCRIPTION
Part of [Quartz #4360](https://github.com/influxdata/quartz/pull/4859)

Adds definition for `DELETE /account` to Unity swagger. This API will allow a user to self-delete an account, as long as the account is `free` and there are no other users.