### PR TITLE
feat: add OSS APIs for managing remote connections

### DIFF
--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -1808,6 +1808,175 @@ paths:
         default:
           description: Unexpected error
           $ref: '#/components/responses/ServerError'
+  /remotes:
+    get:
+      operationId: GetRemoteConnections
+      tags:
+        - RemoteConnections
+      summary: List all remote connections
+      parameters:
+        - $ref: '#/paths/~1ready/get/parameters/0'
+        - in: query
+          name: org
+          schema:
+            type: string
+        - in: query
+          name: orgID
+          description: The organization ID.
+          schema:
+            type: string
+        - in: query
+          name: name
+          schema:
+            type: string
+        - in: query
+          name: id
+          schema:
+            type: string
+        - in: query
+          name: remoteOrgId
+          schema:
+            type: string
+        - in: query
+          name: remoteUrl
+          schema:
+            type: string
+            format: uri
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemoteConnections'
+        '404':
+          $ref: '#/components/responses/ServerError'
+        default:
+          $ref: '#/components/responses/ServerError'
+    post:
+      operationId: PostRemoteConnections
+      tags:
+        - RemoteConnections
+      summary: Register a new remote connection
+      parameters:
+        - $ref: '#/paths/~1ready/get/parameters/0'
+        - in: query
+          name: dryRun
+          description: 'If true, validate the remote connection, but don''t save it.'
+          schema:
+            type: boolean
+            default: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            $ref: '#/components/schemas/RemoteConnectionCreationRequest'
+      responses:
+        '201':
+          description: Remote connection validated and saved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemoteConnection'
+        '204':
+          description: 'Remote connection validated, but not saved'
+        '400':
+          description: Remote connection failed validation
+          $ref: '#/components/responses/ServerError'
+        default:
+          $ref: '#/components/responses/ServerError'
+  '/remotes/{remoteID}':
+    get:
+      operationId: GetRemoteConnectionByID
+      tags:
+        - RemoteConnections
+      summary: Retrieve a remote connection
+      parameters:
+        - $ref: '#/paths/~1ready/get/parameters/0'
+        - in: path
+          name: remoteID
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemoteConnection'
+        '404':
+          $ref: '#/components/responses/ServerError'
+        default:
+          $ref: '#/components/responses/ServerError'
+    patch:
+      operationId: PatchRemoteConnectionByID
+      tags:
+        - RemoteConnections
+      summary: Update a remote connection
+      parameters:
+        - $ref: '#/paths/~1ready/get/parameters/0'
+        - in: path
+          name: remoteID
+          schema:
+            type: string
+          required: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            $ref: '#/components/schemas/RemoteConnectionUpdateRequest'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemoteConnection'
+        '400':
+          description: Remote connection failed validation
+          $ref: '#/components/responses/ServerError'
+        '404':
+          $ref: '#/components/responses/ServerError'
+        default:
+          $ref: '#/components/responses/ServerError'
+    delete:
+      operationId: DeleteRemoteConnectionByID
+      tags:
+        - RemoteConnections
+      summary: Delete a remote connection
+      parameters:
+        - $ref: '#/paths/~1ready/get/parameters/0'
+        - in: path
+          name: remoteID
+          schema:
+            type: string
+          required: true
+      responses:
+        '204':
+          description: Remote connection info deleted.
+        '404':
+          $ref: '#/components/responses/ServerError'
+        default:
+          $ref: '#/components/responses/ServerError'
+  '/remotes/{remoteID}/validate':
+    post:
+      operationId: PostValidateRemoteConnectionByID
+      tags:
+        - RemoteConnections
+      summary: Validate a remote connection
+      parameters:
+        - $ref: '#/paths/~1ready/get/parameters/0'
+        - in: path
+          name: remoteID
+          schema:
+            type: string
+          required: true
+      responses:
+        '204':
+          description: Remote connection is valid
+        '400':
+          description: Remote connection failed validation
+          $ref: '#/components/responses/ServerError'
+        default:
+          $ref: '#/components/responses/ServerError'
 components:
   parameters: null
   schemas:
@@ -2650,6 +2819,82 @@ components:
       required:
         - oldId
         - newId
+    RemoteConnection:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        orgId:
+          type: string
+        description:
+          type: string
+        remoteUrl:
+          type: string
+          format: uri
+        remoteOrgId:
+          type: string
+        allowInsecureTls:
+          type: boolean
+          default: false
+      required:
+        - id
+        - name
+        - orgId
+        - remoteUrl
+        - remoteOrgId
+        - allowInsecureTls
+    RemoteConnections:
+      type: object
+      properties:
+        remotes:
+          type: array
+          items:
+            $ref: '#/components/schemas/RemoteConnection'
+    RemoteConnectionCreationRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        orgId:
+          type: string
+        remoteUrl:
+          type: string
+          format: uri
+        token:
+          type: string
+        remoteOrgId:
+          type: string
+        allowInsecureTls:
+          type: boolean
+          default: false
+      required:
+        - name
+        - orgId
+        - remoteUrl
+        - token
+        - remoteOrgId
+        - allowInsecureTls
+    RemoteConnectionUpdateRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        remoteUrl:
+          type: string
+          format: uri
+        token:
+          type: string
+        remoteOrgId:
+          type: string
+        allowInsecureTls:
+          type: boolean
+          default: false
   responses:
     ServerError:
       description: Non 2XX error response from server.

--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -1817,12 +1817,9 @@ paths:
       parameters:
         - $ref: '#/paths/~1ready/get/parameters/0'
         - in: query
-          name: org
-          schema:
-            type: string
-        - in: query
           name: orgID
           description: The organization ID.
+          required: true
           schema:
             type: string
         - in: query
@@ -1830,15 +1827,7 @@ paths:
           schema:
             type: string
         - in: query
-          name: id
-          schema:
-            type: string
-        - in: query
-          name: remoteOrgId
-          schema:
-            type: string
-        - in: query
-          name: remoteUrl
+          name: remoteURL
           schema:
             type: string
             format: uri
@@ -1853,7 +1842,7 @@ paths:
         default:
           $ref: '#/components/responses/ServerError'
     post:
-      operationId: PostRemoteConnections
+      operationId: PostRemoteConnection
       tags:
         - RemoteConnections
       summary: Register a new remote connection
@@ -2828,25 +2817,25 @@ components:
           type: string
         name:
           type: string
-        orgId:
+        orgID:
           type: string
         description:
           type: string
-        remoteUrl:
+        remoteURL:
           type: string
           format: uri
-        remoteOrgId:
+        remoteOrgID:
           type: string
-        allowInsecureTls:
+        allowInsecureTLS:
           type: boolean
           default: false
       required:
         - id
         - name
-        - orgId
-        - remoteUrl
-        - remoteOrgId
-        - allowInsecureTls
+        - orgID
+        - remoteURL
+        - remoteOrgID
+        - allowInsecureTLS
     RemoteConnections:
       type: object
       properties:
@@ -2861,25 +2850,25 @@ components:
           type: string
         description:
           type: string
-        orgId:
+        orgID:
           type: string
-        remoteUrl:
+        remoteURL:
           type: string
           format: uri
-        token:
+        remoteAPIToken:
           type: string
-        remoteOrgId:
+        remoteOrgID:
           type: string
-        allowInsecureTls:
+        allowInsecureTLS:
           type: boolean
           default: false
       required:
         - name
-        - orgId
-        - remoteUrl
-        - token
-        - remoteOrgId
-        - allowInsecureTls
+        - orgID
+        - remoteURL
+        - remoteAPIToken
+        - remoteOrgID
+        - allowInsecureTLS
     RemoteConnectionUpdateRequest:
       type: object
       properties:
@@ -2887,14 +2876,14 @@ components:
           type: string
         description:
           type: string
-        remoteUrl:
+        remoteURL:
           type: string
           format: uri
-        token:
+        remoteAPIToken:
           type: string
-        remoteOrgId:
+        remoteOrgID:
           type: string
-        allowInsecureTls:
+        allowInsecureTLS:
           type: boolean
           default: false
   responses:

--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -1869,7 +1869,8 @@ paths:
         required: true
         content:
           application/json:
-            $ref: '#/components/schemas/RemoteConnectionCreationRequest'
+            schema:
+              $ref: '#/components/schemas/RemoteConnectionCreationRequest'
       responses:
         '201':
           description: Remote connection validated and saved
@@ -1923,7 +1924,8 @@ paths:
         required: true
         content:
           application/json:
-            $ref: '#/components/schemas/RemoteConnectionUpdateRequest'
+            schema:
+              $ref: '#/components/schemas/RemoteConnectionUpdateRequest'
       responses:
         '200':
           content:

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -11498,7 +11498,9 @@
           "required": true,
           "content": {
             "application/json": {
-              "$ref": "#/components/schemas/RemoteConnectionCreationRequest"
+              "schema": {
+                "$ref": "#/components/schemas/RemoteConnectionCreationRequest"
+              }
             }
           }
         },
@@ -11587,7 +11589,9 @@
           "required": true,
           "content": {
             "application/json": {
-              "$ref": "#/components/schemas/RemoteConnectionUpdateRequest"
+              "schema": {
+                "$ref": "#/components/schemas/RemoteConnectionUpdateRequest"
+              }
             }
           }
         },

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -11399,6 +11399,285 @@
           }
         }
       }
+    },
+    "/remotes": {
+      "get": {
+        "operationId": "GetRemoteConnections",
+        "tags": [
+          "RemoteConnections"
+        ],
+        "summary": "List all remote connections",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TraceSpan"
+          },
+          {
+            "in": "query",
+            "name": "org",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "orgID",
+            "description": "The organization ID.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "name",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "remoteOrgId",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "remoteUrl",
+            "schema": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RemoteConnections"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "default": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      },
+      "post": {
+        "operationId": "PostRemoteConnections",
+        "tags": [
+          "RemoteConnections"
+        ],
+        "summary": "Register a new remote connection",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TraceSpan"
+          },
+          {
+            "in": "query",
+            "name": "dryRun",
+            "description": "If true, validate the remote connection, but don't save it.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "$ref": "#/components/schemas/RemoteConnectionCreationRequest"
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Remote connection validated and saved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RemoteConnection"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "Remote connection validated, but not saved"
+          },
+          "400": {
+            "description": "Remote connection failed validation",
+            "$ref": "#/components/responses/ServerError"
+          },
+          "default": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/remotes/{remoteID}": {
+      "get": {
+        "operationId": "GetRemoteConnectionByID",
+        "tags": [
+          "RemoteConnections"
+        ],
+        "summary": "Retrieve a remote connection",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TraceSpan"
+          },
+          {
+            "in": "path",
+            "name": "remoteID",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RemoteConnection"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "default": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "PatchRemoteConnectionByID",
+        "tags": [
+          "RemoteConnections"
+        ],
+        "summary": "Update a remote connection",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TraceSpan"
+          },
+          {
+            "in": "path",
+            "name": "remoteID",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "$ref": "#/components/schemas/RemoteConnectionUpdateRequest"
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RemoteConnection"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Remote connection failed validation",
+            "$ref": "#/components/responses/ServerError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "default": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "DeleteRemoteConnectionByID",
+        "tags": [
+          "RemoteConnections"
+        ],
+        "summary": "Delete a remote connection",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TraceSpan"
+          },
+          {
+            "in": "path",
+            "name": "remoteID",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Remote connection info deleted."
+          },
+          "404": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "default": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/remotes/{remoteID}/validate": {
+      "post": {
+        "operationId": "PostValidateRemoteConnectionByID",
+        "tags": [
+          "RemoteConnections"
+        ],
+        "summary": "Validate a remote connection",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TraceSpan"
+          },
+          {
+            "in": "path",
+            "name": "remoteID",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Remote connection is valid"
+          },
+          "400": {
+            "description": "Remote connection failed validation",
+            "$ref": "#/components/responses/ServerError"
+          },
+          "default": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -19943,6 +20222,114 @@
           "oldId",
           "newId"
         ]
+      },
+      "RemoteConnection": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "orgId": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "remoteUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "remoteOrgId": {
+            "type": "string"
+          },
+          "allowInsecureTls": {
+            "type": "boolean",
+            "default": false
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "orgId",
+          "remoteUrl",
+          "remoteOrgId",
+          "allowInsecureTls"
+        ]
+      },
+      "RemoteConnections": {
+        "type": "object",
+        "properties": {
+          "remotes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RemoteConnection"
+            }
+          }
+        }
+      },
+      "RemoteConnectionCreationRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "orgId": {
+            "type": "string"
+          },
+          "remoteUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "token": {
+            "type": "string"
+          },
+          "remoteOrgId": {
+            "type": "string"
+          },
+          "allowInsecureTls": {
+            "type": "boolean",
+            "default": false
+          }
+        },
+        "required": [
+          "name",
+          "orgId",
+          "remoteUrl",
+          "token",
+          "remoteOrgId",
+          "allowInsecureTls"
+        ]
+      },
+      "RemoteConnectionUpdateRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "remoteUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "token": {
+            "type": "string"
+          },
+          "remoteOrgId": {
+            "type": "string"
+          },
+          "allowInsecureTls": {
+            "type": "boolean",
+            "default": false
+          }
+        }
       }
     },
     "responses": {

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -11413,15 +11413,9 @@
           },
           {
             "in": "query",
-            "name": "org",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
             "name": "orgID",
             "description": "The organization ID.",
+            "required": true,
             "schema": {
               "type": "string"
             }
@@ -11435,21 +11429,7 @@
           },
           {
             "in": "query",
-            "name": "id",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "remoteOrgId",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "remoteUrl",
+            "name": "remoteURL",
             "schema": {
               "type": "string",
               "format": "uri"
@@ -11475,7 +11455,7 @@
         }
       },
       "post": {
-        "operationId": "PostRemoteConnections",
+        "operationId": "PostRemoteConnection",
         "tags": [
           "RemoteConnections"
         ],
@@ -20236,20 +20216,20 @@
           "name": {
             "type": "string"
           },
-          "orgId": {
+          "orgID": {
             "type": "string"
           },
           "description": {
             "type": "string"
           },
-          "remoteUrl": {
+          "remoteURL": {
             "type": "string",
             "format": "uri"
           },
-          "remoteOrgId": {
+          "remoteOrgID": {
             "type": "string"
           },
-          "allowInsecureTls": {
+          "allowInsecureTLS": {
             "type": "boolean",
             "default": false
           }
@@ -20257,10 +20237,10 @@
         "required": [
           "id",
           "name",
-          "orgId",
-          "remoteUrl",
-          "remoteOrgId",
-          "allowInsecureTls"
+          "orgID",
+          "remoteURL",
+          "remoteOrgID",
+          "allowInsecureTLS"
         ]
       },
       "RemoteConnections": {
@@ -20283,31 +20263,31 @@
           "description": {
             "type": "string"
           },
-          "orgId": {
+          "orgID": {
             "type": "string"
           },
-          "remoteUrl": {
+          "remoteURL": {
             "type": "string",
             "format": "uri"
           },
-          "token": {
+          "remoteAPIToken": {
             "type": "string"
           },
-          "remoteOrgId": {
+          "remoteOrgID": {
             "type": "string"
           },
-          "allowInsecureTls": {
+          "allowInsecureTLS": {
             "type": "boolean",
             "default": false
           }
         },
         "required": [
           "name",
-          "orgId",
-          "remoteUrl",
-          "token",
-          "remoteOrgId",
-          "allowInsecureTls"
+          "orgID",
+          "remoteURL",
+          "remoteAPIToken",
+          "remoteOrgID",
+          "allowInsecureTLS"
         ]
       },
       "RemoteConnectionUpdateRequest": {
@@ -20319,17 +20299,17 @@
           "description": {
             "type": "string"
           },
-          "remoteUrl": {
+          "remoteURL": {
             "type": "string",
             "format": "uri"
           },
-          "token": {
+          "remoteAPIToken": {
             "type": "string"
           },
-          "remoteOrgId": {
+          "remoteOrgID": {
             "type": "string"
           },
-          "allowInsecureTls": {
+          "allowInsecureTLS": {
             "type": "boolean",
             "default": false
           }

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -6964,6 +6964,175 @@ paths:
         default:
           description: Unexpected error
           $ref: '#/components/responses/ServerError'
+  /remotes:
+    get:
+      operationId: GetRemoteConnections
+      tags:
+        - RemoteConnections
+      summary: List all remote connections
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: query
+          name: org
+          schema:
+            type: string
+        - in: query
+          name: orgID
+          description: The organization ID.
+          schema:
+            type: string
+        - in: query
+          name: name
+          schema:
+            type: string
+        - in: query
+          name: id
+          schema:
+            type: string
+        - in: query
+          name: remoteOrgId
+          schema:
+            type: string
+        - in: query
+          name: remoteUrl
+          schema:
+            type: string
+            format: uri
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemoteConnections'
+        '404':
+          $ref: '#/components/responses/ServerError'
+        default:
+          $ref: '#/components/responses/ServerError'
+    post:
+      operationId: PostRemoteConnections
+      tags:
+        - RemoteConnections
+      summary: Register a new remote connection
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: query
+          name: dryRun
+          description: 'If true, validate the remote connection, but don''t save it.'
+          schema:
+            type: boolean
+            default: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            $ref: '#/components/schemas/RemoteConnectionCreationRequest'
+      responses:
+        '201':
+          description: Remote connection validated and saved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemoteConnection'
+        '204':
+          description: 'Remote connection validated, but not saved'
+        '400':
+          description: Remote connection failed validation
+          $ref: '#/components/responses/ServerError'
+        default:
+          $ref: '#/components/responses/ServerError'
+  '/remotes/{remoteID}':
+    get:
+      operationId: GetRemoteConnectionByID
+      tags:
+        - RemoteConnections
+      summary: Retrieve a remote connection
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: path
+          name: remoteID
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemoteConnection'
+        '404':
+          $ref: '#/components/responses/ServerError'
+        default:
+          $ref: '#/components/responses/ServerError'
+    patch:
+      operationId: PatchRemoteConnectionByID
+      tags:
+        - RemoteConnections
+      summary: Update a remote connection
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: path
+          name: remoteID
+          schema:
+            type: string
+          required: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            $ref: '#/components/schemas/RemoteConnectionUpdateRequest'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemoteConnection'
+        '400':
+          description: Remote connection failed validation
+          $ref: '#/components/responses/ServerError'
+        '404':
+          $ref: '#/components/responses/ServerError'
+        default:
+          $ref: '#/components/responses/ServerError'
+    delete:
+      operationId: DeleteRemoteConnectionByID
+      tags:
+        - RemoteConnections
+      summary: Delete a remote connection
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: path
+          name: remoteID
+          schema:
+            type: string
+          required: true
+      responses:
+        '204':
+          description: Remote connection info deleted.
+        '404':
+          $ref: '#/components/responses/ServerError'
+        default:
+          $ref: '#/components/responses/ServerError'
+  '/remotes/{remoteID}/validate':
+    post:
+      operationId: PostValidateRemoteConnectionByID
+      tags:
+        - RemoteConnections
+      summary: Validate a remote connection
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: path
+          name: remoteID
+          schema:
+            type: string
+          required: true
+      responses:
+        '204':
+          description: Remote connection is valid
+        '400':
+          description: Remote connection failed validation
+          $ref: '#/components/responses/ServerError'
+        default:
+          $ref: '#/components/responses/ServerError'
 components:
   parameters:
     TraceSpan:
@@ -12729,6 +12898,82 @@ components:
       required:
         - oldId
         - newId
+    RemoteConnection:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        orgId:
+          type: string
+        description:
+          type: string
+        remoteUrl:
+          type: string
+          format: uri
+        remoteOrgId:
+          type: string
+        allowInsecureTls:
+          type: boolean
+          default: false
+      required:
+        - id
+        - name
+        - orgId
+        - remoteUrl
+        - remoteOrgId
+        - allowInsecureTls
+    RemoteConnections:
+      type: object
+      properties:
+        remotes:
+          type: array
+          items:
+            $ref: '#/components/schemas/RemoteConnection'
+    RemoteConnectionCreationRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        orgId:
+          type: string
+        remoteUrl:
+          type: string
+          format: uri
+        token:
+          type: string
+        remoteOrgId:
+          type: string
+        allowInsecureTls:
+          type: boolean
+          default: false
+      required:
+        - name
+        - orgId
+        - remoteUrl
+        - token
+        - remoteOrgId
+        - allowInsecureTls
+    RemoteConnectionUpdateRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        remoteUrl:
+          type: string
+          format: uri
+        token:
+          type: string
+        remoteOrgId:
+          type: string
+        allowInsecureTls:
+          type: boolean
+          default: false
   responses:
     ServerError:
       description: Non 2XX error response from server.

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -6973,12 +6973,9 @@ paths:
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: query
-          name: org
-          schema:
-            type: string
-        - in: query
           name: orgID
           description: The organization ID.
+          required: true
           schema:
             type: string
         - in: query
@@ -6986,15 +6983,7 @@ paths:
           schema:
             type: string
         - in: query
-          name: id
-          schema:
-            type: string
-        - in: query
-          name: remoteOrgId
-          schema:
-            type: string
-        - in: query
-          name: remoteUrl
+          name: remoteURL
           schema:
             type: string
             format: uri
@@ -7009,7 +6998,7 @@ paths:
         default:
           $ref: '#/components/responses/ServerError'
     post:
-      operationId: PostRemoteConnections
+      operationId: PostRemoteConnection
       tags:
         - RemoteConnections
       summary: Register a new remote connection
@@ -12907,25 +12896,25 @@ components:
           type: string
         name:
           type: string
-        orgId:
+        orgID:
           type: string
         description:
           type: string
-        remoteUrl:
+        remoteURL:
           type: string
           format: uri
-        remoteOrgId:
+        remoteOrgID:
           type: string
-        allowInsecureTls:
+        allowInsecureTLS:
           type: boolean
           default: false
       required:
         - id
         - name
-        - orgId
-        - remoteUrl
-        - remoteOrgId
-        - allowInsecureTls
+        - orgID
+        - remoteURL
+        - remoteOrgID
+        - allowInsecureTLS
     RemoteConnections:
       type: object
       properties:
@@ -12940,25 +12929,25 @@ components:
           type: string
         description:
           type: string
-        orgId:
+        orgID:
           type: string
-        remoteUrl:
+        remoteURL:
           type: string
           format: uri
-        token:
+        remoteAPIToken:
           type: string
-        remoteOrgId:
+        remoteOrgID:
           type: string
-        allowInsecureTls:
+        allowInsecureTLS:
           type: boolean
           default: false
       required:
         - name
-        - orgId
-        - remoteUrl
-        - token
-        - remoteOrgId
-        - allowInsecureTls
+        - orgID
+        - remoteURL
+        - remoteAPIToken
+        - remoteOrgID
+        - allowInsecureTLS
     RemoteConnectionUpdateRequest:
       type: object
       properties:
@@ -12966,14 +12955,14 @@ components:
           type: string
         description:
           type: string
-        remoteUrl:
+        remoteURL:
           type: string
           format: uri
-        token:
+        remoteAPIToken:
           type: string
-        remoteOrgId:
+        remoteOrgID:
           type: string
-        allowInsecureTls:
+        allowInsecureTLS:
           type: boolean
           default: false
   responses:

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -7025,7 +7025,8 @@ paths:
         required: true
         content:
           application/json:
-            $ref: '#/components/schemas/RemoteConnectionCreationRequest'
+            schema:
+              $ref: '#/components/schemas/RemoteConnectionCreationRequest'
       responses:
         '201':
           description: Remote connection validated and saved
@@ -7079,7 +7080,8 @@ paths:
         required: true
         content:
           application/json:
-            $ref: '#/components/schemas/RemoteConnectionUpdateRequest'
+            schema:
+              $ref: '#/components/schemas/RemoteConnectionUpdateRequest'
       responses:
         '200':
           content:

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -4157,7 +4157,8 @@ paths:
       requestBody:
         content:
           application/json:
-            $ref: '#/components/schemas/RemoteConnectionCreationRequest'
+            schema:
+              $ref: '#/components/schemas/RemoteConnectionCreationRequest'
         required: true
       responses:
         "201":
@@ -4230,7 +4231,8 @@ paths:
       requestBody:
         content:
           application/json:
-            $ref: '#/components/schemas/RemoteConnectionUpdateRequest'
+            schema:
+              $ref: '#/components/schemas/RemoteConnectionUpdateRequest'
         required: true
       responses:
         "200":

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -4105,13 +4105,10 @@ paths:
       operationId: GetRemoteConnections
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
-      - in: query
-        name: org
-        schema:
-          type: string
       - description: The organization ID.
         in: query
         name: orgID
+        required: true
         schema:
           type: string
       - in: query
@@ -4119,15 +4116,7 @@ paths:
         schema:
           type: string
       - in: query
-        name: id
-        schema:
-          type: string
-      - in: query
-        name: remoteOrgId
-        schema:
-          type: string
-      - in: query
-        name: remoteUrl
+        name: remoteURL
         schema:
           format: uri
           type: string
@@ -4145,7 +4134,7 @@ paths:
       tags:
       - RemoteConnections
     post:
-      operationId: PostRemoteConnections
+      operationId: PostRemoteConnection
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
       - description: If true, validate the remote connection, but don't save it.
@@ -10502,7 +10491,7 @@ components:
       type: object
     RemoteConnection:
       properties:
-        allowInsecureTls:
+        allowInsecureTLS:
           default: false
           type: boolean
         description:
@@ -10511,62 +10500,62 @@ components:
           type: string
         name:
           type: string
-        orgId:
+        orgID:
           type: string
-        remoteOrgId:
+        remoteOrgID:
           type: string
-        remoteUrl:
+        remoteURL:
           format: uri
           type: string
       required:
       - id
       - name
-      - orgId
-      - remoteUrl
-      - remoteOrgId
-      - allowInsecureTls
+      - orgID
+      - remoteURL
+      - remoteOrgID
+      - allowInsecureTLS
       type: object
     RemoteConnectionCreationRequest:
       properties:
-        allowInsecureTls:
+        allowInsecureTLS:
           default: false
           type: boolean
         description:
           type: string
         name:
           type: string
-        orgId:
+        orgID:
           type: string
-        remoteOrgId:
+        remoteAPIToken:
           type: string
-        remoteUrl:
+        remoteOrgID:
+          type: string
+        remoteURL:
           format: uri
-          type: string
-        token:
           type: string
       required:
       - name
-      - orgId
-      - remoteUrl
-      - token
-      - remoteOrgId
-      - allowInsecureTls
+      - orgID
+      - remoteURL
+      - remoteAPIToken
+      - remoteOrgID
+      - allowInsecureTLS
       type: object
     RemoteConnectionUpdateRequest:
       properties:
-        allowInsecureTls:
+        allowInsecureTLS:
           default: false
           type: boolean
         description:
           type: string
         name:
           type: string
-        remoteOrgId:
+        remoteAPIToken:
           type: string
-        remoteUrl:
+        remoteOrgID:
+          type: string
+        remoteURL:
           format: uri
-          type: string
-        token:
           type: string
       type: object
     RemoteConnections:

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -4100,6 +4100,175 @@ paths:
       - Ready
     servers:
     - url: ""
+  /api/v2/remotes:
+    get:
+      operationId: GetRemoteConnections
+      parameters:
+      - $ref: '#/components/parameters/TraceSpan'
+      - in: query
+        name: org
+        schema:
+          type: string
+      - description: The organization ID.
+        in: query
+        name: orgID
+        schema:
+          type: string
+      - in: query
+        name: name
+        schema:
+          type: string
+      - in: query
+        name: id
+        schema:
+          type: string
+      - in: query
+        name: remoteOrgId
+        schema:
+          type: string
+      - in: query
+        name: remoteUrl
+        schema:
+          format: uri
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemoteConnections'
+        "404":
+          $ref: '#/components/responses/ServerError'
+        default:
+          $ref: '#/components/responses/ServerError'
+      summary: List all remote connections
+      tags:
+      - RemoteConnections
+    post:
+      operationId: PostRemoteConnections
+      parameters:
+      - $ref: '#/components/parameters/TraceSpan'
+      - description: If true, validate the remote connection, but don't save it.
+        in: query
+        name: dryRun
+        schema:
+          default: false
+          type: boolean
+      requestBody:
+        content:
+          application/json:
+            $ref: '#/components/schemas/RemoteConnectionCreationRequest'
+        required: true
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemoteConnection'
+          description: Remote connection validated and saved
+        "204":
+          description: Remote connection validated, but not saved
+        "400":
+          $ref: '#/components/responses/ServerError'
+          description: Remote connection failed validation
+        default:
+          $ref: '#/components/responses/ServerError'
+      summary: Register a new remote connection
+      tags:
+      - RemoteConnections
+  /api/v2/remotes/{remoteID}:
+    delete:
+      operationId: DeleteRemoteConnectionByID
+      parameters:
+      - $ref: '#/components/parameters/TraceSpan'
+      - in: path
+        name: remoteID
+        required: true
+        schema:
+          type: string
+      responses:
+        "204":
+          description: Remote connection info deleted.
+        "404":
+          $ref: '#/components/responses/ServerError'
+        default:
+          $ref: '#/components/responses/ServerError'
+      summary: Delete a remote connection
+      tags:
+      - RemoteConnections
+    get:
+      operationId: GetRemoteConnectionByID
+      parameters:
+      - $ref: '#/components/parameters/TraceSpan'
+      - in: path
+        name: remoteID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemoteConnection'
+        "404":
+          $ref: '#/components/responses/ServerError'
+        default:
+          $ref: '#/components/responses/ServerError'
+      summary: Retrieve a remote connection
+      tags:
+      - RemoteConnections
+    patch:
+      operationId: PatchRemoteConnectionByID
+      parameters:
+      - $ref: '#/components/parameters/TraceSpan'
+      - in: path
+        name: remoteID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            $ref: '#/components/schemas/RemoteConnectionUpdateRequest'
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemoteConnection'
+        "400":
+          $ref: '#/components/responses/ServerError'
+          description: Remote connection failed validation
+        "404":
+          $ref: '#/components/responses/ServerError'
+        default:
+          $ref: '#/components/responses/ServerError'
+      summary: Update a remote connection
+      tags:
+      - RemoteConnections
+  /api/v2/remotes/{remoteID}/validate:
+    post:
+      operationId: PostValidateRemoteConnectionByID
+      parameters:
+      - $ref: '#/components/parameters/TraceSpan'
+      - in: path
+        name: remoteID
+        required: true
+        schema:
+          type: string
+      responses:
+        "204":
+          description: Remote connection is valid
+        "400":
+          $ref: '#/components/responses/ServerError'
+          description: Remote connection failed validation
+        default:
+          $ref: '#/components/responses/ServerError'
+      summary: Validate a remote connection
+      tags:
+      - RemoteConnections
   /api/v2/resources:
     get:
       operationId: GetResources
@@ -10328,6 +10497,82 @@ components:
           $ref: '#/components/schemas/NodeType'
         value:
           type: string
+      type: object
+    RemoteConnection:
+      properties:
+        allowInsecureTls:
+          default: false
+          type: boolean
+        description:
+          type: string
+        id:
+          type: string
+        name:
+          type: string
+        orgId:
+          type: string
+        remoteOrgId:
+          type: string
+        remoteUrl:
+          format: uri
+          type: string
+      required:
+      - id
+      - name
+      - orgId
+      - remoteUrl
+      - remoteOrgId
+      - allowInsecureTls
+      type: object
+    RemoteConnectionCreationRequest:
+      properties:
+        allowInsecureTls:
+          default: false
+          type: boolean
+        description:
+          type: string
+        name:
+          type: string
+        orgId:
+          type: string
+        remoteOrgId:
+          type: string
+        remoteUrl:
+          format: uri
+          type: string
+        token:
+          type: string
+      required:
+      - name
+      - orgId
+      - remoteUrl
+      - token
+      - remoteOrgId
+      - allowInsecureTls
+      type: object
+    RemoteConnectionUpdateRequest:
+      properties:
+        allowInsecureTls:
+          default: false
+          type: boolean
+        description:
+          type: string
+        name:
+          type: string
+        remoteOrgId:
+          type: string
+        remoteUrl:
+          format: uri
+          type: string
+        token:
+          type: string
+      type: object
+    RemoteConnections:
+      properties:
+        remotes:
+          items:
+            $ref: '#/components/schemas/RemoteConnection'
+          type: array
       type: object
     RenamableField:
       description: Describes a field that can be renamed and made visible or invisible.

--- a/src/oss.yml
+++ b/src/oss.yml
@@ -80,6 +80,12 @@ paths:
     $ref: "./oss/paths/restore_bucketMetadata.yml"
   "/restore/shards/{shardID}":
     $ref: "./oss/paths/restore_shards_shardID.yml"
+  /remotes:
+    $ref: "./oss/paths/remotes.yml"
+  /remotes/{remoteID}:
+    $ref: "./oss/paths/remotes_remoteID.yml"
+  /remotes/{remoteID}/validate:
+    $ref: "./oss/paths/remotes_remoteID_validate.yml"
 components:
   parameters:
 #REF_COMMON_PARAMETERS
@@ -151,6 +157,14 @@ components:
       $ref: "./oss/schemas/BucketShardMappings.yml"
     BucketShardMapping:
       $ref: "./oss/schemas/BucketShardMapping.yml"
+    RemoteConnection:
+      $ref: "./oss/schemas/RemoteConnection.yml"
+    RemoteConnections:
+      $ref: "./oss/schemas/RemoteConnections.yml"
+    RemoteConnectionCreationRequest:
+      $ref: "./oss/schemas/RemoteConnectionCreationRequest.yml"
+    RemoteConnectionUpdateRequest:
+      $ref: "./oss/schemas/RemoteConnectionUpdateRequest.yml"
   responses:
     ServerError:
       $ref: "./common/responses/ServerError.yml"

--- a/src/oss/paths/remotes.yml
+++ b/src/oss/paths/remotes.yml
@@ -6,12 +6,9 @@ get:
   parameters:
     - $ref: "../../common/parameters/TraceSpan.yml"
     - in: query
-      name: org
-      schema:
-        type: string
-    - in: query
       name: orgID
       description: The organization ID.
+      required: true
       schema:
         type: string
     - in: query
@@ -19,15 +16,7 @@ get:
       schema:
         type: string
     - in: query
-      name: id
-      schema:
-        type: string
-    - in: query
-      name: remoteOrgId
-      schema:
-        type: string
-    - in: query
-      name: remoteUrl
+      name: remoteURL
       schema:
         type: string
         format: uri
@@ -43,7 +32,7 @@ get:
       $ref: "../../common/responses/ServerError.yml"
 
 post:
-  operationId: PostRemoteConnections
+  operationId: PostRemoteConnection
   tags:
     - RemoteConnections
   summary: Register a new remote connection

--- a/src/oss/paths/remotes.yml
+++ b/src/oss/paths/remotes.yml
@@ -1,0 +1,76 @@
+get:
+  operationId: GetRemoteConnections
+  tags:
+    - RemoteConnections
+  summary: List all remote connections
+  parameters:
+    - $ref: "../../common/parameters/TraceSpan.yml"
+    - in: query
+      name: org
+      schema:
+        type: string
+    - in: query
+      name: orgID
+      description: The organization ID.
+      schema:
+        type: string
+    - in: query
+      name: name
+      schema:
+        type: string
+    - in: query
+      name: id
+      schema:
+        type: string
+    - in: query
+      name: remoteOrgId
+      schema:
+        type: string
+    - in: query
+      name: remoteUrl
+      schema:
+        type: string
+        format: uri
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/RemoteConnections.yml"
+    "404":
+      $ref: "../../common/responses/ServerError.yml"
+    default:
+      $ref: "../../common/responses/ServerError.yml"
+
+post:
+  operationId: PostRemoteConnections
+  tags:
+    - RemoteConnections
+  summary: Register a new remote connection
+  parameters:
+    - $ref: "../../common/parameters/TraceSpan.yml"
+    - in: query
+      name: dryRun
+      description: If true, validate the remote connection, but don't save it.
+      schema:
+        type: boolean
+        default: false
+  requestBody:
+    required: true
+    content:
+      application/json:
+        $ref: "../schemas/RemoteConnectionCreationRequest.yml"
+  responses:
+    "204":
+      description: Remote connection validated, but not saved
+    "201":
+      description: Remote connection validated and saved
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/RemoteConnection.yml"
+    "400":
+      description: Remote connection failed validation
+      $ref: "../../common/responses/ServerError.yml"
+    default:
+      $ref: "../../common/responses/ServerError.yml"

--- a/src/oss/paths/remotes.yml
+++ b/src/oss/paths/remotes.yml
@@ -59,7 +59,8 @@ post:
     required: true
     content:
       application/json:
-        $ref: "../schemas/RemoteConnectionCreationRequest.yml"
+        schema:
+          $ref: "../schemas/RemoteConnectionCreationRequest.yml"
   responses:
     "204":
       description: Remote connection validated, but not saved

--- a/src/oss/paths/remotes_remoteID.yml
+++ b/src/oss/paths/remotes_remoteID.yml
@@ -37,7 +37,8 @@ patch:
     required: true
     content:
       application/json:
-        $ref: "../schemas/RemoteConnectionUpdateRequest.yml"
+        schema:
+          $ref: "../schemas/RemoteConnectionUpdateRequest.yml"
   responses:
     "200":
       content:

--- a/src/oss/paths/remotes_remoteID.yml
+++ b/src/oss/paths/remotes_remoteID.yml
@@ -1,0 +1,73 @@
+get:
+  operationId: GetRemoteConnectionByID
+  tags:
+    - RemoteConnections
+  summary: Retrieve a remote connection
+  parameters:
+    - $ref: "../../common/parameters/TraceSpan.yml"
+    - in: path
+      name: remoteID
+      schema:
+        type: string
+      required: true
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/RemoteConnection.yml"
+    "404":
+      $ref: "../../common/responses/ServerError.yml"
+    default:
+      $ref: "../../common/responses/ServerError.yml"
+
+patch:
+  operationId: PatchRemoteConnectionByID
+  tags:
+    - RemoteConnections
+  summary: Update a remote connection
+  parameters:
+    - $ref: "../../common/parameters/TraceSpan.yml"
+    - in: path
+      name: remoteID
+      schema:
+        type: string
+      required: true
+  requestBody:
+    required: true
+    content:
+      application/json:
+        $ref: "../schemas/RemoteConnectionUpdateRequest.yml"
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/RemoteConnection.yml"
+    "404":
+      $ref: "../../common/responses/ServerError.yml"
+    "400":
+      description: Remote connection failed validation
+      $ref: "../../common/responses/ServerError.yml"
+    default:
+      $ref: "../../common/responses/ServerError.yml"
+
+delete:
+  operationId: DeleteRemoteConnectionByID
+  tags:
+    - RemoteConnections
+  summary: Delete a remote connection
+  parameters:
+    - $ref: "../../common/parameters/TraceSpan.yml"
+    - in: path
+      name: remoteID
+      schema:
+        type: string
+      required: true
+  responses:
+    "204":
+      description: Remote connection info deleted.
+    "404":
+      $ref: "../../common/responses/ServerError.yml"
+    default:
+      $ref: "../../common/responses/ServerError.yml"

--- a/src/oss/paths/remotes_remoteID_validate.yml
+++ b/src/oss/paths/remotes_remoteID_validate.yml
@@ -1,0 +1,20 @@
+post:
+  operationId: PostValidateRemoteConnectionByID
+  tags:
+    - RemoteConnections
+  summary: Validate a remote connection
+  parameters:
+    - $ref: "../../common/parameters/TraceSpan.yml"
+    - in: path
+      name: remoteID
+      schema:
+        type: string
+      required: true
+  responses:
+    "204":
+      description: Remote connection is valid
+    "400":
+      description: Remote connection failed validation
+      $ref: "../../common/responses/ServerError.yml"
+    default:
+      $ref: "../../common/responses/ServerError.yml"

--- a/src/oss/schemas/RemoteConnection.yml
+++ b/src/oss/schemas/RemoteConnection.yml
@@ -1,0 +1,25 @@
+type: object
+properties:
+  id:
+    type: string
+  name:
+    type: string
+  orgId:
+    type: string
+  description:
+    type: string
+  remoteUrl:
+    type: string
+    format: uri
+  remoteOrgId:
+    type: string
+  allowInsecureTls:
+    type: boolean
+    default: false
+required:
+  - id
+  - name
+  - orgId
+  - remoteUrl
+  - remoteOrgId
+  - allowInsecureTls

--- a/src/oss/schemas/RemoteConnection.yml
+++ b/src/oss/schemas/RemoteConnection.yml
@@ -4,22 +4,22 @@ properties:
     type: string
   name:
     type: string
-  orgId:
+  orgID:
     type: string
   description:
     type: string
-  remoteUrl:
+  remoteURL:
     type: string
     format: uri
-  remoteOrgId:
+  remoteOrgID:
     type: string
-  allowInsecureTls:
+  allowInsecureTLS:
     type: boolean
     default: false
 required:
   - id
   - name
-  - orgId
-  - remoteUrl
-  - remoteOrgId
-  - allowInsecureTls
+  - orgID
+  - remoteURL
+  - remoteOrgID
+  - allowInsecureTLS

--- a/src/oss/schemas/RemoteConnectionCreationRequest.yml
+++ b/src/oss/schemas/RemoteConnectionCreationRequest.yml
@@ -4,22 +4,22 @@ properties:
     type: string
   description:
     type: string
-  orgId:
+  orgID:
     type: string
-  remoteUrl:
+  remoteURL:
     type: string
     format: uri
-  token:
+  remoteAPIToken:
     type: string
-  remoteOrgId:
+  remoteOrgID:
     type: string
-  allowInsecureTls:
+  allowInsecureTLS:
     type: boolean
     default: false
 required:
   - name
-  - orgId
-  - remoteUrl
-  - token
-  - remoteOrgId
-  - allowInsecureTls
+  - orgID
+  - remoteURL
+  - remoteAPIToken
+  - remoteOrgID
+  - allowInsecureTLS

--- a/src/oss/schemas/RemoteConnectionCreationRequest.yml
+++ b/src/oss/schemas/RemoteConnectionCreationRequest.yml
@@ -1,0 +1,25 @@
+type: object
+properties:
+  name:
+    type: string
+  description:
+    type: string
+  orgId:
+    type: string
+  remoteUrl:
+    type: string
+    format: uri
+  token:
+    type: string
+  remoteOrgId:
+    type: string
+  allowInsecureTls:
+    type: boolean
+    default: false
+required:
+  - name
+  - orgId
+  - remoteUrl
+  - token
+  - remoteOrgId
+  - allowInsecureTls

--- a/src/oss/schemas/RemoteConnectionUpdateRequest.yml
+++ b/src/oss/schemas/RemoteConnectionUpdateRequest.yml
@@ -1,0 +1,16 @@
+type: object
+properties:
+  name:
+    type: string
+  description:
+    type: string
+  remoteUrl:
+    type: string
+    format: uri
+  token:
+    type: string
+  remoteOrgId:
+    type: string
+  allowInsecureTls:
+    type: boolean
+    default: false

--- a/src/oss/schemas/RemoteConnectionUpdateRequest.yml
+++ b/src/oss/schemas/RemoteConnectionUpdateRequest.yml
@@ -4,13 +4,13 @@ properties:
     type: string
   description:
     type: string
-  remoteUrl:
+  remoteURL:
     type: string
     format: uri
-  token:
+  remoteAPIToken:
     type: string
-  remoteOrgId:
+  remoteOrgID:
     type: string
-  allowInsecureTls:
+  allowInsecureTLS:
     type: boolean
     default: false

--- a/src/oss/schemas/RemoteConnections.yml
+++ b/src/oss/schemas/RemoteConnections.yml
@@ -1,0 +1,7 @@
+type: object
+properties:
+  # TODO(danmoran): Add pagination / links?
+  remotes:
+    type: array
+    items:
+      $ref: "./RemoteConnection.yml"


### PR DESCRIPTION
Closes influxdata/influxdb#22202

Open-ish questions:

- [ ] Can we think of a better prefix than `/remotes`?
- [ ] Do we need to add self-links / pagination links to responses?