### PR TITLE
feat(unity): add account name as property for operator account schema

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -1139,6 +1139,9 @@ components:
         id:
           type: number
           description: account id in quartz
+        name:
+          type: string
+          description: account name
         type:
           $ref: '#/components/schemas/AccountType'
         zuoraAccountId:
@@ -1161,6 +1164,7 @@ components:
           description: 'which marketplace, nil if none'
       required:
         - id
+        - name
         - account
         - balance
         - billingContact

--- a/src/unity/schemas/OperatorAccount.yml
+++ b/src/unity/schemas/OperatorAccount.yml
@@ -2,6 +2,9 @@ properties:
   id:
     type: number
     description: account id in quartz
+  name:
+    type: string
+    description: account name
   type:
     $ref: './AccountType.yml'
   zuoraAccountId:
@@ -23,4 +26,4 @@ properties:
     $ref: './MarketplaceSubscription.yml'
     description: which marketplace, nil if none
 required:
-  [id, account, balance, billingContact, marketplaceSubscription, type, users]
+  [id, name, account, balance, billingContact, marketplaceSubscription, type, users]


### PR DESCRIPTION
For the purpose of multi-account, account names will be a required field for an account. The names need to be added to the Operator UI, so I added the `name` value from the `Account` as a property to the `OperatorAccount` schema in Unity. 