### PR TITLE
chore: arrange write path response types so CLI codegen works correctly

### DIFF
--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -1760,17 +1760,6 @@
           "413": {
             "description": "The request payload is too large. InfluxDB rejected the batch and did not write any data.\n#### InfluxDB Cloud:\n - returns this error if the payload exceeds the 50MB size limit.\n - returns `Content-Type: text/html` for this error.\n\n#### InfluxDB OSS:\n - returns this error only if the [Go (golang) `ioutil.ReadAll()`](https://pkg.go.dev/io/ioutil#ReadAll) function raises an error.\n - returns `Content-Type: application/json` for this error.\n",
             "content": {
-              "text/html": {
-                "schema": {
-                  "type": "string"
-                },
-                "examples": {
-                  "dataExceedsSizeLimit": {
-                    "summary": "InfluxDB Cloud response",
-                    "value": "<html>\n  <head><title>413 Request Entity Too Large</title></head>\n  <body>\n    <center><h1>413 Request Entity Too Large</h1></center>\n    <hr>\n    <center>nginx</center>\n  </body>\n</html>\n"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/LineProtocolLengthError"
@@ -1779,6 +1768,17 @@
                   "dataExceedsSizeLimitOSS": {
                     "summary": "InfluxDB OSS response",
                     "value": "{\"code\":\"request too large\",\"message\":\"unable to read data: points batch is too large\"}\n"
+                  }
+                }
+              },
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                },
+                "examples": {
+                  "dataExceedsSizeLimit": {
+                    "summary": "InfluxDB Cloud response",
+                    "value": "<html>\n  <head><title>413 Request Entity Too Large</title></head>\n  <body>\n    <center><h1>413 Request Entity Too Large</h1></center>\n    <hr>\n    <center>nginx</center>\n  </body>\n</html>\n"
                   }
                 }
               }

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -1164,6 +1164,14 @@ paths:
              - returns this error only if the [Go (golang) `ioutil.ReadAll()`](https://pkg.go.dev/io/ioutil#ReadAll) function raises an error.
              - returns `Content-Type: application/json` for this error.
           content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LineProtocolLengthError'
+              examples:
+                dataExceedsSizeLimitOSS:
+                  summary: InfluxDB OSS response
+                  value: |
+                    {"code":"request too large","message":"unable to read data: points batch is too large"}
             text/html:
               schema:
                 type: string
@@ -1179,14 +1187,6 @@ paths:
                         <center>nginx</center>
                       </body>
                     </html>
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LineProtocolLengthError'
-              examples:
-                dataExceedsSizeLimitOSS:
-                  summary: InfluxDB OSS response
-                  value: |
-                    {"code":"request too large","message":"unable to read data: points batch is too large"}
         '429':
           description: InfluxDB Cloud only. The token is temporarily over quota. The Retry-After header describes when to try the write again.
           headers:

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -1048,6 +1048,14 @@ paths:
              - returns this error only if the [Go (golang) `ioutil.ReadAll()`](https://pkg.go.dev/io/ioutil#ReadAll) function raises an error.
              - returns `Content-Type: application/json` for this error.
           content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LineProtocolLengthError'
+              examples:
+                dataExceedsSizeLimitOSS:
+                  summary: InfluxDB OSS response
+                  value: |
+                    {"code":"request too large","message":"unable to read data: points batch is too large"}
             text/html:
               schema:
                 type: string
@@ -1063,14 +1071,6 @@ paths:
                         <center>nginx</center>
                       </body>
                     </html>
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LineProtocolLengthError'
-              examples:
-                dataExceedsSizeLimitOSS:
-                  summary: InfluxDB OSS response
-                  value: |
-                    {"code":"request too large","message":"unable to read data: points batch is too large"}
         '429':
           description: InfluxDB Cloud only. The token is temporarily over quota. The Retry-After header describes when to try the write again.
           headers:

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -1763,17 +1763,6 @@
           "413": {
             "description": "The request payload is too large. InfluxDB rejected the batch and did not write any data.\n#### InfluxDB Cloud:\n - returns this error if the payload exceeds the 50MB size limit.\n - returns `Content-Type: text/html` for this error.\n\n#### InfluxDB OSS:\n - returns this error only if the [Go (golang) `ioutil.ReadAll()`](https://pkg.go.dev/io/ioutil#ReadAll) function raises an error.\n - returns `Content-Type: application/json` for this error.\n",
             "content": {
-              "text/html": {
-                "schema": {
-                  "type": "string"
-                },
-                "examples": {
-                  "dataExceedsSizeLimit": {
-                    "summary": "InfluxDB Cloud response",
-                    "value": "<html>\n  <head><title>413 Request Entity Too Large</title></head>\n  <body>\n    <center><h1>413 Request Entity Too Large</h1></center>\n    <hr>\n    <center>nginx</center>\n  </body>\n</html>\n"
-                  }
-                }
-              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/LineProtocolLengthError"
@@ -1782,6 +1771,17 @@
                   "dataExceedsSizeLimitOSS": {
                     "summary": "InfluxDB OSS response",
                     "value": "{\"code\":\"request too large\",\"message\":\"unable to read data: points batch is too large\"}\n"
+                  }
+                }
+              },
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                },
+                "examples": {
+                  "dataExceedsSizeLimit": {
+                    "summary": "InfluxDB Cloud response",
+                    "value": "<html>\n  <head><title>413 Request Entity Too Large</title></head>\n  <body>\n    <center><h1>413 Request Entity Too Large</h1></center>\n    <hr>\n    <center>nginx</center>\n  </body>\n</html>\n"
                   }
                 }
               }

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -1167,6 +1167,14 @@ paths:
              - returns this error only if the [Go (golang) `ioutil.ReadAll()`](https://pkg.go.dev/io/ioutil#ReadAll) function raises an error.
              - returns `Content-Type: application/json` for this error.
           content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LineProtocolLengthError'
+              examples:
+                dataExceedsSizeLimitOSS:
+                  summary: InfluxDB OSS response
+                  value: |
+                    {"code":"request too large","message":"unable to read data: points batch is too large"}
             text/html:
               schema:
                 type: string
@@ -1182,14 +1190,6 @@ paths:
                         <center>nginx</center>
                       </body>
                     </html>
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LineProtocolLengthError'
-              examples:
-                dataExceedsSizeLimitOSS:
-                  summary: InfluxDB OSS response
-                  value: |
-                    {"code":"request too large","message":"unable to read data: points batch is too large"}
         '429':
           description: InfluxDB Cloud only. The token is temporarily over quota. The Retry-After header describes when to try the write again.
           headers:

--- a/src/common/paths/write.yml
+++ b/src/common/paths/write.yml
@@ -128,6 +128,14 @@ post:
         - returns this error only if the [Go (golang) `ioutil.ReadAll()`](https://pkg.go.dev/io/ioutil#ReadAll) function raises an error.
         - returns `Content-Type: application/json` for this error.
       content:
+        application/json:
+          schema:
+            $ref: "../../common/schemas/LineProtocolLengthError.yml"
+          examples:
+            dataExceedsSizeLimitOSS:
+              summary: InfluxDB OSS response
+              value: |
+                {"code":"request too large","message":"unable to read data: points batch is too large"}
         text/html:
           schema:
             type: string
@@ -143,14 +151,6 @@ post:
                     <center>nginx</center>
                   </body>
                 </html>
-        application/json:
-          schema:
-            $ref: "../../common/schemas/LineProtocolLengthError.yml"
-          examples:
-            dataExceedsSizeLimitOSS:
-              summary: InfluxDB OSS response
-              value: |
-                {"code":"request too large","message":"unable to read data: points batch is too large"}
     "429":
       description: "InfluxDB Cloud only. The token is temporarily over quota. The Retry-After header describes when to try the write again."
       headers:

--- a/src/common/paths/write.yml
+++ b/src/common/paths/write.yml
@@ -128,6 +128,7 @@ post:
         - returns this error only if the [Go (golang) `ioutil.ReadAll()`](https://pkg.go.dev/io/ioutil#ReadAll) function raises an error.
         - returns `Content-Type: application/json` for this error.
       content:
+        # application/json must be listed first for the influx-cli codegen to work properly, see https://github.com/influxdata/openapi/pull/253
         application/json:
           schema:
             $ref: "../../common/schemas/LineProtocolLengthError.yml"


### PR DESCRIPTION
Moves the `application/json` above the `text/html` content type so that the openapi codegen tool used by `influx-cli` uses the correct struct type. With `text/html` appearing first, the error type was being initialized as a `string` rather than a `LineProtocolLengthError`. This should match the intent of https://github.com/influxdata/openapi/pull/242