### PR TITLE
fix: managed function has `/api/v2` prefix

### DIFF
--- a/contracts/managed-functions.yml
+++ b/contracts/managed-functions.yml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  title: Influxdata Managed Functions CRUD API
+  title: InfluxData Managed Functions CRUD API
   version: 0.1.0
 servers:
   - url: /api/v2

--- a/contracts/svc/managed-functions.yml
+++ b/contracts/svc/managed-functions.yml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  title: Influxdata Managed Functions CRUD API
+  title: InfluxData Managed Functions CRUD API
   version: 0.1.0
 servers:
   - url: /api/v2

--- a/contracts/svc/managed-functions.yml
+++ b/contracts/svc/managed-functions.yml
@@ -3,7 +3,7 @@ info:
   title: Influxdata Managed Functions CRUD API
   version: 0.1.0
 servers:
-  - url: /
+  - url: /api/v2
 paths:
   /functions:
     get:

--- a/src/svc-managed-functions.yml
+++ b/src/svc-managed-functions.yml
@@ -1,6 +1,6 @@
 openapi: '3.0.0'
 info:
-  title: Influxdata Managed Functions CRUD API
+  title: InfluxData Managed Functions CRUD API
   version: 0.1.0
 servers:
   - url: '/api/v2'

--- a/src/svc-managed-functions.yml
+++ b/src/svc-managed-functions.yml
@@ -3,7 +3,7 @@ info:
   title: Influxdata Managed Functions CRUD API
   version: 0.1.0
 servers:
-  - url: '/'
+  - url: '/api/v2'
 paths:
   '/functions':
     $ref: './svc/managed-functions/paths/functions.yml'

--- a/src/svc-managed-functions.yml
+++ b/src/svc-managed-functions.yml
@@ -3,7 +3,7 @@ info:
   title: InfluxData Managed Functions CRUD API
   version: 0.1.0
 servers:
-  - url: '/api/v2'
+  - url: '/'
 paths:
   '/functions':
     $ref: './svc/managed-functions/paths/functions.yml'


### PR DESCRIPTION
The managed functions has to have `/api/v2`. Try to:

```
curl -v -X GET 'https://us-west1-1.gcp.cloud2.influxdata.com/api/v2/functions'  --header Authorization <some_token> -H 'accept: application/json'
```

vs

```
curl -v -X GET 'https://us-west1-1.gcp.cloud2.influxdata.com/functions'  --header Authorization <some_token> -H 'accept: application/json'
```