### PR TITLE
fix: v1compat and auth schemes

### DIFF
--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -9,10 +9,13 @@ servers:
 tags:
   - name: Authentication
     description: |
-      Use one of the following schemes to authenticate to the InfluxDB API:
-      - [Token authentication](#section/Authentication/TokenAuthentication)
-      - [Basic authentication](#section/Authentication/BasicAuthentication)
-      - [Querystring authentication](#section/Authentication/QuerystringAuthentication)
+      The InfluxDB `/api/v2` API requires authentication for all requests.
+      Use InfluxDB API tokens to authenticate requests to the `/api/v2` API.
+
+
+      For more information, see
+      [Token authentication](#section/Authentication/TokenAuthentication)
+
       <!-- ReDoc-Inject: <security-definitions> -->
     x-traitTag: true
   - name: Quick start
@@ -3877,73 +3880,27 @@ components:
               - message
   securitySchemes:
     TokenAuthentication:
-      type: http
-      scheme: token
-      bearerFormat: InfluxDB token string
+      type: apiKey
+      name: Authorization
+      in: header
       description: |
-        ### Token authentication scheme
+        Use the [Token authentication](#section/Authentication/TokenAuthentication)
+        scheme to authenticate to the InfluxDB API.
 
-        InfluxDB API tokens ensure secure interaction between users and data. A token belongs to an organization and identifies InfluxDB permissions within the organization.
 
-        Include your API token in an `Authorization: Token INFLUX_TOKEN` HTTP header with each request.
+        In your API requests, send an `Authorization` header.
+        For the header value, provide the word `Token` followed by a space and an InfluxDB API token.
+        The word `Token` is case-sensitive.
 
-        #### Example
 
-        `curl https://us-east-1-1.aws.cloud2.influxdata.com/
-           --header "Authorization: Token INFLUX_API_TOKEN"`
+        ### Syntax
 
-        Replace *`INFLUX_API_TOKEN`* with your [InfluxDB API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token).
+        `Authorization: Token YOUR_INFLUX_TOKEN`
+
 
         For more information and examples, see the following:
           - [`/authorizations`](#tag/Authorizations) endpoint.
           - [Authorize API requests]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication).
           - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens).
-          - [Assign a token to a specific user]({{% INFLUXDB_DOCS_URL %}}/security/tokens/create-token).
-    BasicAuthentication:
-      type: http
-      scheme: basic
-      description: |
-        ### Basic authentication scheme
-
-        Use the HTTP Basic authentication scheme with clients that support the InfluxDB 1.x convention of username and password (that don't support the `Authorization: Token` scheme):
-          - **username**: InfluxDB Cloud username
-          - **password**: InfluxDB Cloud API token
-
-        #### Example
-
-        `curl --get "https://europe-west1-1.gcp.cloud2.influxdata.com/query"
-              --user "exampleuser@influxdata.com":"INFLUX_API_TOKEN"`
-
-        Replace the following:
-        - *`exampleuser@influxdata.com`*: the email address that you signed up with
-        - *`INFLUX_API_TOKEN`*: your [InfluxDB API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token)
-
-        For more information and examples, see how to [authenticate with a username and password]({{% INFLUXDB_DOCS_URL %}}/reference/api/influxdb-1x/).
-    QuerystringAuthentication:
-      type: apiKey
-      in: query
-      name: u=&p=
-      description: |
-        ### Querystring authentication scheme
-
-        Use InfluxDB 1.x API parameters to provide credentials through the query string.
-
-        Username and password schemes require the following credentials:
-        - **username**: InfluxDB Cloud username
-        - **password**: InfluxDB Cloud API token
-
-        #### Example
-
-        `curl --get "https://europe-west1-1.gcp.cloud2.influxdata.com/query"
-              --data-urlencode "u=exampleuser@influxdata.com"
-              --data-urlencode "p=INFLUX_API_TOKEN"`
-
-        Replace the following:
-        - *`exampleuser@influxdata.com`*: the email address that you signed up with
-        - *`INFLUX_API_TOKEN`*: your [InfluxDB API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token)
-
-        For more information and examples, see how to [authenticate with a username and password scheme]({{% INFLUXDB_DOCS_URL %}}/reference/api/influxdb-1x/).
 security:
   - TokenAuthentication: []
-  - BasicAuthentication: []
-  - QuerystringAuthentication: []

--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -3902,5 +3902,25 @@ components:
           - [`/authorizations`](#tag/Authorizations) endpoint.
           - [Authorize API requests]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication).
           - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens).
+    BasicAuthentication:
+      type: http
+      scheme: basic
+      description: |
+        ### Basic authentication scheme
+
+        Use the HTTP Basic authentication scheme for InfluxDB `/api/v2` API operations that support it:
+          - **username**: InfluxDB Cloud username
+          - **password**: InfluxDB Cloud API token
+
+        #### Example
+
+        `curl --get "https://europe-west1-1.gcp.cloud2.influxdata.com/query"
+              --user "exampleuser@influxdata.com":"INFLUX_API_TOKEN"`
+
+        Replace the following:
+        - *`exampleuser@influxdata.com`*: the email address that you signed up with
+        - *`INFLUX_API_TOKEN`*: your [InfluxDB API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token)
+
+        For more information and examples, see how to [authenticate with a username and password]({{% INFLUXDB_DOCS_URL %}}/reference/api/influxdb-1x/).
 security:
   - TokenAuthentication: []

--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -3920,7 +3920,5 @@ components:
         Replace the following:
         - *`exampleuser@influxdata.com`*: the email address that you signed up with
         - *`INFLUX_API_TOKEN`*: your [InfluxDB API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token)
-
-        For more information and examples, see how to [authenticate with a username and password]({{% INFLUXDB_DOCS_URL %}}/reference/api/influxdb-1x/).
 security:
   - TokenAuthentication: []

--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  title: Influx Cloud API Service
+  title: InfluxDB Cloud API Service
   version: 2.0.1
   description: |
     The InfluxDB v2 API provides a programmatic interface for all interactions with InfluxDB. Access the InfluxDB API using the `/api/v2/` endpoint.

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -13,7 +13,7 @@
   "tags": [
     {
       "name": "Authentication",
-      "description": "Use one of the following schemes to authenticate to the InfluxDB API:\n- [Token authentication](#section/Authentication/TokenAuthentication)\n- [Basic authentication](#section/Authentication/BasicAuthentication)\n- [Querystring authentication](#section/Authentication/QuerystringAuthentication)\n<!-- ReDoc-Inject: <security-definitions> -->\n",
+      "description": "The InfluxDB `/api/v2` API requires authentication for all requests.\nUse InfluxDB API tokens to authenticate requests to the `/api/v2` API.\n\n\nFor more information, see\n[Token authentication](#section/Authentication/TokenAuthentication)\n\n<!-- ReDoc-Inject: <security-definitions> -->\n",
       "x-traitTag": true
     },
     {
@@ -18347,33 +18347,16 @@
     },
     "securitySchemes": {
       "TokenAuthentication": {
-        "type": "http",
-        "scheme": "token",
-        "bearerFormat": "InfluxDB token string",
-        "description": "### Token authentication scheme\n\nInfluxDB API tokens ensure secure interaction between users and data. A token belongs to an organization and identifies InfluxDB permissions within the organization.\n\nInclude your API token in an `Authorization: Token INFLUX_TOKEN` HTTP header with each request.\n\n#### Example\n\n`curl https://us-east-1-1.aws.cloud2.influxdata.com/\n   --header \"Authorization: Token INFLUX_API_TOKEN\"`\n\nReplace *`INFLUX_API_TOKEN`* with your [InfluxDB API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token).\n\nFor more information and examples, see the following:\n  - [`/authorizations`](#tag/Authorizations) endpoint.\n  - [Authorize API requests]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication).\n  - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens).\n  - [Assign a token to a specific user]({{% INFLUXDB_DOCS_URL %}}/security/tokens/create-token).\n"
-      },
-      "BasicAuthentication": {
-        "type": "http",
-        "scheme": "basic",
-        "description": "### Basic authentication scheme\n\nUse the HTTP Basic authentication scheme with clients that support the InfluxDB 1.x convention of username and password (that don't support the `Authorization: Token` scheme):\n  - **username**: InfluxDB Cloud username\n  - **password**: InfluxDB Cloud API token\n\n#### Example\n\n`curl --get \"https://europe-west1-1.gcp.cloud2.influxdata.com/query\"\n      --user \"exampleuser@influxdata.com\":\"INFLUX_API_TOKEN\"`\n\nReplace the following:\n- *`exampleuser@influxdata.com`*: the email address that you signed up with\n- *`INFLUX_API_TOKEN`*: your [InfluxDB API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token)\n\nFor more information and examples, see how to [authenticate with a username and password]({{% INFLUXDB_DOCS_URL %}}/reference/api/influxdb-1x/).\n"
-      },
-      "QuerystringAuthentication": {
         "type": "apiKey",
-        "in": "query",
-        "name": "u=&p=",
-        "description": "### Querystring authentication scheme\n\nUse InfluxDB 1.x API parameters to provide credentials through the query string.\n\nUsername and password schemes require the following credentials:\n- **username**: InfluxDB Cloud username\n- **password**: InfluxDB Cloud API token\n\n#### Example\n\n`curl --get \"https://europe-west1-1.gcp.cloud2.influxdata.com/query\"\n      --data-urlencode \"u=exampleuser@influxdata.com\"\n      --data-urlencode \"p=INFLUX_API_TOKEN\"`\n\nReplace the following:\n- *`exampleuser@influxdata.com`*: the email address that you signed up with\n- *`INFLUX_API_TOKEN`*: your [InfluxDB API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token)\n\nFor more information and examples, see how to [authenticate with a username and password scheme]({{% INFLUXDB_DOCS_URL %}}/reference/api/influxdb-1x/).\n"
+        "name": "Authorization",
+        "in": "header",
+        "description": "Use the [Token authentication](#section/Authentication/TokenAuthentication)\nscheme to authenticate to the InfluxDB API.\n\n\nIn your API requests, send an `Authorization` header.\nFor the header value, provide the word `Token` followed by a space and an InfluxDB API token.\nThe word `Token` is case-sensitive.\n\n\n### Syntax\n\n`Authorization: Token YOUR_INFLUX_TOKEN`\n\n\nFor more information and examples, see the following:\n  - [`/authorizations`](#tag/Authorizations) endpoint.\n  - [Authorize API requests]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication).\n  - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens).\n"
       }
     }
   },
   "security": [
     {
       "TokenAuthentication": []
-    },
-    {
-      "BasicAuthentication": []
-    },
-    {
-      "QuerystringAuthentication": []
     }
   ]
 }

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -18351,6 +18351,11 @@
         "name": "Authorization",
         "in": "header",
         "description": "Use the [Token authentication](#section/Authentication/TokenAuthentication)\nscheme to authenticate to the InfluxDB API.\n\n\nIn your API requests, send an `Authorization` header.\nFor the header value, provide the word `Token` followed by a space and an InfluxDB API token.\nThe word `Token` is case-sensitive.\n\n\n### Syntax\n\n`Authorization: Token YOUR_INFLUX_TOKEN`\n\n\nFor more information and examples, see the following:\n  - [`/authorizations`](#tag/Authorizations) endpoint.\n  - [Authorize API requests]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication).\n  - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens).\n"
+      },
+      "BasicAuthentication": {
+        "type": "http",
+        "scheme": "basic",
+        "description": "### Basic authentication scheme\n\nUse the HTTP Basic authentication scheme for InfluxDB `/api/v2` API operations that support it:\n  - **username**: InfluxDB Cloud username\n  - **password**: InfluxDB Cloud API token\n\n#### Example\n\n`curl --get \"https://europe-west1-1.gcp.cloud2.influxdata.com/query\"\n      --user \"exampleuser@influxdata.com\":\"INFLUX_API_TOKEN\"`\n\nReplace the following:\n- *`exampleuser@influxdata.com`*: the email address that you signed up with\n- *`INFLUX_API_TOKEN`*: your [InfluxDB API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token)\n\nFor more information and examples, see how to [authenticate with a username and password]({{% INFLUXDB_DOCS_URL %}}/reference/api/influxdb-1x/).\n"
       }
     }
   },

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "Influx Cloud API Service",
+    "title": "InfluxDB Cloud API Service",
     "version": "2.0.1",
     "description": "The InfluxDB v2 API provides a programmatic interface for all interactions with InfluxDB. Access the InfluxDB API using the `/api/v2/` endpoint.\n"
   },

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -18355,7 +18355,7 @@
       "BasicAuthentication": {
         "type": "http",
         "scheme": "basic",
-        "description": "### Basic authentication scheme\n\nUse the HTTP Basic authentication scheme for InfluxDB `/api/v2` API operations that support it:\n  - **username**: InfluxDB Cloud username\n  - **password**: InfluxDB Cloud API token\n\n#### Example\n\n`curl --get \"https://europe-west1-1.gcp.cloud2.influxdata.com/query\"\n      --user \"exampleuser@influxdata.com\":\"INFLUX_API_TOKEN\"`\n\nReplace the following:\n- *`exampleuser@influxdata.com`*: the email address that you signed up with\n- *`INFLUX_API_TOKEN`*: your [InfluxDB API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token)\n\nFor more information and examples, see how to [authenticate with a username and password]({{% INFLUXDB_DOCS_URL %}}/reference/api/influxdb-1x/).\n"
+        "description": "### Basic authentication scheme\n\nUse the HTTP Basic authentication scheme for InfluxDB `/api/v2` API operations that support it:\n  - **username**: InfluxDB Cloud username\n  - **password**: InfluxDB Cloud API token\n\n#### Example\n\n`curl --get \"https://europe-west1-1.gcp.cloud2.influxdata.com/query\"\n      --user \"exampleuser@influxdata.com\":\"INFLUX_API_TOKEN\"`\n\nReplace the following:\n- *`exampleuser@influxdata.com`*: the email address that you signed up with\n- *`INFLUX_API_TOKEN`*: your [InfluxDB API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token)\n"
       }
     }
   },

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -11916,7 +11916,5 @@ components:
         Replace the following:
         - *`exampleuser@influxdata.com`*: the email address that you signed up with
         - *`INFLUX_API_TOKEN`*: your [InfluxDB API token](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#token)
-
-        For more information and examples, see how to [authenticate with a username and password](https://docs.influxdata.com/influxdb/cloud/reference/api/influxdb-1x/).
 security:
   - TokenAuthentication: []

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -9,10 +9,13 @@ servers:
 tags:
   - name: Authentication
     description: |
-      Use one of the following schemes to authenticate to the InfluxDB API:
-      - [Token authentication](#section/Authentication/TokenAuthentication)
-      - [Basic authentication](#section/Authentication/BasicAuthentication)
-      - [Querystring authentication](#section/Authentication/QuerystringAuthentication)
+      The InfluxDB `/api/v2` API requires authentication for all requests.
+      Use InfluxDB API tokens to authenticate requests to the `/api/v2` API.
+
+
+      For more information, see
+      [Token authentication](#section/Authentication/TokenAuthentication)
+
       <!-- ReDoc-Inject: <security-definitions> -->
     x-traitTag: true
   - name: Quick start
@@ -11873,73 +11876,27 @@ components:
             $ref: '#/components/schemas/Error'
   securitySchemes:
     TokenAuthentication:
-      type: http
-      scheme: token
-      bearerFormat: InfluxDB token string
+      type: apiKey
+      name: Authorization
+      in: header
       description: |
-        ### Token authentication scheme
+        Use the [Token authentication](#section/Authentication/TokenAuthentication)
+        scheme to authenticate to the InfluxDB API.
 
-        InfluxDB API tokens ensure secure interaction between users and data. A token belongs to an organization and identifies InfluxDB permissions within the organization.
 
-        Include your API token in an `Authorization: Token INFLUX_TOKEN` HTTP header with each request.
+        In your API requests, send an `Authorization` header.
+        For the header value, provide the word `Token` followed by a space and an InfluxDB API token.
+        The word `Token` is case-sensitive.
 
-        #### Example
 
-        `curl https://us-east-1-1.aws.cloud2.influxdata.com/
-           --header "Authorization: Token INFLUX_API_TOKEN"`
+        ### Syntax
 
-        Replace *`INFLUX_API_TOKEN`* with your [InfluxDB API token](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#token).
+        `Authorization: Token YOUR_INFLUX_TOKEN`
+
 
         For more information and examples, see the following:
           - [`/authorizations`](#tag/Authorizations) endpoint.
           - [Authorize API requests](https://docs.influxdata.com/influxdb/cloud/api-guide/api_intro/#authentication).
           - [Manage API tokens](https://docs.influxdata.com/influxdb/cloud/security/tokens).
-          - [Assign a token to a specific user](https://docs.influxdata.com/influxdb/cloud/security/tokens/create-token).
-    BasicAuthentication:
-      type: http
-      scheme: basic
-      description: |
-        ### Basic authentication scheme
-
-        Use the HTTP Basic authentication scheme with clients that support the InfluxDB 1.x convention of username and password (that don't support the `Authorization: Token` scheme):
-          - **username**: InfluxDB Cloud username
-          - **password**: InfluxDB Cloud API token
-
-        #### Example
-
-        `curl --get "https://europe-west1-1.gcp.cloud2.influxdata.com/query"
-              --user "exampleuser@influxdata.com":"INFLUX_API_TOKEN"`
-
-        Replace the following:
-        - *`exampleuser@influxdata.com`*: the email address that you signed up with
-        - *`INFLUX_API_TOKEN`*: your [InfluxDB API token](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#token)
-
-        For more information and examples, see how to [authenticate with a username and password](https://docs.influxdata.com/influxdb/cloud/reference/api/influxdb-1x/).
-    QuerystringAuthentication:
-      type: apiKey
-      in: query
-      name: u=&p=
-      description: |
-        ### Querystring authentication scheme
-
-        Use InfluxDB 1.x API parameters to provide credentials through the query string.
-
-        Username and password schemes require the following credentials:
-        - **username**: InfluxDB Cloud username
-        - **password**: InfluxDB Cloud API token
-
-        #### Example
-
-        `curl --get "https://europe-west1-1.gcp.cloud2.influxdata.com/query"
-              --data-urlencode "u=exampleuser@influxdata.com"
-              --data-urlencode "p=INFLUX_API_TOKEN"`
-
-        Replace the following:
-        - *`exampleuser@influxdata.com`*: the email address that you signed up with
-        - *`INFLUX_API_TOKEN`*: your [InfluxDB API token](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#token)
-
-        For more information and examples, see how to [authenticate with a username and password scheme](https://docs.influxdata.com/influxdb/cloud/reference/api/influxdb-1x/).
 security:
   - TokenAuthentication: []
-  - BasicAuthentication: []
-  - QuerystringAuthentication: []

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -11898,5 +11898,25 @@ components:
           - [`/authorizations`](#tag/Authorizations) endpoint.
           - [Authorize API requests](https://docs.influxdata.com/influxdb/cloud/api-guide/api_intro/#authentication).
           - [Manage API tokens](https://docs.influxdata.com/influxdb/cloud/security/tokens).
+    BasicAuthentication:
+      type: http
+      scheme: basic
+      description: |
+        ### Basic authentication scheme
+
+        Use the HTTP Basic authentication scheme for InfluxDB `/api/v2` API operations that support it:
+          - **username**: InfluxDB Cloud username
+          - **password**: InfluxDB Cloud API token
+
+        #### Example
+
+        `curl --get "https://europe-west1-1.gcp.cloud2.influxdata.com/query"
+              --user "exampleuser@influxdata.com":"INFLUX_API_TOKEN"`
+
+        Replace the following:
+        - *`exampleuser@influxdata.com`*: the email address that you signed up with
+        - *`INFLUX_API_TOKEN`*: your [InfluxDB API token](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#token)
+
+        For more information and examples, see how to [authenticate with a username and password](https://docs.influxdata.com/influxdb/cloud/reference/api/influxdb-1x/).
 security:
   - TokenAuthentication: []

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  title: Influx Cloud API Service
+  title: InfluxDB Cloud API Service
   version: 2.0.1
   description: |
     The InfluxDB v2 API provides a programmatic interface for all interactions with InfluxDB. Access the InfluxDB API using the `/api/v2/` endpoint.

--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -4843,7 +4843,5 @@ components:
         Username and password schemes require the following credentials:
           - **username**
           - **password**
-
-        For more information and examples, see how to [authenticate with a username and password scheme]({{% INFLUXDB_DOCS_URL %}}/reference/api/influxdb-1x/)
 security:
   - TokenAuthentication: []

--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  title: Influx OSS API Service
+  title: InfluxDB OSS API Service
   version: 2.0.0
   description: |
     The InfluxDB v2 API provides a programmatic interface for all interactions with InfluxDB. Access the InfluxDB API using the `/api/v2/` endpoint.

--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -9,10 +9,13 @@ servers:
 tags:
   - name: Authentication
     description: |
-      Use one of the following schemes to authenticate to the InfluxDB API:
-      - [Token authentication](#section/Authentication/TokenAuthentication)
-      - [Basic authentication](#section/Authentication/BasicAuthentication)
-      - [Querystring authentication](#section/Authentication/QuerystringAuthentication)
+      The InfluxDB `/api/v2` API requires authentication for all requests.
+      Use InfluxDB API tokens to authenticate requests to the `/api/v2` API.
+
+
+      For examples and more information, see
+      [Token authentication](#section/Authentication/TokenAuthentication)
+
       <!-- ReDoc-Inject: <security-definitions> -->
     x-traitTag: true
   - name: Quick start
@@ -4809,89 +4812,27 @@ components:
               - message
   securitySchemes:
     TokenAuthentication:
-      type: http
-      scheme: token
-      bearerFormat: InfluxDB Token String
+      type: apiKey
+      name: Authorization
+      in: header
       description: |
-        ### Token authentication scheme
+        Use the [Token authentication](#section/Authentication/TokenAuthentication)
+        scheme to authenticate to the InfluxDB API.
 
-        InfluxDB API tokens enable authentication and authorization of API clients.
-        A token belongs to an organization and identifies InfluxDB permissions within the organization.
 
-        Include your API token in an `Authorization: Token` HTTP header with each request.
+        In your API requests, send an `Authorization` header.
+        For the header value, provide the word `Token` followed by a space and an InfluxDB API token.
+        The word `Token` is case-sensitive.
 
-        #### Example
 
-          `curl http://localhost:8086/ping
-             --header "Authorization: Token INFLUX_API_TOKEN"`
+        ### Syntax
 
-        Replace *`INFLUX_API_TOKEN`* with your [InfluxDB API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token).
+        `Authorization: Token YOUR_INFLUX_TOKEN`
+
 
         For more information and examples, see the following:
           - [`/authorizations`](#tag/Authorizations) endpoint.
           - [Authorize API requests]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication).
           - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens).
-          - [Assign a token to a specific user]({{% INFLUXDB_DOCS_URL %}}/security/tokens/create-token).
-    BasicAuthentication:
-      type: http
-      scheme: basic
-      description: |
-        ### Basic authentication scheme
-
-        Use HTTP Basic Auth with clients that support the InfluxDB 1.x convention of username and password (that don't support the `Authorization: Token` scheme).
-
-        Username and password schemes require the following credentials:
-          - **username**: 1.x username (this is separate from the UI login username)
-          - **password**: 1.x password or InfluxDB API token
-
-        #### API token example
-
-        `curl --get "http://localhost:8086/query"
-              --user "1.x_USERNAME":"INFLUX_API_TOKEN"`
-
-        #### 1.x password example
-
-        `curl --get "http://localhost:8086/query"
-              --user "1.x_USERNAME":"1.x_PASSWORD"`
-
-        Replace the following:
-        - *`1.x_USERNAME`*: your InfluxDB v1.x username
-        - *`1.x_PASSWORD`*: your InfluxDB v1.x password
-        - *`INFLUX_API_TOKEN`*: your [InfluxDB API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token)
-
-        For more information and examples, see how to [authenticate with a username and password scheme]({{% INFLUXDB_DOCS_URL %}}/reference/api/influxdb-1x/)
-    QuerystringAuthentication:
-      type: apiKey
-      in: query
-      name: u=&p=
-      description: |
-        ### Querystring authentication scheme
-
-        Use InfluxDB 1.x API parameters to provide credentials through the query string.
-
-        Username and password schemes require the following credentials:
-          - **username**: 1.x username (this is separate from the UI login username)
-          - **password**: 1.x password or InfluxDB API token
-
-        #### API token example
-
-        `curl --get "http://localhost:8086/query"
-              --data-urlencode "u=1.x_USERNAME"
-              --data-urlencode "p=INFLUX_API_TOKEN"`
-
-        #### 1.x password example
-
-        `curl --get "http://localhost:8086/query"
-              --data-urlencode "u=1.x_USERNAME"
-              --data-urlencode "p=1.x_PASSWORD"`
-
-        Replace the following:
-        - *`1.x_USERNAME`*: your InfluxDB v1.x username
-        - *`1.x_PASSWORD`*: your InfluxDB v1.x password
-        - *`INFLUX_API_TOKEN`*: your [InfluxDB API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token)
-
-        For more information and examples, see how to [authenticate with a username and password scheme]({{% INFLUXDB_DOCS_URL %}}/reference/api/influxdb-1x/)
 security:
   - TokenAuthentication: []
-  - BasicAuthentication: []
-  - QuerystringAuthentication: []

--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -4834,5 +4834,16 @@ components:
           - [`/authorizations`](#tag/Authorizations) endpoint.
           - [Authorize API requests]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication).
           - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens).
+    BasicAuthentication:
+      type: http
+      scheme: basic
+      description: |
+        Use the HTTP Basic authentication scheme for InfluxDB `/api/v2` API operations that support it.
+
+        Username and password schemes require the following credentials:
+          - **username**
+          - **password**
+
+        For more information and examples, see how to [authenticate with a username and password scheme]({{% INFLUXDB_DOCS_URL %}}/reference/api/influxdb-1x/)
 security:
   - TokenAuthentication: []

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -19707,7 +19707,7 @@
       "BasicAuthentication": {
         "type": "http",
         "scheme": "basic",
-        "description": "Use the HTTP Basic authentication scheme for InfluxDB `/api/v2` API operations that support it.\n\nUsername and password schemes require the following credentials:\n  - **username**\n  - **password**\n\nFor more information and examples, see how to [authenticate with a username and password scheme]({{% INFLUXDB_DOCS_URL %}}/reference/api/influxdb-1x/)\n"
+        "description": "Use the HTTP Basic authentication scheme for InfluxDB `/api/v2` API operations that support it.\n\nUsername and password schemes require the following credentials:\n  - **username**\n  - **password**\n"
       }
     }
   },

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -13,7 +13,7 @@
   "tags": [
     {
       "name": "Authentication",
-      "description": "Use one of the following schemes to authenticate to the InfluxDB API:\n- [Token authentication](#section/Authentication/TokenAuthentication)\n- [Basic authentication](#section/Authentication/BasicAuthentication)\n- [Querystring authentication](#section/Authentication/QuerystringAuthentication)\n<!-- ReDoc-Inject: <security-definitions> -->\n",
+      "description": "The InfluxDB `/api/v2` API requires authentication for all requests.\nUse InfluxDB API tokens to authenticate requests to the `/api/v2` API.\n\n\nFor examples and more information, see\n[Token authentication](#section/Authentication/TokenAuthentication)\n\n<!-- ReDoc-Inject: <security-definitions> -->\n",
       "x-traitTag": true
     },
     {
@@ -19699,33 +19699,16 @@
     },
     "securitySchemes": {
       "TokenAuthentication": {
-        "type": "http",
-        "scheme": "token",
-        "bearerFormat": "InfluxDB Token String",
-        "description": "### Token authentication scheme\n\nInfluxDB API tokens enable authentication and authorization of API clients.\nA token belongs to an organization and identifies InfluxDB permissions within the organization.\n\nInclude your API token in an `Authorization: Token` HTTP header with each request.\n\n#### Example\n\n  `curl http://localhost:8086/ping\n     --header \"Authorization: Token INFLUX_API_TOKEN\"`\n\nReplace *`INFLUX_API_TOKEN`* with your [InfluxDB API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token).\n\nFor more information and examples, see the following:\n  - [`/authorizations`](#tag/Authorizations) endpoint.\n  - [Authorize API requests]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication).\n  - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens).\n  - [Assign a token to a specific user]({{% INFLUXDB_DOCS_URL %}}/security/tokens/create-token).\n"
-      },
-      "BasicAuthentication": {
-        "type": "http",
-        "scheme": "basic",
-        "description": "### Basic authentication scheme\n\nUse HTTP Basic Auth with clients that support the InfluxDB 1.x convention of username and password (that don't support the `Authorization: Token` scheme).\n\nUsername and password schemes require the following credentials:\n  - **username**: 1.x username (this is separate from the UI login username)\n  - **password**: 1.x password or InfluxDB API token\n\n#### API token example\n\n`curl --get \"http://localhost:8086/query\"\n      --user \"1.x_USERNAME\":\"INFLUX_API_TOKEN\"`\n\n#### 1.x password example\n\n`curl --get \"http://localhost:8086/query\"\n      --user \"1.x_USERNAME\":\"1.x_PASSWORD\"`\n\nReplace the following:\n- *`1.x_USERNAME`*: your InfluxDB v1.x username\n- *`1.x_PASSWORD`*: your InfluxDB v1.x password\n- *`INFLUX_API_TOKEN`*: your [InfluxDB API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token)\n\nFor more information and examples, see how to [authenticate with a username and password scheme]({{% INFLUXDB_DOCS_URL %}}/reference/api/influxdb-1x/)\n"
-      },
-      "QuerystringAuthentication": {
         "type": "apiKey",
-        "in": "query",
-        "name": "u=&p=",
-        "description": "### Querystring authentication scheme\n\nUse InfluxDB 1.x API parameters to provide credentials through the query string.\n\nUsername and password schemes require the following credentials:\n  - **username**: 1.x username (this is separate from the UI login username)\n  - **password**: 1.x password or InfluxDB API token\n\n#### API token example\n\n`curl --get \"http://localhost:8086/query\"\n      --data-urlencode \"u=1.x_USERNAME\"\n      --data-urlencode \"p=INFLUX_API_TOKEN\"`\n\n#### 1.x password example\n\n`curl --get \"http://localhost:8086/query\"\n      --data-urlencode \"u=1.x_USERNAME\"\n      --data-urlencode \"p=1.x_PASSWORD\"`\n\nReplace the following:\n- *`1.x_USERNAME`*: your InfluxDB v1.x username\n- *`1.x_PASSWORD`*: your InfluxDB v1.x password\n- *`INFLUX_API_TOKEN`*: your [InfluxDB API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token)\n\nFor more information and examples, see how to [authenticate with a username and password scheme]({{% INFLUXDB_DOCS_URL %}}/reference/api/influxdb-1x/)\n"
+        "name": "Authorization",
+        "in": "header",
+        "description": "Use the [Token authentication](#section/Authentication/TokenAuthentication)\nscheme to authenticate to the InfluxDB API.\n\n\nIn your API requests, send an `Authorization` header.\nFor the header value, provide the word `Token` followed by a space and an InfluxDB API token.\nThe word `Token` is case-sensitive.\n\n\n### Syntax\n\n`Authorization: Token YOUR_INFLUX_TOKEN`\n\n\nFor more information and examples, see the following:\n  - [`/authorizations`](#tag/Authorizations) endpoint.\n  - [Authorize API requests]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication).\n  - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens).\n"
       }
     }
   },
   "security": [
     {
       "TokenAuthentication": []
-    },
-    {
-      "BasicAuthentication": []
-    },
-    {
-      "QuerystringAuthentication": []
     }
   ]
 }

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "Influx OSS API Service",
+    "title": "InfluxDB OSS API Service",
     "version": "2.0.0",
     "description": "The InfluxDB v2 API provides a programmatic interface for all interactions with InfluxDB. Access the InfluxDB API using the `/api/v2/` endpoint.\n"
   },

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -19703,6 +19703,11 @@
         "name": "Authorization",
         "in": "header",
         "description": "Use the [Token authentication](#section/Authentication/TokenAuthentication)\nscheme to authenticate to the InfluxDB API.\n\n\nIn your API requests, send an `Authorization` header.\nFor the header value, provide the word `Token` followed by a space and an InfluxDB API token.\nThe word `Token` is case-sensitive.\n\n\n### Syntax\n\n`Authorization: Token YOUR_INFLUX_TOKEN`\n\n\nFor more information and examples, see the following:\n  - [`/authorizations`](#tag/Authorizations) endpoint.\n  - [Authorize API requests]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication).\n  - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens).\n"
+      },
+      "BasicAuthentication": {
+        "type": "http",
+        "scheme": "basic",
+        "description": "Use the HTTP Basic authentication scheme for InfluxDB `/api/v2` API operations that support it.\n\nUsername and password schemes require the following credentials:\n  - **username**\n  - **password**\n\nFor more information and examples, see how to [authenticate with a username and password scheme]({{% INFLUXDB_DOCS_URL %}}/reference/api/influxdb-1x/)\n"
       }
     }
   },

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -9,10 +9,13 @@ servers:
 tags:
   - name: Authentication
     description: |
-      Use one of the following schemes to authenticate to the InfluxDB API:
-      - [Token authentication](#section/Authentication/TokenAuthentication)
-      - [Basic authentication](#section/Authentication/BasicAuthentication)
-      - [Querystring authentication](#section/Authentication/QuerystringAuthentication)
+      The InfluxDB `/api/v2` API requires authentication for all requests.
+      Use InfluxDB API tokens to authenticate requests to the `/api/v2` API.
+
+
+      For examples and more information, see
+      [Token authentication](#section/Authentication/TokenAuthentication)
+
       <!-- ReDoc-Inject: <security-definitions> -->
     x-traitTag: true
   - name: Quick start
@@ -12689,89 +12692,27 @@ components:
             $ref: '#/components/schemas/Error'
   securitySchemes:
     TokenAuthentication:
-      type: http
-      scheme: token
-      bearerFormat: InfluxDB Token String
+      type: apiKey
+      name: Authorization
+      in: header
       description: |
-        ### Token authentication scheme
+        Use the [Token authentication](#section/Authentication/TokenAuthentication)
+        scheme to authenticate to the InfluxDB API.
 
-        InfluxDB API tokens enable authentication and authorization of API clients.
-        A token belongs to an organization and identifies InfluxDB permissions within the organization.
 
-        Include your API token in an `Authorization: Token` HTTP header with each request.
+        In your API requests, send an `Authorization` header.
+        For the header value, provide the word `Token` followed by a space and an InfluxDB API token.
+        The word `Token` is case-sensitive.
 
-        #### Example
 
-          `curl http://localhost:8086/ping
-             --header "Authorization: Token INFLUX_API_TOKEN"`
+        ### Syntax
 
-        Replace *`INFLUX_API_TOKEN`* with your [InfluxDB API token](https://docs.influxdata.com/influxdb/v2.1/reference/glossary/#token).
+        `Authorization: Token YOUR_INFLUX_TOKEN`
+
 
         For more information and examples, see the following:
           - [`/authorizations`](#tag/Authorizations) endpoint.
           - [Authorize API requests](https://docs.influxdata.com/influxdb/v2.1/api-guide/api_intro/#authentication).
           - [Manage API tokens](https://docs.influxdata.com/influxdb/v2.1/security/tokens).
-          - [Assign a token to a specific user](https://docs.influxdata.com/influxdb/v2.1/security/tokens/create-token).
-    BasicAuthentication:
-      type: http
-      scheme: basic
-      description: |
-        ### Basic authentication scheme
-
-        Use HTTP Basic Auth with clients that support the InfluxDB 1.x convention of username and password (that don't support the `Authorization: Token` scheme).
-
-        Username and password schemes require the following credentials:
-          - **username**: 1.x username (this is separate from the UI login username)
-          - **password**: 1.x password or InfluxDB API token
-
-        #### API token example
-
-        `curl --get "http://localhost:8086/query"
-              --user "1.x_USERNAME":"INFLUX_API_TOKEN"`
-
-        #### 1.x password example
-
-        `curl --get "http://localhost:8086/query"
-              --user "1.x_USERNAME":"1.x_PASSWORD"`
-
-        Replace the following:
-        - *`1.x_USERNAME`*: your InfluxDB v1.x username
-        - *`1.x_PASSWORD`*: your InfluxDB v1.x password
-        - *`INFLUX_API_TOKEN`*: your [InfluxDB API token](https://docs.influxdata.com/influxdb/v2.1/reference/glossary/#token)
-
-        For more information and examples, see how to [authenticate with a username and password scheme](https://docs.influxdata.com/influxdb/v2.1/reference/api/influxdb-1x/)
-    QuerystringAuthentication:
-      type: apiKey
-      in: query
-      name: u=&p=
-      description: |
-        ### Querystring authentication scheme
-
-        Use InfluxDB 1.x API parameters to provide credentials through the query string.
-
-        Username and password schemes require the following credentials:
-          - **username**: 1.x username (this is separate from the UI login username)
-          - **password**: 1.x password or InfluxDB API token
-
-        #### API token example
-
-        `curl --get "http://localhost:8086/query"
-              --data-urlencode "u=1.x_USERNAME"
-              --data-urlencode "p=INFLUX_API_TOKEN"`
-
-        #### 1.x password example
-
-        `curl --get "http://localhost:8086/query"
-              --data-urlencode "u=1.x_USERNAME"
-              --data-urlencode "p=1.x_PASSWORD"`
-
-        Replace the following:
-        - *`1.x_USERNAME`*: your InfluxDB v1.x username
-        - *`1.x_PASSWORD`*: your InfluxDB v1.x password
-        - *`INFLUX_API_TOKEN`*: your [InfluxDB API token](https://docs.influxdata.com/influxdb/v2.1/reference/glossary/#token)
-
-        For more information and examples, see how to [authenticate with a username and password scheme](https://docs.influxdata.com/influxdb/v2.1/reference/api/influxdb-1x/)
 security:
   - TokenAuthentication: []
-  - BasicAuthentication: []
-  - QuerystringAuthentication: []

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  title: Influx OSS API Service
+  title: InfluxDB OSS API Service
   version: 2.0.0
   description: |
     The InfluxDB v2 API provides a programmatic interface for all interactions with InfluxDB. Access the InfluxDB API using the `/api/v2/` endpoint.

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -12714,5 +12714,16 @@ components:
           - [`/authorizations`](#tag/Authorizations) endpoint.
           - [Authorize API requests](https://docs.influxdata.com/influxdb/v2.1/api-guide/api_intro/#authentication).
           - [Manage API tokens](https://docs.influxdata.com/influxdb/v2.1/security/tokens).
+    BasicAuthentication:
+      type: http
+      scheme: basic
+      description: |
+        Use the HTTP Basic authentication scheme for InfluxDB `/api/v2` API operations that support it.
+
+        Username and password schemes require the following credentials:
+          - **username**
+          - **password**
+
+        For more information and examples, see how to [authenticate with a username and password scheme](https://docs.influxdata.com/influxdb/v2.1/reference/api/influxdb-1x/)
 security:
   - TokenAuthentication: []

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -12723,7 +12723,5 @@ components:
         Username and password schemes require the following credentials:
           - **username**
           - **password**
-
-        For more information and examples, see how to [authenticate with a username and password scheme](https://docs.influxdata.com/influxdb/v2.1/reference/api/influxdb-1x/)
 security:
   - TokenAuthentication: []

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -5855,6 +5855,26 @@ components:
       - position
       type: object
   securitySchemes:
+    BasicAuthentication:
+      description: |
+        ### Basic authentication scheme
+
+        Use the HTTP Basic authentication scheme for InfluxDB `/api/v2` API operations that support it:
+          - **username**: InfluxDB Cloud username
+          - **password**: InfluxDB Cloud API token
+
+        #### Example
+
+        `curl --get "https://europe-west1-1.gcp.cloud2.influxdata.com/query"
+              --user "exampleuser@influxdata.com":"INFLUX_API_TOKEN"`
+
+        Replace the following:
+        - *`exampleuser@influxdata.com`*: the email address that you signed up with
+        - *`INFLUX_API_TOKEN`*: your [InfluxDB API token](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#token)
+
+        For more information and examples, see how to [authenticate with a username and password](https://docs.influxdata.com/influxdb/cloud/reference/api/influxdb-1x/).
+      scheme: basic
+      type: http
     TokenAuthentication:
       description: |
         Use the [Token authentication](#section/Authentication/TokenAuthentication)

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -5855,73 +5855,29 @@ components:
       - position
       type: object
   securitySchemes:
-    BasicAuthentication:
-      description: |
-        ### Basic authentication scheme
-
-        Use the HTTP Basic authentication scheme with clients that support the InfluxDB 1.x convention of username and password (that don't support the `Authorization: Token` scheme):
-          - **username**: InfluxDB Cloud username
-          - **password**: InfluxDB Cloud API token
-
-        #### Example
-
-        `curl --get "https://europe-west1-1.gcp.cloud2.influxdata.com/query"
-              --user "exampleuser@influxdata.com":"INFLUX_API_TOKEN"`
-
-        Replace the following:
-        - *`exampleuser@influxdata.com`*: the email address that you signed up with
-        - *`INFLUX_API_TOKEN`*: your [InfluxDB API token](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#token)
-
-        For more information and examples, see how to [authenticate with a username and password](https://docs.influxdata.com/influxdb/cloud/reference/api/influxdb-1x/).
-      scheme: basic
-      type: http
-    QuerystringAuthentication:
-      description: |
-        ### Querystring authentication scheme
-
-        Use InfluxDB 1.x API parameters to provide credentials through the query string.
-
-        Username and password schemes require the following credentials:
-        - **username**: InfluxDB Cloud username
-        - **password**: InfluxDB Cloud API token
-
-        #### Example
-
-        `curl --get "https://europe-west1-1.gcp.cloud2.influxdata.com/query"
-              --data-urlencode "u=exampleuser@influxdata.com"
-              --data-urlencode "p=INFLUX_API_TOKEN"`
-
-        Replace the following:
-        - *`exampleuser@influxdata.com`*: the email address that you signed up with
-        - *`INFLUX_API_TOKEN`*: your [InfluxDB API token](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#token)
-
-        For more information and examples, see how to [authenticate with a username and password scheme](https://docs.influxdata.com/influxdb/cloud/reference/api/influxdb-1x/).
-      in: query
-      name: u=&p=
-      type: apiKey
     TokenAuthentication:
-      bearerFormat: InfluxDB token string
       description: |
-        ### Token authentication scheme
+        Use the [Token authentication](#section/Authentication/TokenAuthentication)
+        scheme to authenticate to the InfluxDB API.
 
-        InfluxDB API tokens ensure secure interaction between users and data. A token belongs to an organization and identifies InfluxDB permissions within the organization.
 
-        Include your API token in an `Authorization: Token INFLUX_TOKEN` HTTP header with each request.
+        In your API requests, send an `Authorization` header.
+        For the header value, provide the word `Token` followed by a space and an InfluxDB API token.
+        The word `Token` is case-sensitive.
 
-        #### Example
 
-        `curl https://us-east-1-1.aws.cloud2.influxdata.com/
-           --header "Authorization: Token INFLUX_API_TOKEN"`
+        ### Syntax
 
-        Replace *`INFLUX_API_TOKEN`* with your [InfluxDB API token](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#token).
+        `Authorization: Token YOUR_INFLUX_TOKEN`
+
 
         For more information and examples, see the following:
           - [`/authorizations`](#tag/Authorizations) endpoint.
           - [Authorize API requests](https://docs.influxdata.com/influxdb/cloud/api-guide/api_intro/#authentication).
           - [Manage API tokens](https://docs.influxdata.com/influxdb/cloud/security/tokens).
-          - [Assign a token to a specific user](https://docs.influxdata.com/influxdb/cloud/security/tokens/create-token).
-      scheme: token
-      type: http
+      in: header
+      name: Authorization
+      type: apiKey
 info:
   title: Complete InfluxDB Cloud API
 openapi: 3.0.0
@@ -12204,16 +12160,17 @@ paths:
       - Write
 security:
 - TokenAuthentication: []
-- BasicAuthentication: []
-- QuerystringAuthentication: []
 servers:
 - url: ""
 tags:
 - description: |
-    Use one of the following schemes to authenticate to the InfluxDB API:
-    - [Token authentication](#section/Authentication/TokenAuthentication)
-    - [Basic authentication](#section/Authentication/BasicAuthentication)
-    - [Querystring authentication](#section/Authentication/QuerystringAuthentication)
+    The InfluxDB `/api/v2` API requires authentication for all requests.
+    Use InfluxDB API tokens to authenticate requests to the `/api/v2` API.
+
+
+    For more information, see
+    [Token authentication](#section/Authentication/TokenAuthentication)
+
     <!-- ReDoc-Inject: <security-definitions> -->
   name: Authentication
   x-traitTag: true

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -5871,8 +5871,6 @@ components:
         Replace the following:
         - *`exampleuser@influxdata.com`*: the email address that you signed up with
         - *`INFLUX_API_TOKEN`*: your [InfluxDB API token](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#token)
-
-        For more information and examples, see how to [authenticate with a username and password](https://docs.influxdata.com/influxdb/cloud/reference/api/influxdb-1x/).
       scheme: basic
       type: http
     TokenAuthentication:

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -5785,8 +5785,6 @@ components:
         Username and password schemes require the following credentials:
           - **username**
           - **password**
-
-        For more information and examples, see how to [authenticate with a username and password scheme](https://docs.influxdata.com/influxdb/v2.1/reference/api/influxdb-1x/)
       scheme: basic
       type: http
     TokenAuthentication:

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -5778,89 +5778,29 @@ components:
       - position
       type: object
   securitySchemes:
-    BasicAuthentication:
-      description: |
-        ### Basic authentication scheme
-
-        Use HTTP Basic Auth with clients that support the InfluxDB 1.x convention of username and password (that don't support the `Authorization: Token` scheme).
-
-        Username and password schemes require the following credentials:
-          - **username**: 1.x username (this is separate from the UI login username)
-          - **password**: 1.x password or InfluxDB API token
-
-        #### API token example
-
-        `curl --get "http://localhost:8086/query"
-              --user "1.x_USERNAME":"INFLUX_API_TOKEN"`
-
-        #### 1.x password example
-
-        `curl --get "http://localhost:8086/query"
-              --user "1.x_USERNAME":"1.x_PASSWORD"`
-
-        Replace the following:
-        - *`1.x_USERNAME`*: your InfluxDB v1.x username
-        - *`1.x_PASSWORD`*: your InfluxDB v1.x password
-        - *`INFLUX_API_TOKEN`*: your [InfluxDB API token](https://docs.influxdata.com/influxdb/v2.1/reference/glossary/#token)
-
-        For more information and examples, see how to [authenticate with a username and password scheme](https://docs.influxdata.com/influxdb/v2.1/reference/api/influxdb-1x/)
-      scheme: basic
-      type: http
-    QuerystringAuthentication:
-      description: |
-        ### Querystring authentication scheme
-
-        Use InfluxDB 1.x API parameters to provide credentials through the query string.
-
-        Username and password schemes require the following credentials:
-          - **username**: 1.x username (this is separate from the UI login username)
-          - **password**: 1.x password or InfluxDB API token
-
-        #### API token example
-
-        `curl --get "http://localhost:8086/query"
-              --data-urlencode "u=1.x_USERNAME"
-              --data-urlencode "p=INFLUX_API_TOKEN"`
-
-        #### 1.x password example
-
-        `curl --get "http://localhost:8086/query"
-              --data-urlencode "u=1.x_USERNAME"
-              --data-urlencode "p=1.x_PASSWORD"`
-
-        Replace the following:
-        - *`1.x_USERNAME`*: your InfluxDB v1.x username
-        - *`1.x_PASSWORD`*: your InfluxDB v1.x password
-        - *`INFLUX_API_TOKEN`*: your [InfluxDB API token](https://docs.influxdata.com/influxdb/v2.1/reference/glossary/#token)
-
-        For more information and examples, see how to [authenticate with a username and password scheme](https://docs.influxdata.com/influxdb/v2.1/reference/api/influxdb-1x/)
-      in: query
-      name: u=&p=
-      type: apiKey
     TokenAuthentication:
-      bearerFormat: InfluxDB Token String
       description: |
-        ### Token authentication scheme
+        Use the [Token authentication](#section/Authentication/TokenAuthentication)
+        scheme to authenticate to the InfluxDB API.
 
-        InfluxDB API tokens enable authentication and authorization of API clients.
-        A token belongs to an organization and identifies InfluxDB permissions within the organization.
 
-        Include your API token in an `Authorization: Token` HTTP header with each request.
+        In your API requests, send an `Authorization` header.
+        For the header value, provide the word `Token` followed by a space and an InfluxDB API token.
+        The word `Token` is case-sensitive.
 
-        #### Example
 
-          `curl http://localhost:8086/ping
-             --header "Authorization: Token INFLUX_API_TOKEN"`
+        ### Syntax
 
-        Replace *`INFLUX_API_TOKEN`* with your [InfluxDB API token](https://docs.influxdata.com/influxdb/v2.1/reference/glossary/#token).
+        `Authorization: Token YOUR_INFLUX_TOKEN`
+
 
         For more information and examples, see the following:
           - [`/authorizations`](#tag/Authorizations) endpoint.
           - [Authorize API requests](https://docs.influxdata.com/influxdb/v2.1/api-guide/api_intro/#authentication).
           - [Manage API tokens](https://docs.influxdata.com/influxdb/v2.1/security/tokens).
-          - [Assign a token to a specific user](https://docs.influxdata.com/influxdb/v2.1/security/tokens/create-token).
-      scheme: token
-      type: http
+      in: header
+      name: Authorization
+      type: apiKey
 info:
   title: Complete InfluxDB OSS API
 openapi: 3.0.0
@@ -12800,16 +12740,17 @@ paths:
       - Write
 security:
 - TokenAuthentication: []
-- BasicAuthentication: []
-- QuerystringAuthentication: []
 servers:
 - url: ""
 tags:
 - description: |
-    Use one of the following schemes to authenticate to the InfluxDB API:
-    - [Token authentication](#section/Authentication/TokenAuthentication)
-    - [Basic authentication](#section/Authentication/BasicAuthentication)
-    - [Querystring authentication](#section/Authentication/QuerystringAuthentication)
+    The InfluxDB `/api/v2` API requires authentication for all requests.
+    Use InfluxDB API tokens to authenticate requests to the `/api/v2` API.
+
+
+    For examples and more information, see
+    [Token authentication](#section/Authentication/TokenAuthentication)
+
     <!-- ReDoc-Inject: <security-definitions> -->
   name: Authentication
   x-traitTag: true

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -5778,6 +5778,17 @@ components:
       - position
       type: object
   securitySchemes:
+    BasicAuthentication:
+      description: |
+        Use the HTTP Basic authentication scheme for InfluxDB `/api/v2` API operations that support it.
+
+        Username and password schemes require the following credentials:
+          - **username**
+          - **password**
+
+        For more information and examples, see how to [authenticate with a username and password scheme](https://docs.influxdata.com/influxdb/v2.1/reference/api/influxdb-1x/)
+      scheme: basic
+      type: http
     TokenAuthentication:
       description: |
         Use the [Token authentication](#section/Authentication/TokenAuthentication)

--- a/contracts/swaggerV1Compat.yml
+++ b/contracts/swaggerV1Compat.yml
@@ -10,17 +10,17 @@ info:
 
 
     If you want to use the latest InfluxDB `/api/v2` API instead,
-    see the [InfluxDB v2 API documentation]({{% INFLUXDB_DOCS_URL %}}/api).
+    see the [InfluxDB v2 API documentation](https://docs.influxdata.com/influxdb/cloud/api/).
 servers:
   - url: /
-    description: V1 compatible api endpoints.
+    description: V1-compatible API endpoints.
 paths:
   /write:
     post:
       operationId: PostWriteV1
       tags:
         - Write
-      summary: Write time series data into InfluxDB in a V1 compatible format
+      summary: Write time series data into InfluxDB in a V1-compatible format
       requestBody:
         description: Line protocol body
         required: true
@@ -368,8 +368,8 @@ components:
 
         For examples and more information, see the following:
           - [`/authorizations`](#tag/Authorizations) endpoint.
-          - [Authorize API requests]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication).
-          - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens).
+          - [Authorize API requests](https://docs.influxdata.com/influxdb/cloud/api-guide/api_intro/#authentication).
+          - [Manage API tokens](https://docs.influxdata.com/influxdb/cloud/security/tokens/).
     BasicAuthentication:
       type: http
       scheme: basic
@@ -378,7 +378,7 @@ components:
         scheme with clients that support the InfluxDB 1.x convention of username and password (that don't support the `Authorization: Token` scheme):
 
 
-        For examples and more information, see how to [authenticate with a username and password]({{% INFLUXDB_DOCS_URL %}}/reference/api/influxdb-1x/).
+        For examples and more information, see how to [authenticate with a username and password](https://docs.influxdata.com/influxdb/cloud/reference/api/influxdb-1x/).
     QuerystringAuthentication:
        type: apiKey
        in: query
@@ -388,7 +388,7 @@ components:
          scheme with InfluxDB 1.x API parameters to provide credentials through the query string.
 
 
-         For examples and more information, see how to [authenticate with a username and password]({{% INFLUXDB_DOCS_URL %}}/reference/api/influxdb-1x/).
+         For examples and more information, see how to [authenticate with a username and password](https://docs.influxdata.com/influxdb/cloud/reference/api/influxdb-1x/).
 security:
   - TokenAuthentication: []
   - BasicAuthentication: []

--- a/contracts/swaggerV1Compat.yml
+++ b/contracts/swaggerV1Compat.yml
@@ -1,7 +1,7 @@
 # this is a manually maintained file for these old routes until oats#15 is resolved
 openapi: "3.0.0"
 info:
-  title: Influx API Service (V1 compatible endpoints)
+  title: InfluxDB API Service (V1 compatible endpoints)
   version: 0.1.0
   description: |
     The InfluxDB 1.x compatibility /write and /query endpoints work with

--- a/contracts/swaggerV1Compat.yml
+++ b/contracts/swaggerV1Compat.yml
@@ -3,12 +3,20 @@ openapi: "3.0.0"
 info:
   title: Influx API Service (V1 compatible endpoints)
   version: 0.1.0
+  description: |
+    The InfluxDB 1.x compatibility /write and /query endpoints work with
+    InfluxDB 1.x client libraries and third-party integrations like Grafana
+    and others.
+
+
+    If you want to use the latest InfluxDB `/api/v2` API instead,
+    see the [InfluxDB v2 API documentation]({{% INFLUXDB_DOCS_URL %}}/api).
 servers:
   - url: /
     description: V1 compatible api endpoints.
 paths:
   /write:
-    post: # technically this functions with other methods as well
+    post:
       operationId: PostWriteV1
       tags:
         - Write
@@ -42,7 +50,7 @@ paths:
           description: Write precision.
         - in: header
           name: Content-Encoding
-          description: When present, its value indicates to the database that compression is applied to the line-protocol body.
+          description: When present, its value indicates to the database that compression is applied to the line protocol body.
           schema:
             type: string
             description: Specifies that the line protocol in the body is encoded with gzip or not encoded with identity.
@@ -142,6 +150,17 @@ paths:
             type: string
             enum:
               - application/vnd.influxql
+        - in: query
+          name: db
+          schema:
+            type: string
+          required: true
+          description: The bucket to query.
+        - in: query
+          name: rp
+          schema:
+            type: string
+          description: The retention policy name.
         - in: query
           name: q
           description: Defines the influxql query to run.
@@ -327,3 +346,64 @@ components:
           type: integer
           format: int32
       required: [code, message, maxLength]
+  securitySchemes:
+    TokenAuthentication:
+      type: apiKey
+      name: Authorization
+      in: header
+      description: |
+        Use the [Token authentication](#section/Authentication/TokenAuthentication)
+        scheme to authenticate to the InfluxDB API.
+
+
+        In your API requests, send an `Authorization` header.
+        For the header value, provide the word `Token` followed by a space and an InfluxDB API token.
+        The word `Token` is case-sensitive.
+
+
+        ### Syntax
+
+        `Authorization: Token YOUR_INFLUX_TOKEN`
+
+
+        For examples and more information, see the following:
+          - [`/authorizations`](#tag/Authorizations) endpoint.
+          - [Authorize API requests]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication).
+          - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens).
+    BasicAuthentication:
+      type: http
+      scheme: basic
+      description: |
+        Use the HTTP [Basic authentication](#section/Authentication/BasicAuthentication)
+        scheme with clients that support the InfluxDB 1.x convention of username and password (that don't support the `Authorization: Token` scheme):
+
+
+        For examples and more information, see how to [authenticate with a username and password]({{% INFLUXDB_DOCS_URL %}}/reference/api/influxdb-1x/).
+    QuerystringAuthentication:
+       type: apiKey
+       in: query
+       name: u=&p=
+       description: |
+         Use the [Querystring authentication](#section/Authentication/QuerystringAuthentication)
+         scheme with InfluxDB 1.x API parameters to provide credentials through the query string.
+
+
+         For examples and more information, see how to [authenticate with a username and password]({{% INFLUXDB_DOCS_URL %}}/reference/api/influxdb-1x/).
+security:
+  - TokenAuthentication: []
+  - BasicAuthentication: []
+  - QuerystringAuthentication: []
+tags:
+  - name: Authentication
+    description: |
+      The InfluxDB 1.x API requires authentication for all requests.
+      InfluxDB Cloud uses InfluxDB API tokens to authenticate requests.
+
+
+      For more information, see the following:
+      - [Token authentication](#section/Authentication/TokenAuthentication)
+      - [Basic authentication](#section/Authentication/BasicAuthentication)
+      - [Querystring authentication](#section/Authentication/QuerystringAuthentication)
+
+      <!-- ReDoc-Inject: <security-definitions> -->
+    x-traitTag: true

--- a/src/cloud.yml
+++ b/src/cloud.yml
@@ -224,7 +224,5 @@ components:
        Replace the following:
        - *`exampleuser@influxdata.com`*: the email address that you signed up with
        - *`INFLUX_API_TOKEN`*: your [InfluxDB API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token)
-
-       For more information and examples, see how to [authenticate with a username and password]({{% INFLUXDB_DOCS_URL %}}/reference/api/influxdb-1x/).
 security:
   - TokenAuthentication: []

--- a/src/cloud.yml
+++ b/src/cloud.yml
@@ -9,10 +9,13 @@ servers:
 tags:
   - name: Authentication
     description: |
-      Use one of the following schemes to authenticate to the InfluxDB API:
-      - [Token authentication](#section/Authentication/TokenAuthentication)
-      - [Basic authentication](#section/Authentication/BasicAuthentication)
-      - [Querystring authentication](#section/Authentication/QuerystringAuthentication)
+      The InfluxDB `/api/v2` API requires authentication for all requests.
+      Use InfluxDB API tokens to authenticate requests to the `/api/v2` API.
+
+
+      For more information, see
+      [Token authentication](#section/Authentication/TokenAuthentication)
+
       <!-- ReDoc-Inject: <security-definitions> -->
     x-traitTag: true
   - name: Quick start
@@ -181,73 +184,27 @@ components:
       $ref: './common/responses/ServerError.yml'
   securitySchemes:
     TokenAuthentication:
-      type: http
-      scheme: token
-      bearerFormat: InfluxDB token string
+      type: apiKey
+      name: Authorization
+      in: header
       description: |
-        ### Token authentication scheme
+        Use the [Token authentication](#section/Authentication/TokenAuthentication)
+        scheme to authenticate to the InfluxDB API.
 
-        InfluxDB API tokens ensure secure interaction between users and data. A token belongs to an organization and identifies InfluxDB permissions within the organization.
 
-        Include your API token in an `Authorization: Token INFLUX_TOKEN` HTTP header with each request.
+        In your API requests, send an `Authorization` header.
+        For the header value, provide the word `Token` followed by a space and an InfluxDB API token.
+        The word `Token` is case-sensitive.
 
-        #### Example
 
-        `curl https://us-east-1-1.aws.cloud2.influxdata.com/
-           --header "Authorization: Token INFLUX_API_TOKEN"`
+        ### Syntax
 
-        Replace *`INFLUX_API_TOKEN`* with your [InfluxDB API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token).
+        `Authorization: Token YOUR_INFLUX_TOKEN`
+
 
         For more information and examples, see the following:
           - [`/authorizations`](#tag/Authorizations) endpoint.
           - [Authorize API requests]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication).
           - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens).
-          - [Assign a token to a specific user]({{% INFLUXDB_DOCS_URL %}}/security/tokens/create-token).
-    BasicAuthentication:
-      type: http
-      scheme: basic
-      description: |
-        ### Basic authentication scheme
-
-        Use the HTTP Basic authentication scheme with clients that support the InfluxDB 1.x convention of username and password (that don't support the `Authorization: Token` scheme):
-          - **username**: InfluxDB Cloud username
-          - **password**: InfluxDB Cloud API token
-
-        #### Example
-
-        `curl --get "https://europe-west1-1.gcp.cloud2.influxdata.com/query"
-              --user "exampleuser@influxdata.com":"INFLUX_API_TOKEN"`
-
-        Replace the following:
-        - *`exampleuser@influxdata.com`*: the email address that you signed up with
-        - *`INFLUX_API_TOKEN`*: your [InfluxDB API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token)
-
-        For more information and examples, see how to [authenticate with a username and password]({{% INFLUXDB_DOCS_URL %}}/reference/api/influxdb-1x/).
-    QuerystringAuthentication:
-       type: apiKey
-       in: query
-       name: u=&p=
-       description: |
-         ### Querystring authentication scheme
-
-         Use InfluxDB 1.x API parameters to provide credentials through the query string.
-
-         Username and password schemes require the following credentials:
-         - **username**: InfluxDB Cloud username
-         - **password**: InfluxDB Cloud API token
-
-         #### Example
-
-         `curl --get "https://europe-west1-1.gcp.cloud2.influxdata.com/query"
-               --data-urlencode "u=exampleuser@influxdata.com"
-               --data-urlencode "p=INFLUX_API_TOKEN"`
-
-         Replace the following:
-         - *`exampleuser@influxdata.com`*: the email address that you signed up with
-         - *`INFLUX_API_TOKEN`*: your [InfluxDB API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token)
-
-         For more information and examples, see how to [authenticate with a username and password scheme]({{% INFLUXDB_DOCS_URL %}}/reference/api/influxdb-1x/).
 security:
   - TokenAuthentication: []
-  - BasicAuthentication: []
-  - QuerystringAuthentication: []

--- a/src/cloud.yml
+++ b/src/cloud.yml
@@ -1,6 +1,6 @@
 openapi: '3.0.0'
 info:
-  title: Influx Cloud API Service
+  title: InfluxDB Cloud API Service
   version: 2.0.1
   description: |
     The InfluxDB v2 API provides a programmatic interface for all interactions with InfluxDB. Access the InfluxDB API using the `/api/v2/` endpoint.

--- a/src/cloud.yml
+++ b/src/cloud.yml
@@ -206,5 +206,25 @@ components:
           - [`/authorizations`](#tag/Authorizations) endpoint.
           - [Authorize API requests]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication).
           - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens).
+    BasicAuthentication:
+      type: http
+      scheme: basic
+      description: |
+       ### Basic authentication scheme
+
+       Use the HTTP Basic authentication scheme for InfluxDB `/api/v2` API operations that support it:
+         - **username**: InfluxDB Cloud username
+         - **password**: InfluxDB Cloud API token
+
+       #### Example
+
+       `curl --get "https://europe-west1-1.gcp.cloud2.influxdata.com/query"
+             --user "exampleuser@influxdata.com":"INFLUX_API_TOKEN"`
+
+       Replace the following:
+       - *`exampleuser@influxdata.com`*: the email address that you signed up with
+       - *`INFLUX_API_TOKEN`*: your [InfluxDB API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token)
+
+       For more information and examples, see how to [authenticate with a username and password]({{% INFLUXDB_DOCS_URL %}}/reference/api/influxdb-1x/).
 security:
   - TokenAuthentication: []

--- a/src/oss.yml
+++ b/src/oss.yml
@@ -339,7 +339,6 @@ components:
           - **username**
           - **password**
 
-        For more information and examples, see how to [authenticate with a username and password scheme]({{% INFLUXDB_DOCS_URL %}}/reference/api/influxdb-1x/)
 security:
   - TokenAuthentication: []
   # TODO: Uncomment when Bearer auth is also available in Cloud:

--- a/src/oss.yml
+++ b/src/oss.yml
@@ -9,10 +9,13 @@ servers:
 tags:
   - name: Authentication
     description: |
-      Use one of the following schemes to authenticate to the InfluxDB API:
-      - [Token authentication](#section/Authentication/TokenAuthentication)
-      - [Basic authentication](#section/Authentication/BasicAuthentication)
-      - [Querystring authentication](#section/Authentication/QuerystringAuthentication)
+      The InfluxDB `/api/v2` API requires authentication for all requests.
+      Use InfluxDB API tokens to authenticate requests to the `/api/v2` API.
+
+
+      For examples and more information, see
+      [Token authentication](#section/Authentication/TokenAuthentication)
+
       <!-- ReDoc-Inject: <security-definitions> -->
     x-traitTag: true
   - name: Quick start
@@ -281,90 +284,52 @@ components:
     ServerError:
       $ref: './common/responses/ServerError.yml'
   securitySchemes:
+    # TODO: Uncomment when Bearer auth is also available in Cloud:
+    # BearerAuthentication:
+    #   type: http
+    #   scheme: "bearer"
+    #   description: |
+    #     Use the [Bearer authentication](#section/Authentication/BearerAuthentication)
+    #     scheme to authenticate to the InfluxDB API.
+    #
+    #
+    #     In your API requests, send an `Authorization` header.
+    #     For the header value, provide the word `Bearer` followed by a space and an InfluxDB API token.
+    #
+    #
+    #     ### Syntax
+    #
+    #     `Authorization: Bearer YOUR_INFLUX_TOKEN`
+    #
+    #
+    #     For more information and examples, see the following:
+    #       - [`/authorizations`](#tag/Authorizations) endpoint.
+    #       - [Authorize API requests]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication).
+    #       - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens).
     TokenAuthentication:
-      type: http
-      scheme: token
-      bearerFormat: InfluxDB Token String
+      type: apiKey
+      name: Authorization
+      in: header
       description: |
-        ### Token authentication scheme
+        Use the [Token authentication](#section/Authentication/TokenAuthentication)
+        scheme to authenticate to the InfluxDB API.
 
-        InfluxDB API tokens enable authentication and authorization of API clients.
-        A token belongs to an organization and identifies InfluxDB permissions within the organization.
 
-        Include your API token in an `Authorization: Token` HTTP header with each request.
+        In your API requests, send an `Authorization` header.
+        For the header value, provide the word `Token` followed by a space and an InfluxDB API token.
+        The word `Token` is case-sensitive.
 
-        #### Example
 
-          `curl http://localhost:8086/ping
-             --header "Authorization: Token INFLUX_API_TOKEN"`
+        ### Syntax
 
-        Replace *`INFLUX_API_TOKEN`* with your [InfluxDB API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token).
+        `Authorization: Token YOUR_INFLUX_TOKEN`
+
 
         For more information and examples, see the following:
           - [`/authorizations`](#tag/Authorizations) endpoint.
           - [Authorize API requests]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication).
           - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens).
-          - [Assign a token to a specific user]({{% INFLUXDB_DOCS_URL %}}/security/tokens/create-token).
-    BasicAuthentication:
-      type: http
-      scheme: basic
-      description: |
-        ### Basic authentication scheme
-
-        Use HTTP Basic Auth with clients that support the InfluxDB 1.x convention of username and password (that don't support the `Authorization: Token` scheme).
-
-        Username and password schemes require the following credentials:
-          - **username**: 1.x username (this is separate from the UI login username)
-          - **password**: 1.x password or InfluxDB API token
-
-        #### API token example
-
-        `curl --get "http://localhost:8086/query"
-              --user "1.x_USERNAME":"INFLUX_API_TOKEN"`
-
-        #### 1.x password example
-
-        `curl --get "http://localhost:8086/query"
-              --user "1.x_USERNAME":"1.x_PASSWORD"`
-
-        Replace the following:
-        - *`1.x_USERNAME`*: your InfluxDB v1.x username
-        - *`1.x_PASSWORD`*: your InfluxDB v1.x password
-        - *`INFLUX_API_TOKEN`*: your [InfluxDB API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token)
-
-        For more information and examples, see how to [authenticate with a username and password scheme]({{% INFLUXDB_DOCS_URL %}}/reference/api/influxdb-1x/)
-    QuerystringAuthentication:
-      type: apiKey
-      in: query
-      name: u=&p=
-      description: |
-        ### Querystring authentication scheme
-
-        Use InfluxDB 1.x API parameters to provide credentials through the query string.
-
-        Username and password schemes require the following credentials:
-          - **username**: 1.x username (this is separate from the UI login username)
-          - **password**: 1.x password or InfluxDB API token
-
-        #### API token example
-
-        `curl --get "http://localhost:8086/query"
-              --data-urlencode "u=1.x_USERNAME"
-              --data-urlencode "p=INFLUX_API_TOKEN"`
-
-        #### 1.x password example
-
-        `curl --get "http://localhost:8086/query"
-              --data-urlencode "u=1.x_USERNAME"
-              --data-urlencode "p=1.x_PASSWORD"`
-
-        Replace the following:
-        - *`1.x_USERNAME`*: your InfluxDB v1.x username
-        - *`1.x_PASSWORD`*: your InfluxDB v1.x password
-        - *`INFLUX_API_TOKEN`*: your [InfluxDB API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token)
-
-        For more information and examples, see how to [authenticate with a username and password scheme]({{% INFLUXDB_DOCS_URL %}}/reference/api/influxdb-1x/)
 security:
-- TokenAuthentication: []
-- BasicAuthentication: []
-- QuerystringAuthentication: []
+  - TokenAuthentication: []
+  # TODO: Uncomment when Bearer auth is also available in Cloud:
+  # - BearerAuthentication: []

--- a/src/oss.yml
+++ b/src/oss.yml
@@ -329,6 +329,17 @@ components:
           - [`/authorizations`](#tag/Authorizations) endpoint.
           - [Authorize API requests]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication).
           - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens).
+    BasicAuthentication:
+      type: http
+      scheme: basic
+      description: |
+        Use the HTTP Basic authentication scheme for InfluxDB `/api/v2` API operations that support it.
+
+        Username and password schemes require the following credentials:
+          - **username**
+          - **password**
+
+        For more information and examples, see how to [authenticate with a username and password scheme]({{% INFLUXDB_DOCS_URL %}}/reference/api/influxdb-1x/)
 security:
   - TokenAuthentication: []
   # TODO: Uncomment when Bearer auth is also available in Cloud:

--- a/src/oss.yml
+++ b/src/oss.yml
@@ -1,6 +1,6 @@
 openapi: "3.0.0"
 info:
-  title: Influx OSS API Service
+  title: InfluxDB OSS API Service
   version: 2.0.0
   description: |
     The InfluxDB v2 API provides a programmatic interface for all interactions with InfluxDB. Access the InfluxDB API using the `/api/v2/` endpoint.


### PR DESCRIPTION
* Fixes auth (security) schemes in cloud, oss, and v1compat.
* Adds missing `db=` and `rp=` query params in v1compat `/query`.
* Adds tagging for navigation in v1compat API docs.