### PR TITLE
feat(unity): add account-switching API

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -50,6 +50,67 @@ paths:
         default:
           description: Unexpected error
           $ref: '#/components/responses/ServerError'
+  /accounts:
+    get:
+      operationId: GetAccounts
+      tags:
+        - Accounts
+      summary: Get the list of accounts for the current user
+      responses:
+        '200':
+          description: Accounts
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  properties:
+                    id:
+                      type: number
+                      description: account id in quartz
+                    isActive:
+                      type: boolean
+                      description: is this the currently active account in the session?
+                    isDefault:
+                      type: boolean
+                      description: is this the user's default account?
+                    name:
+                      type: string
+                      description: name of the account
+                  required:
+                    - id
+                    - isActive
+                    - isDefault
+                    - name
+        '401':
+          description: Unauthorized
+          $ref: '#/components/responses/ServerError'
+        default:
+          description: Unexpected error
+          $ref: '#/components/responses/ServerError'
+  /accounts/default:
+    put:
+      operationId: PutDefaultAccount
+      tags:
+        - Accounts
+      requestBody:
+        description: The account to set as the user's default account
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                id:
+                  type: number
+                  description: account id in quartz
+              required:
+                - id
+      responses:
+        '204':
+          description: default account set
+        default:
+          description: Unexpected error
+          $ref: '#/components/responses/ServerError'
   /billing:
     get:
       operationId: GetBilling
@@ -714,7 +775,7 @@ paths:
           $ref: '#/components/responses/ServerError'
   /operator/accounts:
     get:
-      operationId: GetAccounts
+      operationId: GetAccountsForOperator
       tags:
         - Accounts
         - Operators

--- a/src/unity.yml
+++ b/src/unity.yml
@@ -9,6 +9,10 @@ paths:
     $ref: './unity/paths/me.yml'
   '/account':
     $ref: './unity/paths/account.yml'
+  '/accounts':
+    $ref: './unity/paths/accounts.yml'
+  '/accounts/default':
+    $ref: './unity/paths/accounts_default.yml'
   '/billing':
     $ref: './unity/paths/billing.yml'
   '/marketplace':

--- a/src/unity/paths/accounts.yml
+++ b/src/unity/paths/accounts.yml
@@ -1,0 +1,18 @@
+get:
+  operationId: GetAccounts
+  tags:
+    - Accounts
+  summary: Get the list of accounts for the current user
+  responses:
+    '200':
+      description: Accounts
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/Accounts.yml'
+    '401':
+      description: Unauthorized
+      $ref: '../../common/responses/ServerError.yml'
+    default:
+      description: Unexpected error
+      $ref: '../../common/responses/ServerError.yml'

--- a/src/unity/paths/accounts_default.yml
+++ b/src/unity/paths/accounts_default.yml
@@ -1,0 +1,17 @@
+put:
+  operationId: PutDefaultAccount
+  tags:
+    - Accounts
+  requestBody:
+    description: The account to set as the user's default account
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/AccountsDefaultRequest.yml'
+  responses:
+    '204':
+      description: default account set
+    default:
+      description: Unexpected error
+      $ref: '../../common/responses/ServerError.yml'

--- a/src/unity/paths/operator_accounts.yml
+++ b/src/unity/paths/operator_accounts.yml
@@ -1,5 +1,5 @@
 get:
-  operationId: GetAccounts
+  operationId: GetAccountsForOperator
   tags:
     - Accounts
     - Operators

--- a/src/unity/schemas/Account.yml
+++ b/src/unity/schemas/Account.yml
@@ -1,0 +1,15 @@
+properties:
+  id:
+    type: number
+    description: account id in quartz
+  isActive:
+    type: boolean
+    description: is this the currently active account in the session?
+  isDefault:
+    type: boolean
+    description: is this the user's default account?
+  name:
+    type: string
+    description: name of the account
+required:
+  [id, isActive, isDefault, name]

--- a/src/unity/schemas/Accounts.yml
+++ b/src/unity/schemas/Accounts.yml
@@ -1,0 +1,3 @@
+type: array
+items:
+  $ref: './Account.yml'

--- a/src/unity/schemas/AccountsDefaultRequest.yml
+++ b/src/unity/schemas/AccountsDefaultRequest.yml
@@ -1,0 +1,6 @@
+properties:
+  id:
+    type: number
+    description: account id in quartz
+required:
+  [id]


### PR DESCRIPTION
Adds APIs for getting a list of the current user's accounts and for allowing the user to select a different default account.

These endpoints won't be implemented in Quartz for a few sprints, but having them defined now will allow the UI team to mock them out and start building out the UI for this feature.

When the implementation starts in Quartz, we'll also move the `DELETE /account` endpoint to `DELETE /accounts/:id` for consistency. See https://github.com/influxdata/quartz/issues/5077.