### PR TITLE
Remove onboardingState from User schema

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -1138,16 +1138,12 @@ components:
         sfdcContactId:
           type: string
           description: the contact id of the user in salesforce
-        onboardingState:
-          type: string
-          description: stage of onboarding the account is in
       required:
         - accountId
         - firstName
         - id
         - idpeId
         - lastName
-        - onboardingState
     Users:
       type: array
       items:

--- a/src/unity/schemas/User.yml
+++ b/src/unity/schemas/User.yml
@@ -23,7 +23,4 @@ properties:
   sfdcContactId:
     type: string
     description: the contact id of the user in salesforce
-  onboardingState:
-    type: string
-    description: stage of onboarding the account is in
-required: [accountId, firstName, id, idpeId, lastName, onboardingState]
+required: [accountId, firstName, id, idpeId, lastName]


### PR DESCRIPTION
Quartz is removing the concept of onboarding state in preparation for multi-account. This removes the `onboardingState` field from the `User` schema that is being used for the Operator UI.