### PR TITLE
fix: add description for responses in Remote API

### DIFF
--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -1833,7 +1833,7 @@ paths:
             format: uri
       responses:
         '200':
-          description: List all remote connections
+          description: List of remote connections
           content:
             application/json:
               schema:
@@ -1889,7 +1889,7 @@ paths:
           required: true
       responses:
         '200':
-          description: Retrieve a remote connection
+          description: Remote connection
           content:
             application/json:
               schema:

--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -1833,6 +1833,7 @@ paths:
             format: uri
       responses:
         '200':
+          description: List all remote connections
           content:
             application/json:
               schema:
@@ -1888,6 +1889,7 @@ paths:
           required: true
       responses:
         '200':
+          description: Retrieve a remote connection
           content:
             application/json:
               schema:

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -11438,6 +11438,7 @@
         ],
         "responses": {
           "200": {
+            "description": "List all remote connections",
             "content": {
               "application/json": {
                 "schema": {
@@ -11529,6 +11530,7 @@
         ],
         "responses": {
           "200": {
+            "description": "Retrieve a remote connection",
             "content": {
               "application/json": {
                 "schema": {

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -11438,7 +11438,7 @@
         ],
         "responses": {
           "200": {
-            "description": "List all remote connections",
+            "description": "List of remote connections",
             "content": {
               "application/json": {
                 "schema": {
@@ -11530,7 +11530,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Retrieve a remote connection",
+            "description": "Remote connection",
             "content": {
               "application/json": {
                 "schema": {

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -6989,7 +6989,7 @@ paths:
             format: uri
       responses:
         '200':
-          description: List all remote connections
+          description: List of remote connections
           content:
             application/json:
               schema:
@@ -7045,7 +7045,7 @@ paths:
           required: true
       responses:
         '200':
-          description: Retrieve a remote connection
+          description: Remote connection
           content:
             application/json:
               schema:

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -6989,6 +6989,7 @@ paths:
             format: uri
       responses:
         '200':
+          description: List all remote connections
           content:
             application/json:
               schema:
@@ -7044,6 +7045,7 @@ paths:
           required: true
       responses:
         '200':
+          description: Retrieve a remote connection
           content:
             application/json:
               schema:

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -4126,7 +4126,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RemoteConnections'
-          description: List all remote connections
+          description: List of remote connections
         "404":
           $ref: '#/components/responses/ServerError'
         default:
@@ -4201,7 +4201,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RemoteConnection'
-          description: Retrieve a remote connection
+          description: Remote connection
         "404":
           $ref: '#/components/responses/ServerError'
         default:

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -4126,6 +4126,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RemoteConnections'
+          description: List all remote connections
         "404":
           $ref: '#/components/responses/ServerError'
         default:
@@ -4200,6 +4201,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RemoteConnection'
+          description: Retrieve a remote connection
         "404":
           $ref: '#/components/responses/ServerError'
         default:

--- a/src/oss/paths/remotes.yml
+++ b/src/oss/paths/remotes.yml
@@ -22,7 +22,7 @@ get:
         format: uri
   responses:
     "200":
-      description: List all remote connections
+      description: List of remote connections
       content:
         application/json:
           schema:

--- a/src/oss/paths/remotes.yml
+++ b/src/oss/paths/remotes.yml
@@ -22,6 +22,7 @@ get:
         format: uri
   responses:
     "200":
+      description: List all remote connections
       content:
         application/json:
           schema:

--- a/src/oss/paths/remotes_remoteID.yml
+++ b/src/oss/paths/remotes_remoteID.yml
@@ -12,6 +12,7 @@ get:
       required: true
   responses:
     "200":
+      description: Retrieve a remote connection
       content:
         application/json:
           schema:

--- a/src/oss/paths/remotes_remoteID.yml
+++ b/src/oss/paths/remotes_remoteID.yml
@@ -12,7 +12,7 @@ get:
       required: true
   responses:
     "200":
-      description: Retrieve a remote connection
+      description: Remote connection
       content:
         application/json:
           schema:


### PR DESCRIPTION
The OpenAPI Specification defines the **description** of Response Object as a required field - https://swagger.io/specification/#response-object. 

The responses without description causes the fails of our client generator - https://app.circleci.com/pipelines/github/bonitoo-io/influxdb-clients-apigen/143/workflows/4f34b35f-a797-4774-8a30-e5fe3c809a63