### PR TITLE
fix: correct names used in replications API

### DIFF
--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -5193,8 +5193,8 @@ components:
         - name
         - orgID
         - remoteID
-        - sourceBucketID
-        - targetBucketID
+        - localBucketID
+        - remoteBucketID
         - maxQueueSizeBytes
     ReplicationUpdateRequest:
       type: object

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -20883,8 +20883,8 @@
           "name",
           "orgID",
           "remoteID",
-          "sourceBucketID",
-          "targetBucketID",
+          "localBucketID",
+          "remoteBucketID",
           "maxQueueSizeBytes"
         ]
       },

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -13374,8 +13374,8 @@ components:
         - name
         - orgID
         - remoteID
-        - sourceBucketID
-        - targetBucketID
+        - localBucketID
+        - remoteBucketID
         - maxQueueSizeBytes
     ReplicationUpdateRequest:
       type: object

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -10875,8 +10875,8 @@ components:
       - name
       - orgID
       - remoteID
-      - sourceBucketID
-      - targetBucketID
+      - localBucketID
+      - remoteBucketID
       - maxQueueSizeBytes
       type: object
     ReplicationUpdateRequest:

--- a/src/oss/schemas/ReplicationCreationRequest.yml
+++ b/src/oss/schemas/ReplicationCreationRequest.yml
@@ -21,6 +21,6 @@ required:
   - name
   - orgID
   - remoteID
-  - sourceBucketID
-  - targetBucketID
+  - localBucketID
+  - remoteBucketID
   - maxQueueSizeBytes


### PR DESCRIPTION
The names used in the `required` field of the replication-creation schema didn't match the rest of the schema