### PR TITLE
feat: add payg credit boolean

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -1381,6 +1381,9 @@ components:
         isNotify:
           description: whether the user will be notified about their balance
           type: boolean
+        isPaygCreditActive:
+          description: whether the user is a part of the payg credit
+          type: boolean
     Invite:
       properties:
         id:

--- a/src/unity/schemas/CheckoutRequest.yml
+++ b/src/unity/schemas/CheckoutRequest.yml
@@ -29,3 +29,6 @@ properties:
   isNotify:
     description: whether the user will be notified about their balance
     type: boolean
+  isPaygCreditActive:
+    description: whether the user is a part of the payg credit
+    type: boolean


### PR DESCRIPTION
Adds payg credit boolean to respond back after checkout succeeds so quartz can add data in the quartz DB for credit tracking. 