### PR TITLE
fix: use empty string for OSS root-path server URL

### DIFF
--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -205,7 +205,7 @@
         "summary": "Checks the status of InfluxDB instance and version of InfluxDB.",
         "servers": [
           {
-            "url": "/"
+            "url": ""
           }
         ],
         "tags": [
@@ -236,7 +236,7 @@
         "summary": "Checks the status of InfluxDB instance and version of InfluxDB.",
         "servers": [
           {
-            "url": "/"
+            "url": ""
           }
         ],
         "tags": [

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -141,7 +141,7 @@ paths:
       operationId: GetPing
       summary: Checks the status of InfluxDB instance and version of InfluxDB.
       servers:
-        - url: /
+        - url: ''
       tags:
         - Ping
       responses:
@@ -160,7 +160,7 @@ paths:
       operationId: HeadPing
       summary: Checks the status of InfluxDB instance and version of InfluxDB.
       servers:
-        - url: /
+        - url: ''
       tags:
         - Ping
       responses:

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -66,7 +66,7 @@ paths:
       operationId: GetPing
       summary: Checks the status of InfluxDB instance and version of InfluxDB.
       servers:
-        - url: /
+        - url: ''
       tags:
         - Ping
       responses:
@@ -85,7 +85,7 @@ paths:
       operationId: HeadPing
       summary: Checks the status of InfluxDB instance and version of InfluxDB.
       servers:
-        - url: /
+        - url: ''
       tags:
         - Ping
       responses:

--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -91,7 +91,7 @@ paths:
         - Health
       summary: Get the health of an instance
       servers:
-        - url: /
+        - url: ''
       parameters:
         - $ref: '#/paths/~1ready/get/parameters/0'
       responses:
@@ -138,7 +138,7 @@ paths:
         - Ready
       summary: Get the readiness of an instance at startup
       servers:
-        - url: /
+        - url: ''
       parameters:
         - in: header
           name: Zap-Trace-Span

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -209,7 +209,7 @@
         "summary": "Checks the status of InfluxDB instance and version of InfluxDB.",
         "servers": [
           {
-            "url": "/"
+            "url": ""
           }
         ],
         "tags": [
@@ -240,7 +240,7 @@
         "summary": "Checks the status of InfluxDB instance and version of InfluxDB.",
         "servers": [
           {
-            "url": "/"
+            "url": ""
           }
         ],
         "tags": [
@@ -8574,7 +8574,7 @@
         "summary": "Get the health of an instance",
         "servers": [
           {
-            "url": "/"
+            "url": ""
           }
         ],
         "parameters": [
@@ -8619,7 +8619,7 @@
         "summary": "Get the readiness of an instance at startup",
         "servers": [
           {
-            "url": "/"
+            "url": ""
           }
         ],
         "parameters": [

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -145,7 +145,7 @@ paths:
       operationId: GetPing
       summary: Checks the status of InfluxDB instance and version of InfluxDB.
       servers:
-        - url: /
+        - url: ''
       tags:
         - Ping
       responses:
@@ -164,7 +164,7 @@ paths:
       operationId: HeadPing
       summary: Checks the status of InfluxDB instance and version of InfluxDB.
       servers:
-        - url: /
+        - url: ''
       tags:
         - Ping
       responses:
@@ -5277,7 +5277,7 @@ paths:
         - Health
       summary: Get the health of an instance
       servers:
-        - url: /
+        - url: ''
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
       responses:
@@ -5303,7 +5303,7 @@ paths:
         - Ready
       summary: Get the readiness of an instance at startup
       servers:
-        - url: /
+        - url: ''
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
       responses:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -3888,7 +3888,7 @@ paths:
               schema:
                 type: integer
       servers:
-      - url: /
+      - url: ""
       summary: Checks the status of InfluxDB instance and version of InfluxDB.
       tags:
       - Ping
@@ -3907,7 +3907,7 @@ paths:
               schema:
                 type: integer
       servers:
-      - url: /
+      - url: ""
       summary: Checks the status of InfluxDB instance and version of InfluxDB.
       tags:
       - Ping

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -2352,7 +2352,7 @@ paths:
           $ref: '#/components/responses/ServerError'
           description: Unexpected error
       servers:
-      - url: /
+      - url: ""
       summary: Get the health of an instance
       tags:
       - Health
@@ -3840,7 +3840,7 @@ paths:
               schema:
                 type: integer
       servers:
-      - url: /
+      - url: ""
       summary: Checks the status of InfluxDB instance and version of InfluxDB.
       tags:
       - Ping
@@ -3859,7 +3859,7 @@ paths:
               schema:
                 type: integer
       servers:
-      - url: /
+      - url: ""
       summary: Checks the status of InfluxDB instance and version of InfluxDB.
       tags:
       - Ping
@@ -4114,7 +4114,7 @@ paths:
           $ref: '#/components/responses/ServerError'
           description: Unexpected error
       servers:
-      - url: /
+      - url: ""
       summary: Get the readiness of an instance at startup
       tags:
       - Ready

--- a/src/common/paths/ping.yml
+++ b/src/common/paths/ping.yml
@@ -2,7 +2,7 @@ get:
   operationId: GetPing
   summary: Checks the status of InfluxDB instance and version of InfluxDB.
   servers:
-    - url: '/'
+    - url: ''
   tags:
     - Ping
   responses:
@@ -21,7 +21,7 @@ head:
   operationId: HeadPing
   summary: Checks the status of InfluxDB instance and version of InfluxDB.
   servers:
-    - url: '/'
+    - url: ''
   tags:
     - Ping
   responses:

--- a/src/oss/paths/health.yml
+++ b/src/oss/paths/health.yml
@@ -4,7 +4,7 @@ get:
     - Health
   summary: Get the health of an instance
   servers:
-    - url: '/'
+    - url: ''
   parameters:
     - $ref: "../../common/parameters/TraceSpan.yml"
   responses:

--- a/src/oss/paths/ready.yml
+++ b/src/oss/paths/ready.yml
@@ -4,7 +4,7 @@ get:
     - Ready
   summary: Get the readiness of an instance at startup
   servers:
-    - url: '/'
+    - url: ''
   parameters:
     - $ref: "../../common/parameters/TraceSpan.yml"
   responses:


### PR DESCRIPTION
Using `/` causes codegen'd clients to generate routes like `//health`. Empty string generates the right thing.