### PR TITLE
fix: Add orgID and bucketID properties to the MeasurementSchema entity

### DIFF
--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -3647,6 +3647,8 @@ components:
       type: object
       example:
         id: 1a3c5e7f9b0a8642
+        orgID: 0a3c5e7f9b0a0001
+        bucketID: ba3c5e7f9b0a0010
         name: cpu
         columns:
           - name: time
@@ -3673,6 +3675,12 @@ components:
         id:
           type: string
           readOnly: true
+        orgID:
+          type: string
+          description: ID of organization that the measurement schema is associated with.
+        bucketID:
+          type: string
+          description: ID of the bucket that the measurement schema is associated with.
         name:
           type: string
           nullable: false
@@ -3739,14 +3747,20 @@ components:
       example:
         measurementSchemas:
           - id: 1a3c5e7f9b0a8642
+            orgID: 0a3c5e7f9b0a0001
+            bucketID: ba3c5e7f9b0a0010
             name: cpu
             createdAt: '2021-01-21T00:48:40.993Z'
             updatedAt: '2021-01-21T00:48:40.993Z'
           - id: 1a3c5e7f9b0a8643
+            orgID: 0a3c5e7f9b0a0001
+            bucketID: ba3c5e7f9b0a0010
             name: memory
             createdAt: '2021-01-21T00:48:40.993Z'
             updatedAt: '2021-01-21T00:48:40.993Z'
           - id: 1a3c5e7f9b0a8644
+            orgID: 0a3c5e7f9b0a0001
+            bucketID: ba3c5e7f9b0a0010
             name: disk
             createdAt: '2021-01-21T00:48:40.993Z'
             updatedAt: '2021-01-21T00:48:40.993Z'

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -18560,6 +18560,8 @@
         "type": "object",
         "example": {
           "id": "1a3c5e7f9b0a8642",
+          "orgID": "0a3c5e7f9b0a0001",
+          "bucketID": "ba3c5e7f9b0a0010",
           "name": "cpu",
           "columns": [
             {
@@ -18599,6 +18601,14 @@
           "id": {
             "type": "string",
             "readOnly": true
+          },
+          "orgID": {
+            "type": "string",
+            "description": "ID of organization that the measurement schema is associated with."
+          },
+          "bucketID": {
+            "type": "string",
+            "description": "ID of the bucket that the measurement schema is associated with."
           },
           "name": {
             "type": "string",
@@ -18699,18 +18709,24 @@
           "measurementSchemas": [
             {
               "id": "1a3c5e7f9b0a8642",
+              "orgID": "0a3c5e7f9b0a0001",
+              "bucketID": "ba3c5e7f9b0a0010",
               "name": "cpu",
               "createdAt": "2021-01-21T00:48:40.993Z",
               "updatedAt": "2021-01-21T00:48:40.993Z"
             },
             {
               "id": "1a3c5e7f9b0a8643",
+              "orgID": "0a3c5e7f9b0a0001",
+              "bucketID": "ba3c5e7f9b0a0010",
               "name": "memory",
               "createdAt": "2021-01-21T00:48:40.993Z",
               "updatedAt": "2021-01-21T00:48:40.993Z"
             },
             {
               "id": "1a3c5e7f9b0a8644",
+              "orgID": "0a3c5e7f9b0a0001",
+              "bucketID": "ba3c5e7f9b0a0010",
               "name": "disk",
               "createdAt": "2021-01-21T00:48:40.993Z",
               "updatedAt": "2021-01-21T00:48:40.993Z"

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -11944,6 +11944,8 @@ components:
       type: object
       example:
         id: 1a3c5e7f9b0a8642
+        orgID: 0a3c5e7f9b0a0001
+        bucketID: ba3c5e7f9b0a0010
         name: cpu
         columns:
           - name: time
@@ -11970,6 +11972,12 @@ components:
         id:
           type: string
           readOnly: true
+        orgID:
+          type: string
+          description: ID of organization that the measurement schema is associated with.
+        bucketID:
+          type: string
+          description: ID of the bucket that the measurement schema is associated with.
         name:
           type: string
           nullable: false
@@ -12036,14 +12044,20 @@ components:
       example:
         measurementSchemas:
           - id: 1a3c5e7f9b0a8642
+            orgID: 0a3c5e7f9b0a0001
+            bucketID: ba3c5e7f9b0a0010
             name: cpu
             createdAt: '2021-01-21T00:48:40.993Z'
             updatedAt: '2021-01-21T00:48:40.993Z'
           - id: 1a3c5e7f9b0a8643
+            orgID: 0a3c5e7f9b0a0001
+            bucketID: ba3c5e7f9b0a0010
             name: memory
             createdAt: '2021-01-21T00:48:40.993Z'
             updatedAt: '2021-01-21T00:48:40.993Z'
           - id: 1a3c5e7f9b0a8644
+            orgID: 0a3c5e7f9b0a0001
+            bucketID: ba3c5e7f9b0a0010
             name: disk
             createdAt: '2021-01-21T00:48:40.993Z'
             updatedAt: '2021-01-21T00:48:40.993Z'

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -10103,6 +10103,7 @@ components:
     MeasurementSchema:
       description: The schema definition for a single measurement
       example:
+        bucketID: ba3c5e7f9b0a0010
         columns:
         - name: time
           type: timestamp
@@ -10119,8 +10120,13 @@ components:
         createdAt: "2021-01-21T00:48:40.993Z"
         id: 1a3c5e7f9b0a8642
         name: cpu
+        orgID: 0a3c5e7f9b0a0001
         updatedAt: "2021-01-21T00:48:40.993Z"
       properties:
+        bucketID:
+          description: ID of the bucket that the measurement schema is associated
+            with.
+          type: string
         columns:
           description: An ordered collection of column definitions
           items:
@@ -10135,6 +10141,10 @@ components:
           type: string
         name:
           nullable: false
+          type: string
+        orgID:
+          description: ID of organization that the measurement schema is associated
+            with.
           type: string
         updatedAt:
           format: date-time
@@ -10196,17 +10206,23 @@ components:
       description: A list of measurement schemas returning summary information
       example:
         measurementSchemas:
-        - createdAt: "2021-01-21T00:48:40.993Z"
+        - bucketID: ba3c5e7f9b0a0010
+          createdAt: "2021-01-21T00:48:40.993Z"
           id: 1a3c5e7f9b0a8642
           name: cpu
+          orgID: 0a3c5e7f9b0a0001
           updatedAt: "2021-01-21T00:48:40.993Z"
-        - createdAt: "2021-01-21T00:48:40.993Z"
+        - bucketID: ba3c5e7f9b0a0010
+          createdAt: "2021-01-21T00:48:40.993Z"
           id: 1a3c5e7f9b0a8643
           name: memory
+          orgID: 0a3c5e7f9b0a0001
           updatedAt: "2021-01-21T00:48:40.993Z"
-        - createdAt: "2021-01-21T00:48:40.993Z"
+        - bucketID: ba3c5e7f9b0a0010
+          createdAt: "2021-01-21T00:48:40.993Z"
           id: 1a3c5e7f9b0a8644
           name: disk
+          orgID: 0a3c5e7f9b0a0001
           updatedAt: "2021-01-21T00:48:40.993Z"
       properties:
         measurementSchemas:

--- a/src/cloud/schemas/MeasurementSchema.yml
+++ b/src/cloud/schemas/MeasurementSchema.yml
@@ -2,6 +2,8 @@
   type: object
   example:
     id: 1a3c5e7f9b0a8642
+    orgID: 0a3c5e7f9b0a0001
+    bucketID: ba3c5e7f9b0a0010
     name: cpu
     columns:
       - name: time
@@ -23,6 +25,12 @@
     id:
       type: string
       readOnly: true
+    orgID:
+      type: string
+      description: ID of organization that the measurement schema is associated with.
+    bucketID:
+      type: string
+      description: ID of the bucket that the measurement schema is associated with.
     name:
       type: string
       nullable: false

--- a/src/cloud/schemas/MeasurementSchemaList.yml
+++ b/src/cloud/schemas/MeasurementSchemaList.yml
@@ -2,14 +2,20 @@
   example:
     measurementSchemas:
       - id: 1a3c5e7f9b0a8642
+        orgID: 0a3c5e7f9b0a0001
+        bucketID: ba3c5e7f9b0a0010
         name: cpu
         createdAt: "2021-01-21T00:48:40.993Z"
         updatedAt: "2021-01-21T00:48:40.993Z"
       - id: 1a3c5e7f9b0a8643
+        orgID: 0a3c5e7f9b0a0001
+        bucketID: ba3c5e7f9b0a0010
         name: memory
         createdAt: "2021-01-21T00:48:40.993Z"
         updatedAt: "2021-01-21T00:48:40.993Z"
       - id: 1a3c5e7f9b0a8644
+        orgID: 0a3c5e7f9b0a0001
+        bucketID: ba3c5e7f9b0a0010
         name: disk
         createdAt: "2021-01-21T00:48:40.993Z"
         updatedAt: "2021-01-21T00:48:40.993Z"


### PR DESCRIPTION
This PR amends the `MeasurementSchema` entity to add the following properties:

* `orgID`,
* `bucketID`

NOTE that the Cloud 2.0 API already returns these values and therefore this PR is ensuring the public API and the spec agree.