### PR TITLE
fix: add legacy backup/restore routes to OSS contract

### DIFF
--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -1503,6 +1503,26 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/responses/ServerError/content/application~1json/schema'
+  /backup/kv:
+    get:
+      operationId: GetBackupKV
+      tags:
+        - Backup
+      summary: 'Download snapshot of metadata stored in the server''s embedded KV store. Should not be used in versions > 2.1.x, as it doesn''t include metadata stored in embedded SQL.'
+      deprecated: true
+      parameters:
+        - $ref: '#/paths/~1ready/get/parameters/0'
+      responses:
+        '200':
+          description: Snapshot of KV metadata
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          description: Unexpected error
+          $ref: '#/components/responses/ServerError'
   /backup/metadata:
     get:
       operationId: GetBackupMetadata
@@ -1674,6 +1694,40 @@ paths:
       responses:
         '204':
           description: SQL store successfully overwritten.
+        default:
+          description: Unexpected error
+          $ref: '#/components/responses/ServerError'
+  '/restore/bucket/{bucketID}':
+    post:
+      operationId: PostRestoreBucketID
+      tags:
+        - Restore
+      summary: Overwrite storage metadata for a bucket with shard info from a backup.
+      deprecated: true
+      parameters:
+        - $ref: '#/paths/~1ready/get/parameters/0'
+        - in: path
+          name: bucketID
+          schema:
+            type: string
+          required: true
+          description: The bucket ID.
+      requestBody:
+        description: Database info serialized as protobuf.
+        required: true
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: byte
+      responses:
+        '200':
+          description: ID mappings for shards in bucket.
+          content:
+            application/json:
+              schema:
+                type: string
+                format: byte
         default:
           description: Unexpected error
           $ref: '#/components/responses/ServerError'

--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -1712,11 +1712,18 @@ paths:
             type: string
           required: true
           description: The bucket ID.
+        - in: header
+          name: Content-Type
+          schema:
+            type: string
+            default: application/octet-stream
+            enum:
+              - application/octet-stream
       requestBody:
         description: Database info serialized as protobuf.
         required: true
         content:
-          application/octet-stream:
+          text/plain:
             schema:
               type: string
               format: byte

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -10794,6 +10794,38 @@
         }
       }
     },
+    "/backup/kv": {
+      "get": {
+        "operationId": "GetBackupKV",
+        "tags": [
+          "Backup"
+        ],
+        "summary": "Download snapshot of metadata stored in the server's embedded KV store. Should not be used in versions > 2.1.x, as it doesn't include metadata stored in embedded SQL.",
+        "deprecated": true,
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TraceSpan"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Snapshot of KV metadata",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
     "/backup/metadata": {
       "get": {
         "operationId": "GetBackupMetadata",
@@ -11052,6 +11084,59 @@
         "responses": {
           "204": {
             "description": "SQL store successfully overwritten."
+          },
+          "default": {
+            "description": "Unexpected error",
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/restore/bucket/{bucketID}": {
+      "post": {
+        "operationId": "PostRestoreBucketID",
+        "tags": [
+          "Restore"
+        ],
+        "summary": "Overwrite storage metadata for a bucket with shard info from a backup.",
+        "deprecated": true,
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TraceSpan"
+          },
+          {
+            "in": "path",
+            "name": "bucketID",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "The bucket ID."
+          }
+        ],
+        "requestBody": {
+          "description": "Database info serialized as protobuf.",
+          "required": true,
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "byte"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "ID mappings for shards in bucket.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              }
+            }
           },
           "default": {
             "description": "Unexpected error",

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -11112,13 +11112,24 @@
             },
             "required": true,
             "description": "The bucket ID."
+          },
+          {
+            "in": "header",
+            "name": "Content-Type",
+            "schema": {
+              "type": "string",
+              "default": "application/octet-stream",
+              "enum": [
+                "application/octet-stream"
+              ]
+            }
           }
         ],
         "requestBody": {
           "description": "Database info serialized as protobuf.",
           "required": true,
           "content": {
-            "application/octet-stream": {
+            "text/plain": {
               "schema": {
                 "type": "string",
                 "format": "byte"

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -6576,6 +6576,26 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /backup/kv:
+    get:
+      operationId: GetBackupKV
+      tags:
+        - Backup
+      summary: 'Download snapshot of metadata stored in the server''s embedded KV store. Should not be used in versions > 2.1.x, as it doesn''t include metadata stored in embedded SQL.'
+      deprecated: true
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+      responses:
+        '200':
+          description: Snapshot of KV metadata
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          description: Unexpected error
+          $ref: '#/components/responses/ServerError'
   /backup/metadata:
     get:
       operationId: GetBackupMetadata
@@ -6747,6 +6767,40 @@ paths:
       responses:
         '204':
           description: SQL store successfully overwritten.
+        default:
+          description: Unexpected error
+          $ref: '#/components/responses/ServerError'
+  '/restore/bucket/{bucketID}':
+    post:
+      operationId: PostRestoreBucketID
+      tags:
+        - Restore
+      summary: Overwrite storage metadata for a bucket with shard info from a backup.
+      deprecated: true
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: path
+          name: bucketID
+          schema:
+            type: string
+          required: true
+          description: The bucket ID.
+      requestBody:
+        description: Database info serialized as protobuf.
+        required: true
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: byte
+      responses:
+        '200':
+          description: ID mappings for shards in bucket.
+          content:
+            application/json:
+              schema:
+                type: string
+                format: byte
         default:
           description: Unexpected error
           $ref: '#/components/responses/ServerError'

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -6785,11 +6785,18 @@ paths:
             type: string
           required: true
           description: The bucket ID.
+        - in: header
+          name: Content-Type
+          schema:
+            type: string
+            default: application/octet-stream
+            enum:
+              - application/octet-stream
       requestBody:
         description: Database info serialized as protobuf.
         required: true
         content:
-          application/octet-stream:
+          text/plain:
             schema:
               type: string
               format: byte

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -4077,9 +4077,16 @@ paths:
         required: true
         schema:
           type: string
+      - in: header
+        name: Content-Type
+        schema:
+          default: application/octet-stream
+          enum:
+          - application/octet-stream
+          type: string
       requestBody:
         content:
-          application/octet-stream:
+          text/plain:
             schema:
               format: byte
               type: string

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -157,6 +157,28 @@ paths:
       summary: Update an authorization to be active or inactive
       tags:
       - Authorizations
+  /api/v2/backup/kv:
+    get:
+      deprecated: true
+      operationId: GetBackupKV
+      parameters:
+      - $ref: '#/components/parameters/TraceSpan'
+      responses:
+        "200":
+          content:
+            application/octet-stream:
+              schema:
+                format: binary
+                type: string
+          description: Snapshot of KV metadata
+        default:
+          $ref: '#/components/responses/ServerError'
+          description: Unexpected error
+      summary: Download snapshot of metadata stored in the server's embedded KV store.
+        Should not be used in versions > 2.1.x, as it doesn't include metadata stored
+        in embedded SQL.
+      tags:
+      - Backup
   /api/v2/backup/metadata:
     get:
       operationId: GetBackupMetadata
@@ -4041,6 +4063,40 @@ paths:
           $ref: '#/components/responses/ServerError'
           description: Unexpected error
       summary: Create a new bucket pre-seeded with shard info from a backup.
+      tags:
+      - Restore
+  /api/v2/restore/bucket/{bucketID}:
+    post:
+      deprecated: true
+      operationId: PostRestoreBucketID
+      parameters:
+      - $ref: '#/components/parameters/TraceSpan'
+      - description: The bucket ID.
+        in: path
+        name: bucketID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/octet-stream:
+            schema:
+              format: byte
+              type: string
+        description: Database info serialized as protobuf.
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                format: byte
+                type: string
+          description: ID mappings for shards in bucket.
+        default:
+          $ref: '#/components/responses/ServerError'
+          description: Unexpected error
+      summary: Overwrite storage metadata for a bucket with shard info from a backup.
       tags:
       - Restore
   /api/v2/restore/kv:

--- a/src/oss.yml
+++ b/src/oss.yml
@@ -64,6 +64,8 @@ paths:
     $ref: "./common/paths/scrapers_scraperTargetID_owners.yml"
   "/scrapers/{scraperTargetID}/owners/{userID}":
     $ref: "./common/paths/scrapers_scraperTargetID_owners_userID.yml"
+  "/backup/kv":
+    $ref: "./oss/paths/backup_kv.yml"
   "/backup/metadata":
     $ref: "./oss/paths/backup_metadata.yml"
   "/backup/shards/{shardID}":
@@ -72,6 +74,8 @@ paths:
     $ref: "./oss/paths/restore_kv.yml"
   "/restore/sql":
     $ref: "./oss/paths/restore_sql.yml"
+  "/restore/bucket/{bucketID}":
+    $ref: "./oss/paths/restore_bucket_bucketID.yml"
   "/restore/bucket-metadata":
     $ref: "./oss/paths/restore_bucket-metadata.yml"
   "/restore/shards/{shardID}":

--- a/src/oss/paths/backup_kv.yml
+++ b/src/oss/paths/backup_kv.yml
@@ -1,0 +1,21 @@
+get:
+  operationId: GetBackupKV
+  tags:
+    - Backup
+  summary: >-
+    Download snapshot of metadata stored in the server's embedded KV store. Should not be
+    used in versions > 2.1.x, as it doesn't include metadata stored in embedded SQL.
+  deprecated: true
+  parameters:
+    - $ref: "../../common/parameters/TraceSpan.yml"
+  responses:
+    "200":
+      description: Snapshot of KV metadata
+      content:
+        application/octet-stream:
+          schema:
+            type: string
+            format: binary
+    default:
+      description: Unexpected error
+      $ref: "../../common/responses/ServerError.yml"

--- a/src/oss/paths/restore_bucket_bucketID.yml
+++ b/src/oss/paths/restore_bucket_bucketID.yml
@@ -12,11 +12,19 @@ post:
         type: string
       required: true
       description: The bucket ID.
+    - in: header
+      name: Content-Type
+      schema:
+        type: string
+        default: application/octet-stream
+        enum:
+          - application/octet-stream
   requestBody:
     description: Database info serialized as protobuf.
     required: true
     content:
-      application/octet-stream:
+      # NOTE: Use text-plain here to work around https://github.com/influxdata/oats/issues/16.
+      text/plain:
         schema:
           type: string
           format: byte

--- a/src/oss/paths/restore_bucket_bucketID.yml
+++ b/src/oss/paths/restore_bucket_bucketID.yml
@@ -1,0 +1,35 @@
+post:
+  operationId: PostRestoreBucketID
+  tags:
+    - Restore
+  summary: Overwrite storage metadata for a bucket with shard info from a backup.
+  deprecated: true
+  parameters:
+    - $ref: "../../common/parameters/TraceSpan.yml"
+    - in: path
+      name: bucketID
+      schema:
+        type: string
+      required: true
+      description: The bucket ID.
+  requestBody:
+    description: Database info serialized as protobuf.
+    required: true
+    content:
+      application/octet-stream:
+        schema:
+          type: string
+          format: byte
+  responses:
+    "200":
+      description: ID mappings for shards in bucket.
+      content:
+        application/json:
+          schema:
+            # Actually an object mapping uint64 -> uint64,
+            # can't find a good way to represent that in OpenAPI.
+            type: string
+            format: byte
+    default:
+      description: Unexpected error
+      $ref: "../../common/responses/ServerError.yml"


### PR DESCRIPTION
These routes will be deprecated as of OSS v2.1.0, but we include them here for completeness & to support codegen on the CLI side.