### PR TITLE
feat(oss): Document /metrics path for OSS

### DIFF
--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -56,8 +56,8 @@ tags:
 
       For more information and examples, see the following:
         - [Authorize API requests]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication).
-        - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens).
-        - [Assign a token to a specific user]({{% INFLUXDB_DOCS_URL %}}/security/tokens/create-token).
+        - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens/).
+        - [Assign a token to a specific user]({{% INFLUXDB_DOCS_URL %}}/security/tokens/create-token/).
 x-tagGroups:
   - name: Overview
     tags:
@@ -3911,7 +3911,7 @@ components:
         For more information and examples, see the following:
           - [`/authorizations`](#tag/Authorizations) endpoint.
           - [Authorize API requests]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication).
-          - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens).
+          - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens/).
     BasicAuthentication:
       type: http
       scheme: basic

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -36,7 +36,7 @@
     },
     {
       "name": "Authorizations",
-      "description": "Create and manage API tokens. An **authorization** associates a list of permissions to an **organization** and provides a token for API access. Optionally, you can restrict an authorization and its token to a specific user.\n\nFor more information and examples, see the following:\n  - [Authorize API requests]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication).\n  - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens).\n  - [Assign a token to a specific user]({{% INFLUXDB_DOCS_URL %}}/security/tokens/create-token).\n"
+      "description": "Create and manage API tokens. An **authorization** associates a list of permissions to an **organization** and provides a token for API access. Optionally, you can restrict an authorization and its token to a specific user.\n\nFor more information and examples, see the following:\n  - [Authorize API requests]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication).\n  - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens/).\n  - [Assign a token to a specific user]({{% INFLUXDB_DOCS_URL %}}/security/tokens/create-token/).\n"
     }
   ],
   "x-tagGroups": [
@@ -1698,7 +1698,7 @@
         ],
         "responses": {
           "204": {
-            "description": "InfluxDB validated the request data format and accepted the data for writing to the bucket. `204` doesn't indicate a successful write operation since writes are asynchronous. See [how to check for write errors]({{% INFLUXDB_DOCS_URL %}}/write-data/troubleshoot)."
+            "description": "InfluxDB validated the request data format and accepted the data for writing to the bucket. `204` doesn't indicate a successful write operation since writes are asynchronous. See [how to check for write errors]({{% INFLUXDB_DOCS_URL %}}/write-data/troubleshoot/)."
           },
           "400": {
             "description": "Bad request. The line protocol data in the request is malformed. The response body contains the first malformed line in the data. InfluxDB rejected the batch and did not write any data.",
@@ -1815,7 +1815,7 @@
             }
           },
           "503": {
-            "description": "The server is temporarily unavailable to accept writes.  The `Retry-After` header describes when to try the write again.",
+            "description": "The server is temporarily unavailable to accept writes. The `Retry-After` header describes when to try the write again.",
             "headers": {
               "Retry-After": {
                 "description": "A non-negative decimal integer indicating the seconds to delay after the response is received.",
@@ -18367,7 +18367,7 @@
         "type": "apiKey",
         "name": "Authorization",
         "in": "header",
-        "description": "Use the [Token authentication](#section/Authentication/TokenAuthentication)\nscheme to authenticate to the InfluxDB API.\n\n\nIn your API requests, send an `Authorization` header.\nFor the header value, provide the word `Token` followed by a space and an InfluxDB API token.\nThe word `Token` is case-sensitive.\n\n\n### Syntax\n\n`Authorization: Token YOUR_INFLUX_TOKEN`\n\n\nFor more information and examples, see the following:\n  - [`/authorizations`](#tag/Authorizations) endpoint.\n  - [Authorize API requests]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication).\n  - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens).\n"
+        "description": "Use the [Token authentication](#section/Authentication/TokenAuthentication)\nscheme to authenticate to the InfluxDB API.\n\n\nIn your API requests, send an `Authorization` header.\nFor the header value, provide the word `Token` followed by a space and an InfluxDB API token.\nThe word `Token` is case-sensitive.\n\n\n### Syntax\n\n`Authorization: Token YOUR_INFLUX_TOKEN`\n\n\nFor more information and examples, see the following:\n  - [`/authorizations`](#tag/Authorizations) endpoint.\n  - [Authorize API requests]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication).\n  - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens/).\n"
       },
       "BasicAuthentication": {
         "type": "http",

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -56,8 +56,8 @@ tags:
 
       For more information and examples, see the following:
         - [Authorize API requests](https://docs.influxdata.com/influxdb/cloud/api-guide/api_intro/#authentication).
-        - [Manage API tokens](https://docs.influxdata.com/influxdb/cloud/security/tokens).
-        - [Assign a token to a specific user](https://docs.influxdata.com/influxdb/cloud/security/tokens/create-token).
+        - [Manage API tokens](https://docs.influxdata.com/influxdb/cloud/security/tokens/).
+        - [Assign a token to a specific user](https://docs.influxdata.com/influxdb/cloud/security/tokens/create-token/).
 x-tagGroups:
   - name: Overview
     tags:
@@ -1112,7 +1112,7 @@ paths:
             $ref: '#/components/schemas/WritePrecision'
       responses:
         '204':
-          description: 'InfluxDB validated the request data format and accepted the data for writing to the bucket. `204` doesn''t indicate a successful write operation since writes are asynchronous. See [how to check for write errors](https://docs.influxdata.com/influxdb/cloud/write-data/troubleshoot).'
+          description: 'InfluxDB validated the request data format and accepted the data for writing to the bucket. `204` doesn''t indicate a successful write operation since writes are asynchronous. See [how to check for write errors](https://docs.influxdata.com/influxdb/cloud/write-data/troubleshoot/).'
         '400':
           description: Bad request. The line protocol data in the request is malformed. The response body contains the first malformed line in the data. InfluxDB rejected the batch and did not write any data.
           content:
@@ -1207,7 +1207,7 @@ paths:
                   value:
                     code: internal error
         '503':
-          description: The server is temporarily unavailable to accept writes.  The `Retry-After` header describes when to try the write again.
+          description: The server is temporarily unavailable to accept writes. The `Retry-After` header describes when to try the write again.
           headers:
             Retry-After:
               description: A non-negative decimal integer indicating the seconds to delay after the response is received.
@@ -11910,7 +11910,7 @@ components:
         For more information and examples, see the following:
           - [`/authorizations`](#tag/Authorizations) endpoint.
           - [Authorize API requests](https://docs.influxdata.com/influxdb/cloud/api-guide/api_intro/#authentication).
-          - [Manage API tokens](https://docs.influxdata.com/influxdb/cloud/security/tokens).
+          - [Manage API tokens](https://docs.influxdata.com/influxdb/cloud/security/tokens/).
     BasicAuthentication:
       type: http
       scheme: basic

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -996,7 +996,7 @@ paths:
             $ref: '#/components/schemas/WritePrecision'
       responses:
         '204':
-          description: 'InfluxDB validated the request data format and accepted the data for writing to the bucket. `204` doesn''t indicate a successful write operation since writes are asynchronous. See [how to check for write errors](https://docs.influxdata.com/influxdb/v2.1/write-data/troubleshoot).'
+          description: 'InfluxDB validated the request data format and accepted the data for writing to the bucket. `204` doesn''t indicate a successful write operation since writes are asynchronous. See [how to check for write errors](https://docs.influxdata.com/influxdb/v2.1/write-data/troubleshoot/).'
         '400':
           description: Bad request. The line protocol data in the request is malformed. The response body contains the first malformed line in the data. InfluxDB rejected the batch and did not write any data.
           content:
@@ -1091,7 +1091,7 @@ paths:
                   value:
                     code: internal error
         '503':
-          description: The server is temporarily unavailable to accept writes.  The `Retry-After` header describes when to try the write again.
+          description: The server is temporarily unavailable to accept writes. The `Retry-After` header describes when to try the write again.
           headers:
             Retry-After:
               description: A non-negative decimal integer indicating the seconds to delay after the response is received.

--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -56,8 +56,8 @@ tags:
 
       For more information and examples, see the following:
         - [Authorize API requests]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication).
-        - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens).
-        - [Assign a token to a specific user]({{% INFLUXDB_DOCS_URL %}}/security/tokens/create-token).
+        - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens/).
+        - [Assign a token to a specific user]({{% INFLUXDB_DOCS_URL %}}/security/tokens/create-token/).
 x-tagGroups:
   - name: Overview
     tags:
@@ -82,6 +82,7 @@ x-tagGroups:
   - name: System information endpoints
     tags:
       - Health
+      - Metrics
       - Ping
       - Ready
       - Routes
@@ -97,6 +98,7 @@ x-tagGroups:
       - Dashboards
       - Delete
       - Health
+      - Metrics
       - Labels
       - Legacy Authorizations
       - NotificationEndpoints
@@ -137,7 +139,7 @@ paths:
         - $ref: '#/paths/~1ready/get/parameters/0'
       responses:
         '200':
-          description: The instance is healthy
+          description: The instance is healthy.
           content:
             application/json:
               schema:
@@ -164,11 +166,56 @@ paths:
                   commit:
                     type: string
         '503':
-          description: The instance is unhealthy
+          description: The instance is unhealthy.
           content:
             application/json:
               schema:
                 $ref: '#/paths/~1health/get/responses/200/content/application~1json/schema'
+        default:
+          description: Unexpected error
+          $ref: '#/components/responses/ServerError'
+  /metrics:
+    get:
+      operationId: GetMetrics
+      tags:
+        - Metrics
+      summary: Get metrics of an instance
+      servers:
+        - url: ''
+      parameters:
+        - $ref: '#/paths/~1ready/get/parameters/0'
+      responses:
+        '200':
+          description: |
+            Payload body contains metrics about the InfluxDB instance.
+
+            Metrics are formatted in the
+            Prometheus [plain-text exposition format](https://prometheus.io/docs/instrumenting/exposition_formats).
+            Each metric is identified by its name and a set of optional key-value pairs.
+
+            The following descriptors precede each metric:
+
+            - *`HELP`*: description of the metric
+            - *`TYPE`*: type of the metric (e.g. `counter`, `gauge`, `histogram`, or `summary`)
+          content:
+            text/plain:
+              schema:
+                type: Prometheus text-based exposition
+                externalDocs:
+                  description: Prometheus exposition formats
+                  url: 'https://prometheus.io/docs/instrumenting/exposition_formats'
+              examples:
+                expositionResponse:
+                  summary: Metrics in plain text
+                  value: |
+                    # HELP go_threads Number of OS threads created.
+                    # TYPE go_threads gauge
+                    go_threads 19
+                    # HELP http_api_request_duration_seconds Time taken to respond to HTTP request
+                    # TYPE http_api_request_duration_seconds histogram
+                    http_api_request_duration_seconds_bucket{handler="platform",method="GET",path="/:fallback_path",response_code="200",status="2XX",user_agent="curl",le="0.005"} 4
+                    http_api_request_duration_seconds_bucket{handler="platform",method="GET",path="/:fallback_path",response_code="200",status="2XX",user_agent="curl",le="0.01"} 4
+                    http_api_request_duration_seconds_bucket{handler="platform",method="GET",path="/:fallback_path",response_code="200",status="2XX",user_agent="curl",le="0.025"} 5
         default:
           description: Unexpected error
           $ref: '#/components/responses/ServerError'
@@ -1947,7 +1994,7 @@ paths:
         - $ref: '#/paths/~1ready/get/parameters/0'
       responses:
         '200':
-          description: Run-time configuration of the instance
+          description: Payload body contains the run-time configuration of the InfluxDB instance.
           content:
             application/json:
               schema:
@@ -5338,7 +5385,7 @@ components:
         For more information and examples, see the following:
           - [`/authorizations`](#tag/Authorizations) endpoint.
           - [Authorize API requests]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication).
-          - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens).
+          - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens/).
     BasicAuthentication:
       type: http
       scheme: basic

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -36,7 +36,7 @@
     },
     {
       "name": "Authorizations",
-      "description": "Create and manage API tokens. An **authorization** associates a list of permissions to an **organization** and provides a token for API access. Optionally, you can restrict an authorization and its token to a specific user.\n\nFor more information and examples, see the following:\n  - [Authorize API requests]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication).\n  - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens).\n  - [Assign a token to a specific user]({{% INFLUXDB_DOCS_URL %}}/security/tokens/create-token).\n"
+      "description": "Create and manage API tokens. An **authorization** associates a list of permissions to an **organization** and provides a token for API access. Optionally, you can restrict an authorization and its token to a specific user.\n\nFor more information and examples, see the following:\n  - [Authorize API requests]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication).\n  - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens/).\n  - [Assign a token to a specific user]({{% INFLUXDB_DOCS_URL %}}/security/tokens/create-token/).\n"
     }
   ],
   "x-tagGroups": [
@@ -76,6 +76,7 @@
       "name": "System information endpoints",
       "tags": [
         "Health",
+        "Metrics",
         "Ping",
         "Ready",
         "Routes"
@@ -94,6 +95,7 @@
         "Dashboards",
         "Delete",
         "Health",
+        "Metrics",
         "Labels",
         "Legacy Authorizations",
         "NotificationEndpoints",
@@ -1702,7 +1704,7 @@
         ],
         "responses": {
           "204": {
-            "description": "InfluxDB validated the request data format and accepted the data for writing to the bucket. `204` doesn't indicate a successful write operation since writes are asynchronous. See [how to check for write errors]({{% INFLUXDB_DOCS_URL %}}/write-data/troubleshoot)."
+            "description": "InfluxDB validated the request data format and accepted the data for writing to the bucket. `204` doesn't indicate a successful write operation since writes are asynchronous. See [how to check for write errors]({{% INFLUXDB_DOCS_URL %}}/write-data/troubleshoot/)."
           },
           "400": {
             "description": "Bad request. The line protocol data in the request is malformed. The response body contains the first malformed line in the data. InfluxDB rejected the batch and did not write any data.",
@@ -1819,7 +1821,7 @@
             }
           },
           "503": {
-            "description": "The server is temporarily unavailable to accept writes.  The `Retry-After` header describes when to try the write again.",
+            "description": "The server is temporarily unavailable to accept writes. The `Retry-After` header describes when to try the write again.",
             "headers": {
               "Retry-After": {
                 "description": "A non-negative decimal integer indicating the seconds to delay after the response is received.",
@@ -8262,7 +8264,7 @@
         ],
         "responses": {
           "200": {
-            "description": "The instance is healthy",
+            "description": "The instance is healthy.",
             "content": {
               "application/json": {
                 "schema": {
@@ -8272,11 +8274,56 @@
             }
           },
           "503": {
-            "description": "The instance is unhealthy",
+            "description": "The instance is unhealthy.",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/HealthCheck"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/metrics": {
+      "get": {
+        "operationId": "GetMetrics",
+        "tags": [
+          "Metrics"
+        ],
+        "summary": "Get metrics of an instance",
+        "servers": [
+          {
+            "url": ""
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TraceSpan"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Payload body contains metrics about the InfluxDB instance.\n\nMetrics are formatted in the\nPrometheus [plain-text exposition format](https://prometheus.io/docs/instrumenting/exposition_formats).\nEach metric is identified by its name and a set of optional key-value pairs.\n\nThe following descriptors precede each metric:\n\n- *`HELP`*: description of the metric\n- *`TYPE`*: type of the metric (e.g. `counter`, `gauge`, `histogram`, or `summary`)\n",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "Prometheus text-based exposition",
+                  "externalDocs": {
+                    "description": "Prometheus exposition formats",
+                    "url": "https://prometheus.io/docs/instrumenting/exposition_formats"
+                  }
+                },
+                "examples": {
+                  "expositionResponse": {
+                    "summary": "Metrics in plain text",
+                    "value": "# HELP go_threads Number of OS threads created.\n# TYPE go_threads gauge\ngo_threads 19\n# HELP http_api_request_duration_seconds Time taken to respond to HTTP request\n# TYPE http_api_request_duration_seconds histogram\nhttp_api_request_duration_seconds_bucket{handler=\"platform\",method=\"GET\",path=\"/:fallback_path\",response_code=\"200\",status=\"2XX\",user_agent=\"curl\",le=\"0.005\"} 4\nhttp_api_request_duration_seconds_bucket{handler=\"platform\",method=\"GET\",path=\"/:fallback_path\",response_code=\"200\",status=\"2XX\",user_agent=\"curl\",le=\"0.01\"} 4\nhttp_api_request_duration_seconds_bucket{handler=\"platform\",method=\"GET\",path=\"/:fallback_path\",response_code=\"200\",status=\"2XX\",user_agent=\"curl\",le=\"0.025\"} 5\n"
+                  }
                 }
               }
             }
@@ -10939,7 +10986,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Run-time configuration of the instance",
+            "description": "Payload body contains the run-time configuration of the InfluxDB instance.",
             "content": {
               "application/json": {
                 "schema": {
@@ -20493,7 +20540,7 @@
         "type": "apiKey",
         "name": "Authorization",
         "in": "header",
-        "description": "Use the [Token authentication](#section/Authentication/TokenAuthentication)\nscheme to authenticate to the InfluxDB API.\n\n\nIn your API requests, send an `Authorization` header.\nFor the header value, provide the word `Token` followed by a space and an InfluxDB API token.\nThe word `Token` is case-sensitive.\n\n\n### Syntax\n\n`Authorization: Token YOUR_INFLUX_TOKEN`\n\n\nFor more information and examples, see the following:\n  - [`/authorizations`](#tag/Authorizations) endpoint.\n  - [Authorize API requests]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication).\n  - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens).\n"
+        "description": "Use the [Token authentication](#section/Authentication/TokenAuthentication)\nscheme to authenticate to the InfluxDB API.\n\n\nIn your API requests, send an `Authorization` header.\nFor the header value, provide the word `Token` followed by a space and an InfluxDB API token.\nThe word `Token` is case-sensitive.\n\n\n### Syntax\n\n`Authorization: Token YOUR_INFLUX_TOKEN`\n\n\nFor more information and examples, see the following:\n  - [`/authorizations`](#tag/Authorizations) endpoint.\n  - [Authorize API requests]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication).\n  - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens/).\n"
       },
       "BasicAuthentication": {
         "type": "http",

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -56,8 +56,8 @@ tags:
 
       For more information and examples, see the following:
         - [Authorize API requests](https://docs.influxdata.com/influxdb/v2.1/api-guide/api_intro/#authentication).
-        - [Manage API tokens](https://docs.influxdata.com/influxdb/v2.1/security/tokens).
-        - [Assign a token to a specific user](https://docs.influxdata.com/influxdb/v2.1/security/tokens/create-token).
+        - [Manage API tokens](https://docs.influxdata.com/influxdb/v2.1/security/tokens/).
+        - [Assign a token to a specific user](https://docs.influxdata.com/influxdb/v2.1/security/tokens/create-token/).
 x-tagGroups:
   - name: Overview
     tags:
@@ -82,6 +82,7 @@ x-tagGroups:
   - name: System information endpoints
     tags:
       - Health
+      - Metrics
       - Ping
       - Ready
       - Routes
@@ -97,6 +98,7 @@ x-tagGroups:
       - Dashboards
       - Delete
       - Health
+      - Metrics
       - Labels
       - Legacy Authorizations
       - NotificationEndpoints
@@ -1116,7 +1118,7 @@ paths:
             $ref: '#/components/schemas/WritePrecision'
       responses:
         '204':
-          description: 'InfluxDB validated the request data format and accepted the data for writing to the bucket. `204` doesn''t indicate a successful write operation since writes are asynchronous. See [how to check for write errors](https://docs.influxdata.com/influxdb/v2.1/write-data/troubleshoot).'
+          description: 'InfluxDB validated the request data format and accepted the data for writing to the bucket. `204` doesn''t indicate a successful write operation since writes are asynchronous. See [how to check for write errors](https://docs.influxdata.com/influxdb/v2.1/write-data/troubleshoot/).'
         '400':
           description: Bad request. The line protocol data in the request is malformed. The response body contains the first malformed line in the data. InfluxDB rejected the batch and did not write any data.
           content:
@@ -1211,7 +1213,7 @@ paths:
                   value:
                     code: internal error
         '503':
-          description: The server is temporarily unavailable to accept writes.  The `Retry-After` header describes when to try the write again.
+          description: The server is temporarily unavailable to accept writes. The `Retry-After` header describes when to try the write again.
           headers:
             Retry-After:
               description: A non-negative decimal integer indicating the seconds to delay after the response is received.
@@ -5151,17 +5153,62 @@ paths:
         - $ref: '#/components/parameters/TraceSpan'
       responses:
         '200':
-          description: The instance is healthy
+          description: The instance is healthy.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/HealthCheck'
         '503':
-          description: The instance is unhealthy
+          description: The instance is unhealthy.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/HealthCheck'
+        default:
+          description: Unexpected error
+          $ref: '#/components/responses/ServerError'
+  /metrics:
+    get:
+      operationId: GetMetrics
+      tags:
+        - Metrics
+      summary: Get metrics of an instance
+      servers:
+        - url: ''
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+      responses:
+        '200':
+          description: |
+            Payload body contains metrics about the InfluxDB instance.
+
+            Metrics are formatted in the
+            Prometheus [plain-text exposition format](https://prometheus.io/docs/instrumenting/exposition_formats).
+            Each metric is identified by its name and a set of optional key-value pairs.
+
+            The following descriptors precede each metric:
+
+            - *`HELP`*: description of the metric
+            - *`TYPE`*: type of the metric (e.g. `counter`, `gauge`, `histogram`, or `summary`)
+          content:
+            text/plain:
+              schema:
+                type: Prometheus text-based exposition
+                externalDocs:
+                  description: Prometheus exposition formats
+                  url: 'https://prometheus.io/docs/instrumenting/exposition_formats'
+              examples:
+                expositionResponse:
+                  summary: Metrics in plain text
+                  value: |
+                    # HELP go_threads Number of OS threads created.
+                    # TYPE go_threads gauge
+                    go_threads 19
+                    # HELP http_api_request_duration_seconds Time taken to respond to HTTP request
+                    # TYPE http_api_request_duration_seconds histogram
+                    http_api_request_duration_seconds_bucket{handler="platform",method="GET",path="/:fallback_path",response_code="200",status="2XX",user_agent="curl",le="0.005"} 4
+                    http_api_request_duration_seconds_bucket{handler="platform",method="GET",path="/:fallback_path",response_code="200",status="2XX",user_agent="curl",le="0.01"} 4
+                    http_api_request_duration_seconds_bucket{handler="platform",method="GET",path="/:fallback_path",response_code="200",status="2XX",user_agent="curl",le="0.025"} 5
         default:
           description: Unexpected error
           $ref: '#/components/responses/ServerError'
@@ -6809,7 +6856,7 @@ paths:
         - $ref: '#/components/parameters/TraceSpan'
       responses:
         '200':
-          description: Run-time configuration of the instance
+          description: Payload body contains the run-time configuration of the InfluxDB instance.
           content:
             application/json:
               schema:
@@ -13221,7 +13268,7 @@ components:
         For more information and examples, see the following:
           - [`/authorizations`](#tag/Authorizations) endpoint.
           - [Authorize API requests](https://docs.influxdata.com/influxdb/v2.1/api-guide/api_intro/#authentication).
-          - [Manage API tokens](https://docs.influxdata.com/influxdb/v2.1/security/tokens).
+          - [Manage API tokens](https://docs.influxdata.com/influxdb/v2.1/security/tokens/).
     BasicAuthentication:
       type: http
       scheme: basic

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -5906,7 +5906,7 @@ components:
         For more information and examples, see the following:
           - [`/authorizations`](#tag/Authorizations) endpoint.
           - [Authorize API requests](https://docs.influxdata.com/influxdb/cloud/api-guide/api_intro/#authentication).
-          - [Manage API tokens](https://docs.influxdata.com/influxdb/cloud/security/tokens).
+          - [Manage API tokens](https://docs.influxdata.com/influxdb/cloud/security/tokens/).
       in: header
       name: Authorization
       type: apiKey
@@ -12072,7 +12072,7 @@ paths:
         "204":
           description: InfluxDB validated the request data format and accepted the
             data for writing to the bucket. `204` doesn't indicate a successful write
-            operation since writes are asynchronous. See [how to check for write errors](https://docs.influxdata.com/influxdb/cloud/write-data/troubleshoot).
+            operation since writes are asynchronous. See [how to check for write errors](https://docs.influxdata.com/influxdb/cloud/write-data/troubleshoot/).
         "400":
           content:
             application/json:
@@ -12176,7 +12176,7 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: Internal server error.
         "503":
-          description: The server is temporarily unavailable to accept writes.  The
+          description: The server is temporarily unavailable to accept writes. The
             `Retry-After` header describes when to try the write again.
           headers:
             Retry-After:
@@ -12243,8 +12243,8 @@ tags:
 
     For more information and examples, see the following:
       - [Authorize API requests](https://docs.influxdata.com/influxdb/cloud/api-guide/api_intro/#authentication).
-      - [Manage API tokens](https://docs.influxdata.com/influxdb/cloud/security/tokens).
-      - [Assign a token to a specific user](https://docs.influxdata.com/influxdb/cloud/security/tokens/create-token).
+      - [Manage API tokens](https://docs.influxdata.com/influxdb/cloud/security/tokens/).
+      - [Assign a token to a specific user](https://docs.influxdata.com/influxdb/cloud/security/tokens/create-token/).
   name: Authorizations
 x-tagGroups:
 - name: Overview

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -5993,7 +5993,7 @@ components:
         For more information and examples, see the following:
           - [`/authorizations`](#tag/Authorizations) endpoint.
           - [Authorize API requests](https://docs.influxdata.com/influxdb/v2.1/api-guide/api_intro/#authentication).
-          - [Manage API tokens](https://docs.influxdata.com/influxdb/v2.1/security/tokens).
+          - [Manage API tokens](https://docs.influxdata.com/influxdb/v2.1/security/tokens/).
       in: header
       name: Authorization
       type: apiKey
@@ -7050,7 +7050,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Config'
-          description: Run-time configuration of the instance
+          description: Payload body contains the run-time configuration of the InfluxDB
+            instance.
         "401":
           $ref: '#/components/responses/ServerError'
         default:
@@ -8120,13 +8121,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HealthCheck'
-          description: The instance is healthy
+          description: The instance is healthy.
         "503":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/HealthCheck'
-          description: The instance is unhealthy
+          description: The instance is unhealthy.
         default:
           $ref: '#/components/responses/ServerError'
           description: Unexpected error
@@ -8527,6 +8528,51 @@ paths:
       summary: Update a password
       tags:
       - Users
+  /metrics:
+    get:
+      operationId: GetMetrics
+      parameters:
+      - $ref: '#/components/parameters/TraceSpan'
+      responses:
+        "200":
+          content:
+            text/plain:
+              examples:
+                expositionResponse:
+                  summary: Metrics in plain text
+                  value: |
+                    # HELP go_threads Number of OS threads created.
+                    # TYPE go_threads gauge
+                    go_threads 19
+                    # HELP http_api_request_duration_seconds Time taken to respond to HTTP request
+                    # TYPE http_api_request_duration_seconds histogram
+                    http_api_request_duration_seconds_bucket{handler="platform",method="GET",path="/:fallback_path",response_code="200",status="2XX",user_agent="curl",le="0.005"} 4
+                    http_api_request_duration_seconds_bucket{handler="platform",method="GET",path="/:fallback_path",response_code="200",status="2XX",user_agent="curl",le="0.01"} 4
+                    http_api_request_duration_seconds_bucket{handler="platform",method="GET",path="/:fallback_path",response_code="200",status="2XX",user_agent="curl",le="0.025"} 5
+              schema:
+                externalDocs:
+                  description: Prometheus exposition formats
+                  url: https://prometheus.io/docs/instrumenting/exposition_formats
+                type: Prometheus text-based exposition
+          description: |
+            Payload body contains metrics about the InfluxDB instance.
+
+            Metrics are formatted in the
+            Prometheus [plain-text exposition format](https://prometheus.io/docs/instrumenting/exposition_formats).
+            Each metric is identified by its name and a set of optional key-value pairs.
+
+            The following descriptors precede each metric:
+
+            - *`HELP`*: description of the metric
+            - *`TYPE`*: type of the metric (e.g. `counter`, `gauge`, `histogram`, or `summary`)
+        default:
+          $ref: '#/components/responses/ServerError'
+          description: Unexpected error
+      servers:
+      - url: ""
+      summary: Get metrics of an instance
+      tags:
+      - Metrics
   /api/v2/notificationEndpoints:
     get:
       operationId: GetNotificationEndpoints
@@ -13137,7 +13183,7 @@ paths:
         "204":
           description: InfluxDB validated the request data format and accepted the
             data for writing to the bucket. `204` doesn't indicate a successful write
-            operation since writes are asynchronous. See [how to check for write errors](https://docs.influxdata.com/influxdb/v2.1/write-data/troubleshoot).
+            operation since writes are asynchronous. See [how to check for write errors](https://docs.influxdata.com/influxdb/v2.1/write-data/troubleshoot/).
         "400":
           content:
             application/json:
@@ -13241,7 +13287,7 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: Internal server error.
         "503":
-          description: The server is temporarily unavailable to accept writes.  The
+          description: The server is temporarily unavailable to accept writes. The
             `Retry-After` header describes when to try the write again.
           headers:
             Retry-After:
@@ -13308,8 +13354,8 @@ tags:
 
     For more information and examples, see the following:
       - [Authorize API requests](https://docs.influxdata.com/influxdb/v2.1/api-guide/api_intro/#authentication).
-      - [Manage API tokens](https://docs.influxdata.com/influxdb/v2.1/security/tokens).
-      - [Assign a token to a specific user](https://docs.influxdata.com/influxdb/v2.1/security/tokens/create-token).
+      - [Manage API tokens](https://docs.influxdata.com/influxdb/v2.1/security/tokens/).
+      - [Assign a token to a specific user](https://docs.influxdata.com/influxdb/v2.1/security/tokens/create-token/).
   name: Authorizations
 x-tagGroups:
 - name: Overview
@@ -13335,6 +13381,7 @@ x-tagGroups:
 - name: System information endpoints
   tags:
   - Health
+  - Metrics
   - Ping
   - Ready
   - Routes
@@ -13350,6 +13397,7 @@ x-tagGroups:
   - Dashboards
   - Delete
   - Health
+  - Metrics
   - Labels
   - Legacy Authorizations
   - NotificationEndpoints

--- a/contracts/swaggerV1Compat.yml
+++ b/contracts/swaggerV1Compat.yml
@@ -37,12 +37,12 @@ paths:
           schema:
             type: string
           required: true
-          description: The bucket to write to. If none exist a bucket will be created with a default 3 day retention policy.
+          description: Bucket to write to. If none exist a bucket will be created with a default 3 day retention policy.
         - in: query
           name: rp
           schema:
             type: string
-          description: The retention policy name.
+          description: Retention policy name.
         - in: query
           name: precision
           schema:
@@ -155,12 +155,12 @@ paths:
           schema:
             type: string
           required: true
-          description: The bucket to query.
+          description: Bucket to query.
         - in: query
           name: rp
           schema:
             type: string
-          description: The retention policy name.
+          description: Retention policy name.
         - in: query
           name: q
           description: Defines the influxql query to run.

--- a/contracts/swaggerV1Compat.yml
+++ b/contracts/swaggerV1Compat.yml
@@ -4,7 +4,7 @@ info:
   title: InfluxDB API Service (V1 compatible endpoints)
   version: 0.1.0
   description: |
-    The InfluxDB 1.x compatibility /write and /query endpoints work with
+    The InfluxDB 1.x compatibility `/write` and `/query` endpoints work with
     InfluxDB 1.x client libraries and third-party integrations like Grafana
     and others.
 
@@ -37,7 +37,7 @@ paths:
           schema:
             type: string
           required: true
-          description: Bucket to write to. If none exist a bucket will be created with a default 3 day retention policy.
+          description: Bucket to write to. If none exists, a bucket will be created with a default 3-day retention policy.
         - in: query
           name: rp
           schema:

--- a/scripts/reference.sh
+++ b/scripts/reference.sh
@@ -21,6 +21,7 @@ swagrag \
   -api-title "Complete InfluxDB OSS API" \
   | sed -e 's|^  /api/v2/health|  /health|' \
   | sed -e 's|^  /api/v2/legacy|  /legacy|' \
+  | sed -e 's|^  /api/v2/metrics|  /metrics|' \
   | sed -e 's|^  /api/v2/ping|  /ping|' \
   | sed -e 's|^  /api/v2/ready|  /ready|' \
   > ${TCONTRACTS}/ref/oss.yml

--- a/src/cloud.yml
+++ b/src/cloud.yml
@@ -36,8 +36,8 @@ tags:
 
       For more information and examples, see the following:
         - [Authorize API requests]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication).
-        - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens).
-        - [Assign a token to a specific user]({{% INFLUXDB_DOCS_URL %}}/security/tokens/create-token).
+        - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens/).
+        - [Assign a token to a specific user]({{% INFLUXDB_DOCS_URL %}}/security/tokens/create-token/).
 x-tagGroups:
   - name: Overview
     tags:
@@ -205,7 +205,7 @@ components:
         For more information and examples, see the following:
           - [`/authorizations`](#tag/Authorizations) endpoint.
           - [Authorize API requests]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication).
-          - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens).
+          - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens/).
     BasicAuthentication:
       type: http
       scheme: basic

--- a/src/common/paths/write.yml
+++ b/src/common/paths/write.yml
@@ -162,7 +162,7 @@ post:
     "500":
       $ref: "../../common/responses/InternalServerError.yml"
     "503":
-      description: The server is temporarily unavailable to accept writes.  The `Retry-After` header describes when to try the write again.
+      description: The server is temporarily unavailable to accept writes. The `Retry-After` header describes when to try the write again.
       headers:
         Retry-After:
           description: A non-negative decimal integer indicating the seconds to delay after the response is received.

--- a/src/common/paths/write.yml
+++ b/src/common/paths/write.yml
@@ -97,7 +97,7 @@ post:
   responses:
     "204":
       description: InfluxDB validated the request data format and accepted the data for writing to the bucket.
-        `204` doesn't indicate a successful write operation since writes are asynchronous. See [how to check for write errors]({{% INFLUXDB_DOCS_URL %}}/write-data/troubleshoot).
+        `204` doesn't indicate a successful write operation since writes are asynchronous. See [how to check for write errors]({{% INFLUXDB_DOCS_URL %}}/write-data/troubleshoot/).
     "400":
       description: Bad request. The line protocol data in the request is malformed. The response body contains the first malformed line in the data. InfluxDB rejected the batch and did not write any data.
       content:

--- a/src/oss.yml
+++ b/src/oss.yml
@@ -36,8 +36,8 @@ tags:
 
       For more information and examples, see the following:
         - [Authorize API requests]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication).
-        - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens).
-        - [Assign a token to a specific user]({{% INFLUXDB_DOCS_URL %}}/security/tokens/create-token).
+        - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens/).
+        - [Assign a token to a specific user]({{% INFLUXDB_DOCS_URL %}}/security/tokens/create-token/).
 x-tagGroups:
   - name: Overview
     tags:
@@ -62,6 +62,7 @@ x-tagGroups:
   - name: System information endpoints
     tags:
       - Health
+      - Metrics
       - Ping
       - Ready
       - Routes
@@ -77,6 +78,7 @@ x-tagGroups:
       - Dashboards
       - Delete
       - Health
+      - Metrics
       - Labels
       - Legacy Authorizations
       - NotificationEndpoints
@@ -108,6 +110,8 @@ paths:
 #REF_COMMON_PATHS
   /health:
     $ref: "./oss/paths/health.yml"
+  /metrics:
+    $ref: "./oss/paths/metrics.yml"
   /ready:
     $ref: "./oss/paths/ready.yml"
   /users:
@@ -306,7 +310,7 @@ components:
     #     For more information and examples, see the following:
     #       - [`/authorizations`](#tag/Authorizations) endpoint.
     #       - [Authorize API requests]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication).
-    #       - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens).
+    #       - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens/).
     TokenAuthentication:
       type: apiKey
       name: Authorization
@@ -329,7 +333,7 @@ components:
         For more information and examples, see the following:
           - [`/authorizations`](#tag/Authorizations) endpoint.
           - [Authorize API requests]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication).
-          - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens).
+          - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens/).
     BasicAuthentication:
       type: http
       scheme: basic

--- a/src/oss/paths/config.yml
+++ b/src/oss/paths/config.yml
@@ -7,7 +7,7 @@ get:
     - $ref: '../../common/parameters/TraceSpan.yml'
   responses:
     '200':
-      description: Run-time configuration of the instance
+      description: Payload body contains the run-time configuration of the InfluxDB instance.
       content:
         application/json:
           schema:

--- a/src/oss/paths/health.yml
+++ b/src/oss/paths/health.yml
@@ -9,13 +9,13 @@ get:
     - $ref: "../../common/parameters/TraceSpan.yml"
   responses:
     "200":
-      description: The instance is healthy
+      description: The instance is healthy.
       content:
         application/json:
           schema:
             $ref: "../../common/schemas/HealthCheck.yml"
     "503":
-      description: The instance is unhealthy
+      description: The instance is unhealthy.
       content:
         application/json:
           schema:

--- a/src/oss/paths/metrics.yml
+++ b/src/oss/paths/metrics.yml
@@ -1,0 +1,44 @@
+get:
+  operationId: GetMetrics
+  tags:
+    - Metrics
+  summary: Get metrics of an instance
+  servers:
+    - url: ''
+  parameters:
+    - $ref: "../../common/parameters/TraceSpan.yml"
+  responses:
+    "200":
+      description: |
+        Payload body contains metrics about the InfluxDB instance.
+
+        Metrics are formatted in the
+        Prometheus [plain-text exposition format](https://prometheus.io/docs/instrumenting/exposition_formats).
+        Each metric is identified by its name and a set of optional key-value pairs.
+
+        The following descriptors precede each metric:
+
+        - *`HELP`*: description of the metric
+        - *`TYPE`*: type of the metric (e.g. `counter`, `gauge`, `histogram`, or `summary`)
+      content:
+        text/plain:
+            schema:
+              type: "Prometheus text-based exposition"
+              externalDocs:
+                description: Prometheus exposition formats
+                url: https://prometheus.io/docs/instrumenting/exposition_formats
+            examples:
+              expositionResponse:
+                summary: Metrics in plain text
+                value: |
+                  # HELP go_threads Number of OS threads created.
+                  # TYPE go_threads gauge
+                  go_threads 19
+                  # HELP http_api_request_duration_seconds Time taken to respond to HTTP request
+                  # TYPE http_api_request_duration_seconds histogram
+                  http_api_request_duration_seconds_bucket{handler="platform",method="GET",path="/:fallback_path",response_code="200",status="2XX",user_agent="curl",le="0.005"} 4
+                  http_api_request_duration_seconds_bucket{handler="platform",method="GET",path="/:fallback_path",response_code="200",status="2XX",user_agent="curl",le="0.01"} 4
+                  http_api_request_duration_seconds_bucket{handler="platform",method="GET",path="/:fallback_path",response_code="200",status="2XX",user_agent="curl",le="0.025"} 5
+    default:
+      description: Unexpected error
+      $ref: '../../common/responses/ServerError.yml'


### PR DESCRIPTION
Part of https://github.com/influxdata/docs-v2/issues/2567, https://github.com/influxdata/docs-v2/issues/3527

Add `/metrics` path and documentation in OSS.
Cleanup.