### PR TITLE
chore(GetBackupKV): improve doc of GetBackupKV

### DIFF
--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -1508,7 +1508,7 @@ paths:
       operationId: GetBackupKV
       tags:
         - Backup
-      summary: 'Download snapshot of metadata stored in the server''s embedded KV store. Should not be used in versions > 2.1.x, as it doesn''t include metadata stored in embedded SQL.'
+      summary: 'Download snapshot of metadata stored in the server''s embedded KV store. Should not be used in versions greater than 2.1.x, as it doesn''t include metadata stored in embedded SQL.'
       deprecated: true
       parameters:
         - $ref: '#/paths/~1ready/get/parameters/0'

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -10934,7 +10934,7 @@
         "tags": [
           "Backup"
         ],
-        "summary": "Download snapshot of metadata stored in the server's embedded KV store. Should not be used in versions > 2.1.x, as it doesn't include metadata stored in embedded SQL.",
+        "summary": "Download snapshot of metadata stored in the server's embedded KV store. Should not be used in versions greater than 2.1.x, as it doesn't include metadata stored in embedded SQL.",
         "deprecated": true,
         "parameters": [
           {

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -6664,7 +6664,7 @@ paths:
       operationId: GetBackupKV
       tags:
         - Backup
-      summary: 'Download snapshot of metadata stored in the server''s embedded KV store. Should not be used in versions > 2.1.x, as it doesn''t include metadata stored in embedded SQL.'
+      summary: 'Download snapshot of metadata stored in the server''s embedded KV store. Should not be used in versions greater than 2.1.x, as it doesn''t include metadata stored in embedded SQL.'
       deprecated: true
       parameters:
         - $ref: '#/components/parameters/TraceSpan'

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -175,8 +175,8 @@ paths:
           $ref: '#/components/responses/ServerError'
           description: Unexpected error
       summary: Download snapshot of metadata stored in the server's embedded KV store.
-        Should not be used in versions > 2.1.x, as it doesn't include metadata stored
-        in embedded SQL.
+        Should not be used in versions greater than 2.1.x, as it doesn't include metadata
+        stored in embedded SQL.
       tags:
       - Backup
   /api/v2/backup/metadata:

--- a/src/oss/paths/backup_kv.yml
+++ b/src/oss/paths/backup_kv.yml
@@ -4,7 +4,7 @@ get:
     - Backup
   summary: >-
     Download snapshot of metadata stored in the server's embedded KV store. Should not be
-    used in versions > 2.1.x, as it doesn't include metadata stored in embedded SQL.
+    used in versions greater than 2.1.x, as it doesn't include metadata stored in embedded SQL.
   deprecated: true
   parameters:
     - $ref: "../../common/parameters/TraceSpan.yml"


### PR DESCRIPTION
This PR improves the `GetBackupKV` operation description so that a generated typescript code pass linter checks without this complaint: 

```
/packages/apis/src/generated/BackupAPI.ts
  28:109  warning  tsdoc-escape-greater-than: The ">" character should be escaped using a backslash to avoid confusion with an HTML tag  tsdoc/syntax
```

The issue could be possibly fixed in the typescript code generator, but this simple PR will serve the needs in a much easier way pls.