### PR TITLE
chore: add route to delete individual secret

### DIFF
--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -812,6 +812,68 @@ paths:
         default:
           description: unexpected error
           $ref: '#/components/responses/ServerError'
+  '/orgs/{orgID}/secrets/delete':
+    post:
+      deprecated: true
+      operationId: PostOrgsIDSecrets
+      tags:
+        - Secrets
+      summary: Delete secrets from an organization
+      parameters:
+        - $ref: '#/paths/~1users/get/parameters/0'
+        - in: path
+          name: orgID
+          schema:
+            type: string
+          required: true
+          description: The organization ID.
+      requestBody:
+        description: Secret key to delete
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                secrets:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        '204':
+          description: Keys successfully patched
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/responses/ServerError/content/application~1json/schema'
+  '/orgs/{orgID}/secrets/{secretID}':
+    delete:
+      operationId: DeleteOrgsIDSecretsID
+      tags:
+        - Secrets
+      summary: Delete a secret from an organization
+      parameters:
+        - $ref: '#/paths/~1users/get/parameters/0'
+        - in: path
+          name: orgID
+          schema:
+            type: string
+          required: true
+          description: The organization ID.
+        - in: path
+          name: secretID
+          schema:
+            type: string
+          required: true
+          description: The secret ID.
+      responses:
+        '204':
+          description: Keys successfully deleted
+        default:
+          description: Unexpected error
+          $ref: '#/components/responses/ServerError'
 components:
   parameters: null
   schemas:

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -97,6 +97,59 @@
         }
       }
     },
+    "/ping": {
+      "servers": [
+        {
+          "url": ""
+        }
+      ],
+      "get": {
+        "operationId": "GetPing",
+        "summary": "Checks the status of InfluxDB instance and version of InfluxDB.",
+        "responses": {
+          "204": {
+            "description": "OK",
+            "headers": {
+              "X-Influxdb-Build": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "The type of InfluxDB build."
+              },
+              "X-Influxdb-Version": {
+                "schema": {
+                  "type": "integer"
+                },
+                "description": "The version of InfluxDB."
+              }
+            }
+          }
+        }
+      },
+      "head": {
+        "operationId": "HeadPing",
+        "summary": "Checks the status of InfluxDB instance and version of InfluxDB.",
+        "responses": {
+          "204": {
+            "description": "OK",
+            "headers": {
+              "X-Influxdb-Build": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "The type of InfluxDB build."
+              },
+              "X-Influxdb-Version": {
+                "schema": {
+                  "type": "integer"
+                },
+                "description": "The version of InfluxDB."
+              }
+            }
+          }
+        }
+      }
+    },
     "/": {
       "get": {
         "operationId": "GetRoutes",
@@ -4923,55 +4976,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/Secrets"
-              }
-            }
-          }
-        },
-        "responses": {
-          "204": {
-            "description": "Keys successfully patched"
-          },
-          "default": {
-            "description": "Unexpected error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/orgs/{orgID}/secrets/delete": {
-      "post": {
-        "operationId": "PostOrgsIDSecrets",
-        "tags": [
-          "Secrets"
-        ],
-        "summary": "Delete secrets from an organization",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/TraceSpan"
-          },
-          {
-            "in": "path",
-            "name": "orgID",
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "description": "The organization ID."
-          }
-        ],
-        "requestBody": {
-          "description": "Secret key to delete",
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SecretKeys"
               }
             }
           }
@@ -9830,6 +9834,97 @@
           },
           "default": {
             "description": "unexpected error",
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/orgs/{orgID}/secrets/delete": {
+      "post": {
+        "deprecated": true,
+        "operationId": "PostOrgsIDSecrets",
+        "tags": [
+          "Secrets"
+        ],
+        "summary": "Delete secrets from an organization",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TraceSpan"
+          },
+          {
+            "in": "path",
+            "name": "orgID",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "The organization ID."
+          }
+        ],
+        "requestBody": {
+          "description": "Secret key to delete",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SecretKeys"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Keys successfully patched"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/orgs/{orgID}/secrets/{secretID}": {
+      "delete": {
+        "operationId": "DeleteOrgsIDSecretsID",
+        "tags": [
+          "Secrets"
+        ],
+        "summary": "Delete a secret from an organization",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TraceSpan"
+          },
+          {
+            "in": "path",
+            "name": "orgID",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "The organization ID."
+          },
+          {
+            "in": "path",
+            "name": "secretID",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "The secret ID."
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Keys successfully deleted"
+          },
+          "default": {
+            "description": "Unexpected error",
             "$ref": "#/components/responses/ServerError"
           }
         }

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -3043,36 +3043,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  '/orgs/{orgID}/secrets/delete':
-    post:
-      operationId: PostOrgsIDSecrets
-      tags:
-        - Secrets
-      summary: Delete secrets from an organization
-      parameters:
-        - $ref: '#/components/parameters/TraceSpan'
-        - in: path
-          name: orgID
-          schema:
-            type: string
-          required: true
-          description: The organization ID.
-      requestBody:
-        description: Secret key to delete
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SecretKeys'
-      responses:
-        '204':
-          description: Keys successfully patched
-        default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
   '/orgs/{orgID}/members':
     get:
       operationId: GetOrgsIDMembers
@@ -6052,6 +6022,63 @@ paths:
                   #group,false,false,true,true,false,false,true,true,true,true #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string #default,_result,,,,,,,,, ,result,table,_start,_stop,_time,_value,_field,_measurement,bucket_id,org_id ,,0,2021-05-10T14:25:10.865702397Z,2021-05-10T15:25:10.865702397Z,2021-05-10T15:00:00Z,5434066,gauge,storage_usage_bucket_bytes,2f6ba0cf9a2fdcbb,cec6fc1d2176dc11 ,,1,2021-05-10T14:25:10.865702397Z,2021-05-10T15:25:10.865702397Z,2021-05-10T15:00:00Z,9924053.966666665,gauge,storage_usage_bucket_bytes,8af67bcaf69d9daf,cec6fc1d2176dc11
         default:
           description: unexpected error
+          $ref: '#/components/responses/ServerError'
+  '/orgs/{orgID}/secrets/delete':
+    post:
+      deprecated: true
+      operationId: PostOrgsIDSecrets
+      tags:
+        - Secrets
+      summary: Delete secrets from an organization
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: path
+          name: orgID
+          schema:
+            type: string
+          required: true
+          description: The organization ID.
+      requestBody:
+        description: Secret key to delete
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SecretKeys'
+      responses:
+        '204':
+          description: Keys successfully patched
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  '/orgs/{orgID}/secrets/{secretID}':
+    delete:
+      operationId: DeleteOrgsIDSecretsID
+      tags:
+        - Secrets
+      summary: Delete a secret from an organization
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: path
+          name: orgID
+          schema:
+            type: string
+          required: true
+          description: The organization ID.
+        - in: path
+          name: secretID
+          schema:
+            type: string
+          required: true
+          description: The secret ID.
+      responses:
+        '204':
+          description: Keys successfully deleted
+        default:
+          description: Unexpected error
           $ref: '#/components/responses/ServerError'
 components:
   parameters:

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -3043,36 +3043,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  '/orgs/{orgID}/secrets/delete':
-    post:
-      operationId: PostOrgsIDSecrets
-      tags:
-        - Secrets
-      summary: Delete secrets from an organization
-      parameters:
-        - $ref: '#/components/parameters/TraceSpan'
-        - in: path
-          name: orgID
-          schema:
-            type: string
-          required: true
-          description: The organization ID.
-      requestBody:
-        description: Secret key to delete
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SecretKeys'
-      responses:
-        '204':
-          description: Keys successfully patched
-        default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
   '/orgs/{orgID}/members':
     get:
       operationId: GetOrgsIDMembers

--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -1808,6 +1808,41 @@ paths:
         default:
           description: Unexpected error
           $ref: '#/components/responses/ServerError'
+  '/orgs/{orgID}/secrets/delete':
+    post:
+      operationId: PostOrgsIDSecrets
+      tags:
+        - Secrets
+      summary: Delete secrets from an organization
+      parameters:
+        - $ref: '#/paths/~1ready/get/parameters/0'
+        - in: path
+          name: orgID
+          schema:
+            type: string
+          required: true
+          description: The organization ID.
+      requestBody:
+        description: Secret key to delete
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                secrets:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        '204':
+          description: Keys successfully patched
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/responses/ServerError/content/application~1json/schema'
 components:
   parameters: null
   schemas:

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -97,6 +97,59 @@
         }
       }
     },
+    "/ping": {
+      "servers": [
+        {
+          "url": ""
+        }
+      ],
+      "get": {
+        "operationId": "GetPing",
+        "summary": "Checks the status of InfluxDB instance and version of InfluxDB.",
+        "responses": {
+          "204": {
+            "description": "OK",
+            "headers": {
+              "X-Influxdb-Build": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "The type of InfluxDB build."
+              },
+              "X-Influxdb-Version": {
+                "schema": {
+                  "type": "integer"
+                },
+                "description": "The version of InfluxDB."
+              }
+            }
+          }
+        }
+      },
+      "head": {
+        "operationId": "HeadPing",
+        "summary": "Checks the status of InfluxDB instance and version of InfluxDB.",
+        "responses": {
+          "204": {
+            "description": "OK",
+            "headers": {
+              "X-Influxdb-Build": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "The type of InfluxDB build."
+              },
+              "X-Influxdb-Version": {
+                "schema": {
+                  "type": "integer"
+                },
+                "description": "The version of InfluxDB."
+              }
+            }
+          }
+        }
+      }
+    },
     "/": {
       "get": {
         "operationId": "GetRoutes",
@@ -4923,55 +4976,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/Secrets"
-              }
-            }
-          }
-        },
-        "responses": {
-          "204": {
-            "description": "Keys successfully patched"
-          },
-          "default": {
-            "description": "Unexpected error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/orgs/{orgID}/secrets/delete": {
-      "post": {
-        "operationId": "PostOrgsIDSecrets",
-        "tags": [
-          "Secrets"
-        ],
-        "summary": "Delete secrets from an organization",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/TraceSpan"
-          },
-          {
-            "in": "path",
-            "name": "orgID",
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "description": "The organization ID."
-          }
-        ],
-        "requestBody": {
-          "description": "Secret key to delete",
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SecretKeys"
               }
             }
           }
@@ -11262,6 +11266,55 @@
           "default": {
             "description": "Unexpected error",
             "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/orgs/{orgID}/secrets/delete": {
+      "post": {
+        "operationId": "PostOrgsIDSecrets",
+        "tags": [
+          "Secrets"
+        ],
+        "summary": "Delete secrets from an organization",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TraceSpan"
+          },
+          {
+            "in": "path",
+            "name": "orgID",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "The organization ID."
+          }
+        ],
+        "requestBody": {
+          "description": "Secret key to delete",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SecretKeys"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Keys successfully patched"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       }

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -3043,36 +3043,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  '/orgs/{orgID}/secrets/delete':
-    post:
-      operationId: PostOrgsIDSecrets
-      tags:
-        - Secrets
-      summary: Delete secrets from an organization
-      parameters:
-        - $ref: '#/components/parameters/TraceSpan'
-        - in: path
-          name: orgID
-          schema:
-            type: string
-          required: true
-          description: The organization ID.
-      requestBody:
-        description: Secret key to delete
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SecretKeys'
-      responses:
-        '204':
-          description: Keys successfully patched
-        default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
   '/orgs/{orgID}/members':
     get:
       operationId: GetOrgsIDMembers
@@ -6914,6 +6884,36 @@ paths:
         default:
           description: Unexpected error
           $ref: '#/components/responses/ServerError'
+  '/orgs/{orgID}/secrets/delete':
+    post:
+      operationId: PostOrgsIDSecrets
+      tags:
+        - Secrets
+      summary: Delete secrets from an organization
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: path
+          name: orgID
+          schema:
+            type: string
+          required: true
+          description: The organization ID.
+      requestBody:
+        description: Secret key to delete
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SecretKeys'
+      responses:
+        '204':
+          description: Keys successfully patched
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 components:
   parameters:
     TraceSpan:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -3686,8 +3686,35 @@ paths:
       summary: Update secrets in an organization
       tags:
       - Secrets
+  /api/v2/orgs/{orgID}/secrets/{secretID}:
+    delete:
+      operationId: DeleteOrgsIDSecretsID
+      parameters:
+      - $ref: '#/components/parameters/TraceSpan'
+      - description: The organization ID.
+        in: path
+        name: orgID
+        required: true
+        schema:
+          type: string
+      - description: The secret ID.
+        in: path
+        name: secretID
+        required: true
+        schema:
+          type: string
+      responses:
+        "204":
+          description: Keys successfully deleted
+        default:
+          $ref: '#/components/responses/ServerError'
+          description: Unexpected error
+      summary: Delete a secret from an organization
+      tags:
+      - Secrets
   /api/v2/orgs/{orgID}/secrets/delete:
     post:
+      deprecated: true
       operationId: PostOrgsIDSecrets
       parameters:
       - $ref: '#/components/parameters/TraceSpan'

--- a/scripts/reference.sh
+++ b/scripts/reference.sh
@@ -13,6 +13,7 @@ swagrag \
   -file ${CONTRACTS}/mapsd.yml \
   -file ${CONTRACTS}/managed-functions.yml \
   -api-title "Complete InfluxDB Cloud API" \
+  | sed -e 's|^  /api/v2/ping|  /ping|' \
   > ${TCONTRACTS}/ref/cloud.yml
 
 echo "Aggregating oss swaggers"
@@ -20,10 +21,7 @@ swagrag \
   -file ${CONTRACTS}/oss.yml \
   -file ${CONTRACTS}/mapsd.yml \
   -api-title "Complete InfluxDB OSS API" \
+  | sed -e 's|^  /api/v2/ping|  /ping|' \
   > ${TCONTRACTS}/ref/oss.yml
-
-echo "Fixing /ping path"
-sed -i '' -e "s|^  /api/v2/ping|  /ping|" ${TCONTRACTS}/ref/cloud.yml
-sed -i '' -e "s|^  /api/v2/ping|  /ping|" ${TCONTRACTS}/ref/oss.yml
 
 diff -r ${CONTRACTS}/ref ${TCONTRACTS}/ref/

--- a/src/cloud.yml
+++ b/src/cloud.yml
@@ -30,6 +30,10 @@ paths:
     $ref: "./cloud/paths/orgs_orgID_limits_get.yml"
   /orgs/{orgID}/usage:
     $ref: "./cloud/paths/orgs_orgID_usage.yml"
+  /orgs/{orgID}/secrets/delete:
+    $ref: "./cloud/paths/orgs_orgID_secrets_delete.yml"
+  /orgs/{orgID}/secrets/{secretID}:
+    $ref: "./cloud/paths/orgs_orgID_secrets_secretID.yml"
 components:
   parameters:
 #REF_COMMON_PARAMETERS

--- a/src/cloud/paths/orgs_orgID_secrets_delete.yml
+++ b/src/cloud/paths/orgs_orgID_secrets_delete.yml
@@ -1,0 +1,30 @@
+post:
+  deprecated: true
+  operationId: PostOrgsIDSecrets
+  tags:
+    - Secrets
+  summary: Delete secrets from an organization
+  parameters:
+    - $ref: "../../common/parameters/TraceSpan.yml"
+    - in: path
+      name: orgID
+      schema:
+        type: string
+      required: true
+      description: The organization ID.
+  requestBody:
+    description: Secret key to delete
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: "../../common/schemas/SecretKeys.yml"
+  responses:
+    "204":
+      description: Keys successfully patched
+    default:
+      description: Unexpected error
+      content:
+        application/json:
+          schema:
+            $ref: "../../common/schemas/Error.yml"

--- a/src/cloud/paths/orgs_orgID_secrets_secretID.yml
+++ b/src/cloud/paths/orgs_orgID_secrets_secretID.yml
@@ -1,0 +1,25 @@
+delete:
+  operationId: DeleteOrgsIDSecretsID
+  tags:
+    - Secrets
+  summary: Delete a secret from an organization
+  parameters:
+    - $ref: '../../common/parameters/TraceSpan.yml'
+    - in: path
+      name: orgID
+      schema:
+        type: string
+      required: true
+      description: The organization ID.
+    - in: path
+      name: secretID
+      schema:
+        type: string
+      required: true
+      description: The secret ID.
+  responses:
+    "204":
+      description: Keys successfully deleted
+    default:
+      description: Unexpected error
+      $ref: '../../common/responses/ServerError.yml'

--- a/src/common/_paths.yml
+++ b/src/common/_paths.yml
@@ -104,8 +104,6 @@
     $ref: "./common/paths/orgs_orgID.yml"
   "/orgs/{orgID}/secrets":
     $ref: "./common/paths/orgs_orgID_secrets.yml"
-  "/orgs/{orgID}/secrets/delete": # had to make this because swagger wouldn't let me have a request body with a DELETE
-    $ref: "./common/paths/orgs_orgID_secrets_delete.yml"
   "/orgs/{orgID}/members":
     $ref: "./common/paths/orgs_orgID_members.yml"
   "/orgs/{orgID}/members/{userID}":

--- a/src/oss.yml
+++ b/src/oss.yml
@@ -80,6 +80,8 @@ paths:
     $ref: "./oss/paths/restore_bucket-metadata.yml"
   "/restore/shards/{shardID}":
     $ref: "./oss/paths/restore_shards_shardID.yml"
+  "/orgs/{orgID}/secrets/delete": # this should be deprecated
+    $ref: "./common/paths/orgs_orgID_secrets_delete.yml"
 components:
   parameters:
 #REF_COMMON_PARAMETERS


### PR DESCRIPTION
This deprecates the `/orgs/{orgID}/secrets/delete` route and adds one to delete a single secret by id.