### PR TITLE
fix: remove conflicting endpoint

### DIFF
--- a/contracts/priv/notebooksd.yml
+++ b/contracts/priv/notebooksd.yml
@@ -196,30 +196,6 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
   '/notebooks/share/{id}':
-    get:
-      summary: get single Share by its ID
-      operationId: getShare
-      tags:
-        - Share
-      parameters:
-        - name: id
-          in: path
-          schema:
-            type: string
-          required: true
-      responses:
-        '200':
-          description: returns the Share record
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Share'
-        '400':
-          $ref: '#/components/responses/ServerError'
-        '401':
-          $ref: '#/components/responses/ServerError'
-        '500':
-          $ref: '#/components/responses/ServerError'
     delete:
       summary: deletes a single Share by its ID
       operationId: deleteShare

--- a/contracts/svc/notebooksd.yml
+++ b/contracts/svc/notebooksd.yml
@@ -196,30 +196,6 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
   '/notebooks/share/{id}':
-    get:
-      summary: get single Share by its ID
-      operationId: getShare
-      tags:
-        - Share
-      parameters:
-        - name: id
-          in: path
-          schema:
-            type: string
-          required: true
-      responses:
-        '200':
-          description: returns the Share record
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Share'
-        '400':
-          $ref: '#/components/responses/ServerError'
-        '401':
-          $ref: '#/components/responses/ServerError'
-        '500':
-          $ref: '#/components/responses/ServerError'
     delete:
       summary: deletes a single Share by its ID
       operationId: deleteShare

--- a/src/svc/notebooksd/paths/notebooks_share_id.yml
+++ b/src/svc/notebooksd/paths/notebooks_share_id.yml
@@ -1,27 +1,3 @@
-get:
-  summary: get single Share by its ID
-  operationId: getShare
-  tags:
-    - Share
-  parameters:
-    - name: id
-      in: path
-      schema:
-        type: string
-      required: true
-  responses:
-    '200':
-      description: returns the Share record
-      content:
-        application/json:
-          schema:
-            $ref: '../schemas/Share.yml'
-    '400':
-      $ref: '../../../common/responses/ServerError.yml'
-    '401':
-      $ref: '../../../common/responses/ServerError.yml'
-    '500':
-      $ref: '../../../common/responses/ServerError.yml'
 delete:
   summary: deletes a single Share by its ID
   operationId: deleteShare


### PR DESCRIPTION
Oats was generating `getNotebooksShare` fn for two different endpoints. We don't actively use this one, so I'm removing it for now so it doesn't block integration. 