### PR TITLE
fix: keyword for minimal value

### DIFF
--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -3123,9 +3123,9 @@ components:
         remoteBucketID:
           type: string
         maxQueueSizeBytes:
-          type: int
+          type: integer
           format: int64
-          min: 33554430
+          minimum: 33554430
           default: 67108860
       required:
         - name
@@ -3146,9 +3146,9 @@ components:
         remoteBucketID:
           type: string
         maxQueueSizeBytes:
-          type: int
+          type: integer
           format: int64
-          min: 33554430
+          minimum: 33554430
   responses:
     ServerError:
       description: Non 2XX error response from server.

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -20689,9 +20689,9 @@
             "type": "string"
           },
           "maxQueueSizeBytes": {
-            "type": "int",
+            "type": "integer",
             "format": "int64",
-            "min": 33554430,
+            "minimum": 33554430,
             "default": 67108860
           }
         },
@@ -20720,9 +20720,9 @@
             "type": "string"
           },
           "maxQueueSizeBytes": {
-            "type": "int",
+            "type": "integer",
             "format": "int64",
-            "min": 33554430
+            "minimum": 33554430
           }
         }
       }

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -13202,9 +13202,9 @@ components:
         remoteBucketID:
           type: string
         maxQueueSizeBytes:
-          type: int
+          type: integer
           format: int64
-          min: 33554430
+          minimum: 33554430
           default: 67108860
       required:
         - name
@@ -13225,9 +13225,9 @@ components:
         remoteBucketID:
           type: string
         maxQueueSizeBytes:
-          type: int
+          type: integer
           format: int64
-          min: 33554430
+          minimum: 33554430
   responses:
     ServerError:
       description: Non 2XX error response from server.

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -10802,8 +10802,8 @@ components:
         maxQueueSizeBytes:
           default: 67108860
           format: int64
-          min: 33554430
-          type: int
+          minimum: 33554430
+          type: integer
         name:
           type: string
         orgID:
@@ -10826,8 +10826,8 @@ components:
           type: string
         maxQueueSizeBytes:
           format: int64
-          min: 33554430
-          type: int
+          minimum: 33554430
+          type: integer
         name:
           type: string
         remoteBucketID:

--- a/src/oss/schemas/ReplicationCreationRequest.yml
+++ b/src/oss/schemas/ReplicationCreationRequest.yml
@@ -13,9 +13,9 @@ properties:
   remoteBucketID:
     type: string
   maxQueueSizeBytes:
-    type: int
+    type: integer
     format: int64
-    min: 33554430 # 32 MiB
+    minimum: 33554430 # 32 MiB
     default: 67108860 # 64 MiB
 required:
   - name

--- a/src/oss/schemas/ReplicationUpdateRequest.yml
+++ b/src/oss/schemas/ReplicationUpdateRequest.yml
@@ -9,6 +9,6 @@ properties:
   remoteBucketID:
     type: string
   maxQueueSizeBytes:
-    type: int
+    type: integer
     format: int64
-    min: 33554430 # 32 MiB
+    minimum: 33554430 # 32 MiB


### PR DESCRIPTION
The keyword for minimal value is `minimum` - https://swagger.io/docs/specification/data-models/data-types/#range

![image](https://user-images.githubusercontent.com/455137/130558251-34bca166-7685-46ca-9326-0f4512a2af64.png)


This PR fix our generator - https://app.circleci.com/pipelines/github/bonitoo-io/influxdb-clients-apigen/151/workflows/98354d0f-d6fe-4986-be38-c972815473a8