### PR TITLE
feat: add 429 to org invites

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -530,6 +530,9 @@ paths:
         '422':
           description: Missing information
           $ref: '#/components/responses/ServerError'
+        '429':
+          description: Too many requests
+          $ref: '#/components/responses/ServerError'
         default:
           description: Unexpected error
           $ref: '#/components/responses/ServerError'

--- a/src/unity/paths/orgs_orgId_invites.yml
+++ b/src/unity/paths/orgs_orgId_invites.yml
@@ -69,3 +69,6 @@ post:
     default:
       description: Unexpected error
       $ref: '../../common/responses/ServerError.yml'
+    '429':
+      description: Too many requests
+      $ref: '../../common/responses/ServerError.yml'


### PR DESCRIPTION
The `/invites` endpoint rate limits organization invite post requests and will return `429` ( too many requests ) once the limit is reached.
