### PR TITLE
feat: add OpenAPI validator to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,16 @@ jobs:
           environment:
             TCONTRACTS: '/tmp/contracts'
             CONTRACTS: '/root/project/contracts'
+  test-openapi:
+    docker:
+      - image: "openapitools/openapi-generator-cli"
+    steps:
+      - checkout
+      - run:
+          name: Ensure OpenAPI compatibility
+          command: sh /root/project/scripts/test-openapi.sh
+          environment:
+            CONTRACTS: '/root/project/contracts'
   lint-yamls:
     docker:
       - image: "cimg/base:2021.04"
@@ -46,4 +56,5 @@ workflows:
       - test-oats
       - test-contracts
       - test-reference-contracts
+      - test-openapi
       - lint-yamls

--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -292,11 +292,12 @@ paths:
         - DemoDataBuckets
       summary: List of Demo Data Buckets
       parameters:
-        - description: bucket id
         - in: path
           name: bucketID
+          required: true
           schema:
             type: string
+          description: bucket id
       responses:
         '200':
           description: if sampledata route is not available gateway responds with 200
@@ -309,16 +310,17 @@ paths:
               schema:
                 $ref: '#/components/responses/ServerError/content/application~1json/schema'
     delete:
-      operationId: GetDemoDataBucketMembers
+      operationId: DeleteDemoDataBucketMembers
       tags:
         - DemoDataBuckets
       summary: List of Demo Data Buckets
       parameters:
-        - description: bucket id
         - in: path
           name: bucketID
+          required: true
           schema:
             type: string
+          description: bucket id
       responses:
         '200':
           description: if sampledata route is not available gateway responds with 200

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -9171,14 +9171,13 @@
         "summary": "List of Demo Data Buckets",
         "parameters": [
           {
-            "description": "bucket id"
-          },
-          {
             "in": "path",
             "name": "bucketID",
+            "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "bucket id"
           }
         ],
         "responses": {
@@ -9201,21 +9200,20 @@
         }
       },
       "delete": {
-        "operationId": "GetDemoDataBucketMembers",
+        "operationId": "DeleteDemoDataBucketMembers",
         "tags": [
           "DemoDataBuckets"
         ],
         "summary": "List of Demo Data Buckets",
         "parameters": [
           {
-            "description": "bucket id"
-          },
-          {
             "in": "path",
             "name": "bucketID",
+            "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "bucket id"
           }
         ],
         "responses": {

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -5595,11 +5595,12 @@ paths:
         - DemoDataBuckets
       summary: List of Demo Data Buckets
       parameters:
-        - description: bucket id
         - in: path
           name: bucketID
+          required: true
           schema:
             type: string
+          description: bucket id
       responses:
         '200':
           description: if sampledata route is not available gateway responds with 200
@@ -5612,16 +5613,17 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
     delete:
-      operationId: GetDemoDataBucketMembers
+      operationId: DeleteDemoDataBucketMembers
       tags:
         - DemoDataBuckets
       summary: List of Demo Data Buckets
       parameters:
-        - description: bucket id
         - in: path
           name: bucketID
+          required: true
           schema:
             type: string
+          description: bucket id
       responses:
         '200':
           description: if sampledata route is not available gateway responds with 200

--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -3123,9 +3123,9 @@ components:
         remoteBucketID:
           type: string
         maxQueueSizeBytes:
-          type: int
+          type: integer
           format: int64
-          min: 33554430
+          minimum: 33554430
           default: 67108860
       required:
         - name
@@ -3146,9 +3146,9 @@ components:
         remoteBucketID:
           type: string
         maxQueueSizeBytes:
-          type: int
+          type: integer
           format: int64
-          min: 33554430
+          minimum: 33554430
   responses:
     ServerError:
       description: Non 2XX error response from server.

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -20689,9 +20689,9 @@
             "type": "string"
           },
           "maxQueueSizeBytes": {
-            "type": "int",
+            "type": "integer",
             "format": "int64",
-            "min": 33554430,
+            "minimum": 33554430,
             "default": 67108860
           }
         },
@@ -20720,9 +20720,9 @@
             "type": "string"
           },
           "maxQueueSizeBytes": {
-            "type": "int",
+            "type": "integer",
             "format": "int64",
-            "min": 33554430
+            "minimum": 33554430
           }
         }
       }

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -13202,9 +13202,9 @@ components:
         remoteBucketID:
           type: string
         maxQueueSizeBytes:
-          type: int
+          type: integer
           format: int64
-          min: 33554430
+          minimum: 33554430
           default: 67108860
       required:
         - name
@@ -13225,9 +13225,9 @@ components:
         remoteBucketID:
           type: string
         maxQueueSizeBytes:
-          type: int
+          type: integer
           format: int64
-          min: 33554430
+          minimum: 33554430
   responses:
     ServerError:
       description: Non 2XX error response from server.

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -2427,11 +2427,12 @@ paths:
       - DemoDataBuckets
   /api/v2/experimental/sampledata/buckets/{bucketID}/members:
     delete:
-      operationId: GetDemoDataBucketMembers
+      operationId: DeleteDemoDataBucketMembers
       parameters:
       - description: bucket id
-      - in: path
+        in: path
         name: bucketID
+        required: true
         schema:
           type: string
       responses:
@@ -2453,8 +2454,9 @@ paths:
       operationId: GetDemoDataBucketMembers
       parameters:
       - description: bucket id
-      - in: path
+        in: path
         name: bucketID
+        required: true
         schema:
           type: string
       responses:

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -10802,8 +10802,8 @@ components:
         maxQueueSizeBytes:
           default: 67108860
           format: int64
-          min: 33554430
-          type: int
+          minimum: 33554430
+          type: integer
         name:
           type: string
         orgID:
@@ -10826,8 +10826,8 @@ components:
           type: string
         maxQueueSizeBytes:
           format: int64
-          min: 33554430
-          type: int
+          minimum: 33554430
+          type: integer
         name:
           type: string
         remoteBucketID:

--- a/scripts/test-openapi.sh
+++ b/scripts/test-openapi.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+# How to run locally:
+#
+# docker run --rm -it -e CONTRACTS=/local/contracts -v "${PWD}:/local" openapitools/openapi-generator-cli /local/scripts/test-openapi.sh
+#
+
+CONTRACTS=${CONTRACTS:-openapi/contracts}
+
+/usr/local/bin/docker-entrypoint.sh validate -i "${CONTRACTS}/oss.yml"
+/usr/local/bin/docker-entrypoint.sh validate -i "${CONTRACTS}/cloud.yml"

--- a/src/cloud/paths/experimental_sampledata_buckets_members.yml
+++ b/src/cloud/paths/experimental_sampledata_buckets_members.yml
@@ -4,11 +4,12 @@ post:
     - DemoDataBuckets
   summary: List of Demo Data Buckets
   parameters:
-    - description: bucket id
     - in: path
       name: bucketID
+      required: true
       schema:
         type: string
+      description: bucket id
   responses:
     '204':
       description: A list of demo data buckets
@@ -21,16 +22,17 @@ post:
           schema:
             $ref: '../../common/schemas/Error.yml'
 delete:
-  operationId: GetDemoDataBucketMembers
+  operationId: DeleteDemoDataBucketMembers
   tags:
     - DemoDataBuckets
   summary: List of Demo Data Buckets
   parameters:
-    - description: bucket id
     - in: path
       name: bucketID
+      required: true
       schema:
         type: string
+      description: bucket id
   responses:
     '204':
       description: A list of demo data buckets

--- a/src/oss/schemas/ReplicationCreationRequest.yml
+++ b/src/oss/schemas/ReplicationCreationRequest.yml
@@ -13,9 +13,9 @@ properties:
   remoteBucketID:
     type: string
   maxQueueSizeBytes:
-    type: int
+    type: integer
     format: int64
-    min: 33554430 # 32 MiB
+    minimum: 33554430 # 32 MiB
     default: 67108860 # 64 MiB
 required:
   - name

--- a/src/oss/schemas/ReplicationUpdateRequest.yml
+++ b/src/oss/schemas/ReplicationUpdateRequest.yml
@@ -9,6 +9,6 @@ properties:
   remoteBucketID:
     type: string
   maxQueueSizeBytes:
-    type: int
+    type: integer
     format: int64
-    min: 33554430 # 32 MiB
+    minimum: 33554430 # 32 MiB


### PR DESCRIPTION
Add CircleCi check to [validate](https://openapi-generator.tech/docs/usage/#validate) `oss.yml` and `cloud.yml` specification by `openapi-generator-cli`. This CircleCI check ensures that the `oss.yml` and `cloud.yml` can be used for openapi-generator.