### PR TITLE
feat: restore kv responds with new token after metadata update

### DIFF
--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -1644,6 +1644,16 @@ paths:
               type: string
               format: binary
       responses:
+        '200':
+          description: KV store successfully overwritten.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token:
+                    description: token is the root token for the instance after restore (this is overwritten during the restore)
+                    type: string
         '204':
           description: KV store successfully overwritten.
         default:

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -10867,6 +10867,22 @@
           }
         },
         "responses": {
+          "200": {
+            "description": "KV store successfully overwritten.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "token": {
+                      "description": "token is the root token for the instance after restore (this is overwritten during the restore)",
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
           "204": {
             "description": "KV store successfully overwritten."
           },

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -6636,6 +6636,16 @@ paths:
               type: string
               format: binary
       responses:
+        '200':
+          description: KV store successfully overwritten.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token:
+                    description: token is the root token for the instance after restore (this is overwritten during the restore)
+                    type: string
         '204':
           description: KV store successfully overwritten.
         default:

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -4563,6 +4563,17 @@ paths:
         description: Full KV snapshot.
         required: true
       responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                properties:
+                  token:
+                    description: token is the root token for the instance after restore
+                      (this is overwritten during the restore)
+                    type: string
+                type: object
+          description: KV store successfully overwritten.
         "204":
           description: KV store successfully overwritten.
         default:

--- a/src/oss/paths/restore_kv.yml
+++ b/src/oss/paths/restore_kv.yml
@@ -34,6 +34,13 @@ post:
   responses:
     "204":
       description: KV store successfully overwritten.
+    "200":
+      # when application/json is specified, we get json back
+      description: KV store successfully overwritten.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/PostRestoreKVResponse.yml'
     default:
       description: Unexpected error
       $ref: '../../common/responses/ServerError.yml'

--- a/src/oss/schemas/PostRestoreKVResponse.yml
+++ b/src/oss/schemas/PostRestoreKVResponse.yml
@@ -1,0 +1,5 @@
+type: object
+properties:
+  token:
+    description: token is the root token for the instance after restore (this is overwritten during the restore)
+    type: string


### PR DESCRIPTION
During a full metadata update, the operator token used to access the database changes (it is part of the metadata). To handle this properly, we need to know the new token value after a successful restore.

See https://github.com/influxdata/influxdb/issues/20749 .