### PR TITLE
chore(telegrafs): add plugins as valid field in post/put payload

### DIFF
--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -790,7 +790,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TelegrafRequest"
+                "$ref": "#/components/schemas/TelegrafPluginRequest"
               }
             }
           }
@@ -915,7 +915,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TelegrafRequest"
+                "$ref": "#/components/schemas/TelegrafPluginRequest"
               }
             }
           }
@@ -15734,6 +15734,57 @@
           },
           "description": {
             "type": "string"
+          },
+          "metadata": {
+            "type": "object",
+            "properties": {
+              "buckets": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "config": {
+            "type": "string"
+          },
+          "orgID": {
+            "type": "string"
+          }
+        }
+      },
+      "TelegrafPluginRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "plugins": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "alias": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "config": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "metadata": {
             "type": "object",

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -524,7 +524,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TelegrafRequest'
+              $ref: '#/components/schemas/TelegrafPluginRequest'
       responses:
         '201':
           description: Telegraf configuration created
@@ -606,7 +606,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TelegrafRequest'
+              $ref: '#/components/schemas/TelegrafPluginRequest'
       responses:
         '200':
           description: An updated Telegraf configurations
@@ -10124,6 +10124,39 @@ components:
           type: string
         description:
           type: string
+        metadata:
+          type: object
+          properties:
+            buckets:
+              type: array
+              items:
+                type: string
+        config:
+          type: string
+        orgID:
+          type: string
+    TelegrafPluginRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        plugins:
+          type: array
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+              name:
+                type: string
+              alias:
+                type: string
+              description:
+                type: string
+              config:
+                type: string
         metadata:
           type: object
           properties:

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -411,7 +411,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TelegrafRequest'
+              $ref: '#/components/schemas/TelegrafPluginRequest'
       responses:
         '201':
           description: Telegraf configuration created
@@ -493,7 +493,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TelegrafRequest'
+              $ref: '#/components/schemas/TelegrafPluginRequest'
       responses:
         '200':
           description: An updated Telegraf configurations
@@ -8977,6 +8977,39 @@ components:
           type: string
         description:
           type: string
+        metadata:
+          type: object
+          properties:
+            buckets:
+              type: array
+              items:
+                type: string
+        config:
+          type: string
+        orgID:
+          type: string
+    TelegrafPluginRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        plugins:
+          type: array
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+              name:
+                type: string
+              alias:
+                type: string
+              description:
+                type: string
+              config:
+                type: string
         metadata:
           type: object
           properties:

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -793,7 +793,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TelegrafRequest"
+                "$ref": "#/components/schemas/TelegrafPluginRequest"
               }
             }
           }
@@ -918,7 +918,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TelegrafRequest"
+                "$ref": "#/components/schemas/TelegrafPluginRequest"
               }
             }
           }
@@ -17077,6 +17077,57 @@
           },
           "description": {
             "type": "string"
+          },
+          "metadata": {
+            "type": "object",
+            "properties": {
+              "buckets": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "config": {
+            "type": "string"
+          },
+          "orgID": {
+            "type": "string"
+          }
+        }
+      },
+      "TelegrafPluginRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "plugins": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "alias": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "config": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "metadata": {
             "type": "object",

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -527,7 +527,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TelegrafRequest'
+              $ref: '#/components/schemas/TelegrafPluginRequest'
       responses:
         '201':
           description: Telegraf configuration created
@@ -609,7 +609,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TelegrafRequest'
+              $ref: '#/components/schemas/TelegrafPluginRequest'
       responses:
         '200':
           description: An updated Telegraf configurations
@@ -10936,6 +10936,39 @@ components:
           type: string
         description:
           type: string
+        metadata:
+          type: object
+          properties:
+            buckets:
+              type: array
+              items:
+                type: string
+        config:
+          type: string
+        orgID:
+          type: string
+    TelegrafPluginRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        plugins:
+          type: array
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+              name:
+                type: string
+              alias:
+                type: string
+              description:
+                type: string
+              config:
+                type: string
         metadata:
           type: object
           properties:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -4454,6 +4454,39 @@ components:
         type:
           type: string
       type: object
+    TelegrafPluginRequest:
+      properties:
+        config:
+          type: string
+        description:
+          type: string
+        metadata:
+          properties:
+            buckets:
+              items:
+                type: string
+              type: array
+          type: object
+        name:
+          type: string
+        orgID:
+          type: string
+        plugins:
+          items:
+            properties:
+              alias:
+                type: string
+              config:
+                type: string
+              description:
+                type: string
+              name:
+                type: string
+              type:
+                type: string
+            type: object
+          type: array
+      type: object
     TelegrafPlugins:
       properties:
         os:
@@ -11074,7 +11107,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TelegrafRequest'
+              $ref: '#/components/schemas/TelegrafPluginRequest'
         description: Telegraf configuration to create
         required: true
       responses:
@@ -11178,7 +11211,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TelegrafRequest'
+              $ref: '#/components/schemas/TelegrafPluginRequest'
         description: Telegraf configuration update to apply
         required: true
       responses:

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -4386,6 +4386,39 @@ components:
         type:
           type: string
       type: object
+    TelegrafPluginRequest:
+      properties:
+        config:
+          type: string
+        description:
+          type: string
+        metadata:
+          properties:
+            buckets:
+              items:
+                type: string
+              type: array
+          type: object
+        name:
+          type: string
+        orgID:
+          type: string
+        plugins:
+          items:
+            properties:
+              alias:
+                type: string
+              config:
+                type: string
+              description:
+                type: string
+              name:
+                type: string
+              type:
+                type: string
+            type: object
+          type: array
+      type: object
     TelegrafPlugins:
       properties:
         os:
@@ -11659,7 +11692,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TelegrafRequest'
+              $ref: '#/components/schemas/TelegrafPluginRequest'
         description: Telegraf configuration to create
         required: true
       responses:
@@ -11763,7 +11796,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TelegrafRequest'
+              $ref: '#/components/schemas/TelegrafPluginRequest'
         description: Telegraf configuration update to apply
         required: true
       responses:

--- a/src/common/_schemas.yml
+++ b/src/common/_schemas.yml
@@ -302,6 +302,8 @@
       $ref: "./common/schemas/Dashboards.yml"
     TelegrafRequest:
       $ref: "./common/schemas/TelegrafRequest.yml"
+    TelegrafPluginRequest:
+      $ref: "./common/schemas/TelegrafPluginRequest.yml"
     Telegraf:
       $ref: "./common/schemas/Telegraf.yml"
     Telegrafs:

--- a/src/common/paths/telegrafs.yml
+++ b/src/common/paths/telegrafs.yml
@@ -36,7 +36,7 @@ post:
     content:
       application/json:
         schema:
-          $ref: "../schemas/TelegrafRequest.yml"
+          $ref: "../schemas/TelegrafPluginRequest.yml"
   responses:
     "201":
       description: Telegraf configuration created

--- a/src/common/paths/telegrafs_telegrafID.yml
+++ b/src/common/paths/telegrafs_telegrafID.yml
@@ -61,7 +61,7 @@ put:
     content:
       application/json:
         schema:
-          $ref: "../schemas/TelegrafRequest.yml"
+          $ref: "../schemas/TelegrafPluginRequest.yml"
   responses:
     "200":
       description: An updated Telegraf configurations

--- a/src/common/schemas/TelegrafPluginRequest.yml
+++ b/src/common/schemas/TelegrafPluginRequest.yml
@@ -1,0 +1,33 @@
+# This defines the 'legacy' `TelegrafConfigDecode` type in the api.
+type: object
+properties:
+  name:
+    type: string
+  description:
+    type: string
+  plugins:
+    type: array
+    items:
+      type: object
+      properties:
+        type:
+          type: string
+        name:
+          type: string
+        alias:
+          type: string
+        description:
+          type: string
+        config:
+          type: string
+  metadata:
+    type: object
+    properties:
+      buckets:
+        type: array
+        items:
+          type: string
+  config:
+    type: string
+  orgID:
+    type: string


### PR DESCRIPTION
This adds the missing (likely due to it being considered legacy and intended for deprecation (according to comments in api code)) `plugins` field to the request definition used by a post and a put request to `/api/v2/telegrafs[/:id]`.