### PR TITLE
fix: enum declaration for SimpleTable's type

### DIFF
--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -1612,7 +1612,7 @@ paths:
                                             type:
                                               type: string
                                               enum:
-                                                - - simple-table
+                                                - simple-table
                                             showAll:
                                               type: boolean
                                             queries:

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -14936,9 +14936,7 @@
           "type": {
             "type": "string",
             "enum": [
-              [
-                "simple-table"
-              ]
+              "simple-table"
             ]
           },
           "showAll": {

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -9491,7 +9491,7 @@ components:
         type:
           type: string
           enum:
-            - - simple-table
+            - simple-table
         showAll:
           type: boolean
         queries:

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -8457,7 +8457,7 @@ components:
         type:
           type: string
           enum:
-            - - simple-table
+            - simple-table
         showAll:
           type: boolean
         queries:

--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -2889,7 +2889,7 @@ paths:
                                             type:
                                               type: string
                                               enum:
-                                                - - simple-table
+                                                - simple-table
                                             showAll:
                                               type: boolean
                                             queries:

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -16804,9 +16804,7 @@
           "type": {
             "type": "string",
             "enum": [
-              [
-                "simple-table"
-              ]
+              "simple-table"
             ]
           },
           "showAll": {

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -10613,7 +10613,7 @@ components:
         type:
           type: string
           enum:
-            - - simple-table
+            - simple-table
         showAll:
           type: boolean
         queries:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -11837,7 +11837,7 @@ components:
           type: boolean
         type:
           enum:
-          - - simple-table
+          - simple-table
           type: string
       required:
       - type

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -11485,7 +11485,7 @@ components:
           type: boolean
         type:
           enum:
-          - - simple-table
+          - simple-table
           type: string
       required:
       - type

--- a/src/common/schemas/SimpleTableViewProperties.yml
+++ b/src/common/schemas/SimpleTableViewProperties.yml
@@ -9,8 +9,7 @@
   properties:
     type:
       type: string
-      enum:
-        - [simple-table]
+      enum: [simple-table]
     showAll:
       type: boolean
     queries:


### PR DESCRIPTION
It the enum is declared as an array then should be without new line.

![image](https://user-images.githubusercontent.com/455137/130903292-f28f86d4-d380-410f-8dc2-88546f6bb1f2.png)
