### PR TITLE
fix: correct type for integer

### DIFF
--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -3085,13 +3085,13 @@ components:
         remoteBucketID:
           type: string
         maxQueueSizeBytes:
-          type: int
+          type: integer
           format: int64
         currentQueueSizeBytes:
-          type: int
+          type: integer
           format: int64
         latestResponseCode:
-          type: int
+          type: integer
         latestErrorMessage:
           type: string
       required:

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -20635,15 +20635,15 @@
             "type": "string"
           },
           "maxQueueSizeBytes": {
-            "type": "int",
+            "type": "integer",
             "format": "int64"
           },
           "currentQueueSizeBytes": {
-            "type": "int",
+            "type": "integer",
             "format": "int64"
           },
           "latestResponseCode": {
-            "type": "int"
+            "type": "integer"
           },
           "latestErrorMessage": {
             "type": "string"

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -13164,13 +13164,13 @@ components:
         remoteBucketID:
           type: string
         maxQueueSizeBytes:
-          type: int
+          type: integer
           format: int64
         currentQueueSizeBytes:
-          type: int
+          type: integer
           format: int64
         latestResponseCode:
-          type: int
+          type: integer
         latestErrorMessage:
           type: string
       required:

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -10764,7 +10764,7 @@ components:
       properties:
         currentQueueSizeBytes:
           format: int64
-          type: int
+          type: integer
         description:
           type: string
         id:
@@ -10772,12 +10772,12 @@ components:
         latestErrorMessage:
           type: string
         latestResponseCode:
-          type: int
+          type: integer
         localBucketID:
           type: string
         maxQueueSizeBytes:
           format: int64
-          type: int
+          type: integer
         name:
           type: string
         orgID:

--- a/src/oss/schemas/Replication.yml
+++ b/src/oss/schemas/Replication.yml
@@ -15,13 +15,13 @@ properties:
   remoteBucketID:
     type: string
   maxQueueSizeBytes:
-    type: int
+    type: integer
     format: int64
   currentQueueSizeBytes:
-    type: int
+    type: integer
     format: int64
   latestResponseCode:
-    type: int
+    type: integer
   latestErrorMessage:
     type: string
 required:


### PR DESCRIPTION
The type for int number should be `integer` for minimal value is `minimum` - https://swagger.io/docs/specification/data-models/data-types/#numbers

![image](https://user-images.githubusercontent.com/455137/130726627-7e2b05a5-dd95-49f5-838d-62bd6208d76c.png)
