### PR TITLE
feat: rename dryRun to validate, add to update endpoint for remotes

### DIFF
--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -1849,7 +1849,7 @@ paths:
       parameters:
         - $ref: '#/paths/~1ready/get/parameters/0'
         - in: query
-          name: dryRun
+          name: validate
           description: 'If true, validate the remote connection, but don''t save it.'
           schema:
             type: boolean
@@ -1862,7 +1862,7 @@ paths:
               $ref: '#/components/schemas/RemoteConnectionCreationRequest'
       responses:
         '201':
-          description: Remote connection validated and saved
+          description: Remote connection saved
           content:
             application/json:
               schema:
@@ -1870,7 +1870,6 @@ paths:
         '204':
           description: 'Remote connection validated, but not saved'
         '400':
-          description: Remote connection failed validation
           $ref: '#/components/responses/ServerError'
         default:
           $ref: '#/components/responses/ServerError'
@@ -1909,6 +1908,12 @@ paths:
           schema:
             type: string
           required: true
+        - in: query
+          name: validate
+          description: 'If true, validate the updated information, but don''t save it.'
+          schema:
+            type: boolean
+            default: false
       requestBody:
         required: true
         content:
@@ -1917,12 +1922,14 @@ paths:
               $ref: '#/components/schemas/RemoteConnectionUpdateRequest'
       responses:
         '200':
+          description: Updated information saved
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/RemoteConnection'
+        '204':
+          description: 'Updated connection validated, but not saved'
         '400':
-          description: Remote connection failed validation
           $ref: '#/components/responses/ServerError'
         '404':
           $ref: '#/components/responses/ServerError'

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -11466,7 +11466,7 @@
           },
           {
             "in": "query",
-            "name": "dryRun",
+            "name": "validate",
             "description": "If true, validate the remote connection, but don't save it.",
             "schema": {
               "type": "boolean",
@@ -11486,7 +11486,7 @@
         },
         "responses": {
           "201": {
-            "description": "Remote connection validated and saved",
+            "description": "Remote connection saved",
             "content": {
               "application/json": {
                 "schema": {
@@ -11499,7 +11499,6 @@
             "description": "Remote connection validated, but not saved"
           },
           "400": {
-            "description": "Remote connection failed validation",
             "$ref": "#/components/responses/ServerError"
           },
           "default": {
@@ -11563,6 +11562,15 @@
               "type": "string"
             },
             "required": true
+          },
+          {
+            "in": "query",
+            "name": "validate",
+            "description": "If true, validate the updated information, but don't save it.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
           }
         ],
         "requestBody": {
@@ -11577,6 +11585,7 @@
         },
         "responses": {
           "200": {
+            "description": "Updated information saved",
             "content": {
               "application/json": {
                 "schema": {
@@ -11585,8 +11594,10 @@
               }
             }
           },
+          "204": {
+            "description": "Updated connection validated, but not saved"
+          },
           "400": {
-            "description": "Remote connection failed validation",
             "$ref": "#/components/responses/ServerError"
           },
           "404": {

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -7005,7 +7005,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: query
-          name: dryRun
+          name: validate
           description: 'If true, validate the remote connection, but don''t save it.'
           schema:
             type: boolean
@@ -7018,7 +7018,7 @@ paths:
               $ref: '#/components/schemas/RemoteConnectionCreationRequest'
       responses:
         '201':
-          description: Remote connection validated and saved
+          description: Remote connection saved
           content:
             application/json:
               schema:
@@ -7026,7 +7026,6 @@ paths:
         '204':
           description: 'Remote connection validated, but not saved'
         '400':
-          description: Remote connection failed validation
           $ref: '#/components/responses/ServerError'
         default:
           $ref: '#/components/responses/ServerError'
@@ -7065,6 +7064,12 @@ paths:
           schema:
             type: string
           required: true
+        - in: query
+          name: validate
+          description: 'If true, validate the updated information, but don''t save it.'
+          schema:
+            type: boolean
+            default: false
       requestBody:
         required: true
         content:
@@ -7073,12 +7078,14 @@ paths:
               $ref: '#/components/schemas/RemoteConnectionUpdateRequest'
       responses:
         '200':
+          description: Updated information saved
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/RemoteConnection'
+        '204':
+          description: 'Updated connection validated, but not saved'
         '400':
-          description: Remote connection failed validation
           $ref: '#/components/responses/ServerError'
         '404':
           $ref: '#/components/responses/ServerError'

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -4139,7 +4139,7 @@ paths:
       - $ref: '#/components/parameters/TraceSpan'
       - description: If true, validate the remote connection, but don't save it.
         in: query
-        name: dryRun
+        name: validate
         schema:
           default: false
           type: boolean
@@ -4155,12 +4155,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RemoteConnection'
-          description: Remote connection validated and saved
+          description: Remote connection saved
         "204":
           description: Remote connection validated, but not saved
         "400":
           $ref: '#/components/responses/ServerError'
-          description: Remote connection failed validation
         default:
           $ref: '#/components/responses/ServerError'
       summary: Register a new remote connection
@@ -4217,6 +4216,12 @@ paths:
         required: true
         schema:
           type: string
+      - description: If true, validate the updated information, but don't save it.
+        in: query
+        name: validate
+        schema:
+          default: false
+          type: boolean
       requestBody:
         content:
           application/json:
@@ -4229,9 +4234,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RemoteConnection'
+          description: Updated information saved
+        "204":
+          description: Updated connection validated, but not saved
         "400":
           $ref: '#/components/responses/ServerError'
-          description: Remote connection failed validation
         "404":
           $ref: '#/components/responses/ServerError'
         default:

--- a/src/oss/paths/remotes.yml
+++ b/src/oss/paths/remotes.yml
@@ -39,7 +39,7 @@ post:
   parameters:
     - $ref: "../../common/parameters/TraceSpan.yml"
     - in: query
-      name: dryRun
+      name: validate
       description: If true, validate the remote connection, but don't save it.
       schema:
         type: boolean
@@ -54,13 +54,12 @@ post:
     "204":
       description: Remote connection validated, but not saved
     "201":
-      description: Remote connection validated and saved
+      description: Remote connection saved
       content:
         application/json:
           schema:
             $ref: "../schemas/RemoteConnection.yml"
     "400":
-      description: Remote connection failed validation
       $ref: "../../common/responses/ServerError.yml"
     default:
       $ref: "../../common/responses/ServerError.yml"

--- a/src/oss/paths/remotes_remoteID.yml
+++ b/src/oss/paths/remotes_remoteID.yml
@@ -33,6 +33,12 @@ patch:
       schema:
         type: string
       required: true
+    - in: query
+      name: validate
+      description: If true, validate the updated information, but don't save it.
+      schema:
+        type: boolean
+        default: false
   requestBody:
     required: true
     content:
@@ -40,7 +46,10 @@ patch:
         schema:
           $ref: "../schemas/RemoteConnectionUpdateRequest.yml"
   responses:
+    "204":
+      description: Updated connection validated, but not saved
     "200":
+      description: Updated information saved
       content:
         application/json:
           schema:
@@ -48,7 +57,6 @@ patch:
     "404":
       $ref: "../../common/responses/ServerError.yml"
     "400":
-      description: Remote connection failed validation
       $ref: "../../common/responses/ServerError.yml"
     default:
       $ref: "../../common/responses/ServerError.yml"


### PR DESCRIPTION
After stubbing out the server-side, some adjustments occurred to me that I think will make our lives (and users') easier:
* Instead of _always_ having the `POST`/create endpoint validate the connection info, make it an either-or:
  * `dryRun=true`: validate but don't save
  * `dryRun=false` (or missing): save without validating
* Add the same logic to the update-remote endpoint
* Rename `dryRun` to `validate` for clarity (`dryRun` gives the impression that the logic is 1:1 except for the final step of persisting the info to the DB)

I think the ability to save/update without validation will be useful when users are automating a full setup of an OSS instance, and the remote(s) get created before the other end is ready to receive connections (i.e. when connecting to another OSS instance being set up in parallel, or when setting up network egress rules to allow connections to cloud).