### PR TITLE
fix: schema violations and grammar

### DIFF
--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -839,16 +839,17 @@ paths:
       tags:
         - Limits
       summary: Retrieve limits for an organization
+      operationId: GetOrgLimitsID
       parameters:
         - in: path
           name: orgID
-          description: The identifier of the organization.
+          description: ID of the organization.
           required: true
           schema:
             type: string
       responses:
         '200':
-          description: The Limits defined for the organization.
+          description: Limits defined for the organization.
           content:
             application/json:
               schema:
@@ -867,25 +868,32 @@ paths:
       tags:
         - Usage
       summary: Retrieve usage for an organization
+      operationId: GetOrgUsageID
       parameters:
         - in: path
           name: orgID
-          description: The identifier of the organization.
+          description: ID of the organization.
           required: true
           schema:
             type: string
         - in: query
           name: start
-          description: start time
+          description: |
+            Earliest time to include in results.
+            For more information about timestamps, see [Manipulate timestamps with Flux]({{% INFLUXDB_DOCS_URL %}}/query-data/flux/manipulate-timestamps/).
           required: true
           schema:
-            type: timestamp
+            type: integer
+            format: unix timestamp
         - in: query
           name: stop
-          description: stop time
+          description: |
+            Latest time to include in results.
+            For more information about timestamps, see [Manipulate timestamps with Flux]({{% INFLUXDB_DOCS_URL %}}/query-data/flux/manipulate-timestamps/).
           required: false
           schema:
-            type: timestamp
+            type: integer
+            format: unix timestamp
         - in: query
           name: raw
           description: return raw usage data
@@ -1198,26 +1206,26 @@ paths:
                                               properties:
                                                 x:
                                                   type: object
-                                                  description: The description of a particular axis for a visualization.
+                                                  description: Axis used in a visualization.
                                                   properties:
                                                     bounds:
                                                       type: array
                                                       minItems: 0
                                                       maxItems: 2
-                                                      description: 'The extents of an axis in the form [lower, upper]. Clients determine whether bounds are to be inclusive or exclusive of their limits'
+                                                      description: 'The extents of the axis in the form [lower, upper]. Clients determine whether bounds are inclusive or exclusive of their limits.'
                                                       items:
                                                         type: string
                                                     label:
-                                                      description: Label is a description of this Axis
+                                                      description: Description of the axis.
                                                       type: string
                                                     prefix:
-                                                      description: Prefix represents a label prefix for formatting axis values.
+                                                      description: Label prefix for formatting axis values.
                                                       type: string
                                                     suffix:
-                                                      description: Suffix represents a label suffix for formatting axis values.
+                                                      description: Label suffix for formatting axis values.
                                                       type: string
                                                     base:
-                                                      description: Base represents the radix for formatting axis values.
+                                                      description: Radix for formatting axis values.
                                                       type: string
                                                       enum:
                                                         - ''
@@ -1760,8 +1768,7 @@ paths:
                                                               description: An optional description of the check.
                                                               type: string
                                                             latestCompleted:
-                                                              description: 'Timestamp of latest scheduled, completed run, RFC3339.'
-                                                              type: string
+                                                              description: 'Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.'
                                                               format: date-time
                                                               readOnly: true
                                                             lastRunStatus:
@@ -2833,44 +2840,54 @@ paths:
                     readOnly: true
                     type: string
                   type:
-                    description: 'The type of task, this can be used for filtering tasks on list actions.'
+                    description: 'Type of the task, useful for filtering a task list.'
                     type: string
                   orgID:
-                    description: The ID of the organization that owns this Task.
+                    description: ID of the organization that owns the task.
                     type: string
                   org:
-                    description: The name of the organization that owns this Task.
+                    description: Name of the organization that owns the task.
                     type: string
                   name:
-                    description: The name of the task.
+                    description: Name of the task.
                     type: string
                   ownerID:
-                    description: The ID of the user who owns this Task.
+                    description: ID of the user who owns this Task.
                     type: string
                   description:
-                    description: An optional description of the task.
+                    description: Description of the task.
                     type: string
                   status:
                     $ref: '#/paths/~1tasks/post/requestBody/content/application~1json/schema/properties/status'
                   labels:
                     $ref: '#/components/schemas/Variable/properties/labels'
                   authorizationID:
-                    description: The ID of the authorization used when this task communicates with the query engine.
+                    description: ID of the authorization used when the task communicates with the query engine.
                     type: string
                   flux:
-                    description: The Flux script to run for this task.
+                    description: Flux script to run for this task.
                     type: string
                   every:
-                    description: A simple task repetition schedule; parsed from Flux.
+                    description: |-
+                      Interval at which the task runs. `every` also determines when the task first runs, depending on the specified time.
+                      Value is a [duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals)).
                     type: string
+                    format: duration
                   cron:
-                    description: A task repetition schedule in the form '* * * * * *'; parsed from Flux.
+                    description: |-
+                      [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview) that defines the schedule on which the task runs. Cron scheduling is based on system time.
+                      Value is a [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview).
                     type: string
                   offset:
-                    description: 'Duration to delay after the schedule, before executing the task; parsed from flux, if set to zero it will remove this option and use 0 as the default.'
+                    description: |-
+                      [Duration](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals) to delay execution of the task after the scheduled time has elapsed. `0` removes the offset.
+                      The value is a [duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals).
                     type: string
+                    format: duration
                   latestCompleted:
-                    description: 'Timestamp of latest scheduled, completed run, RFC3339.'
+                    description: |-
+                      Timestamp of the latest scheduled and completed run.
+                      Value is a timestamp in [RFC3339 date/time format](https://docs.influxdata.com/flux/v0.x/data-types/basic/time/#time-syntax).
                     type: string
                     format: date-time
                     readOnly: true
@@ -2994,7 +3011,7 @@ components:
       allOf:
         - properties:
             status:
-              description: If inactive the token is inactive and requests using the token will be rejected.
+              description: 'Status of the token. If `inactive`, requests using the token will be rejected.'
               default: active
               type: string
               enum:
@@ -3223,22 +3240,22 @@ components:
                 write: /api/v2/write?org=2&bucket=1
               properties:
                 labels:
-                  description: URL to retrieve labels for this bucket
+                  description: URL to retrieve labels for this bucket.
                   $ref: '#/paths/~1tasks/post/responses/201/content/application~1json/schema/properties/links/properties/self'
                 members:
-                  description: URL to retrieve members that can read this bucket
+                  description: URL to retrieve members that can read this bucket.
                   $ref: '#/paths/~1tasks/post/responses/201/content/application~1json/schema/properties/links/properties/self'
                 org:
-                  description: URL to retrieve parent organization for this bucket
+                  description: URL to retrieve parent organization for this bucket.
                   $ref: '#/paths/~1tasks/post/responses/201/content/application~1json/schema/properties/links/properties/self'
                 owners:
                   description: URL to retrieve owners that can read and write to this bucket.
                   $ref: '#/paths/~1tasks/post/responses/201/content/application~1json/schema/properties/links/properties/self'
                 self:
-                  description: URL for this bucket
+                  description: URL for this bucket.
                   $ref: '#/paths/~1tasks/post/responses/201/content/application~1json/schema/properties/links/properties/self'
                 write:
-                  description: URL to write line protocol for this bucket
+                  description: URL to write line protocol to this bucket.
                   $ref: '#/paths/~1tasks/post/responses/201/content/application~1json/schema/properties/links/properties/self'
             id:
               readOnly: true
@@ -3556,7 +3573,7 @@ components:
         - tag
         - field
     MeasurementSchema:
-      description: The schema definition for a single measurement
+      description: Definition of a measurement schema.
       type: object
       example:
         id: 1a3c5e7f9b0a8642
@@ -3565,7 +3582,8 @@ components:
         name: cpu
         columns:
           - name: time
-            type: timestamp
+            type: integer
+            format: unix timestamp
           - name: host
             type: tag
           - name: region
@@ -3590,7 +3608,7 @@ components:
           readOnly: true
         orgID:
           type: string
-          description: ID of organization that the measurement schema is associated with.
+          description: ID of the organization that the measurement schema is associated with.
         bucketID:
           type: string
           description: ID of the bucket that the measurement schema is associated with.
@@ -3598,7 +3616,7 @@ components:
           type: string
           nullable: false
         columns:
-          description: An ordered collection of column definitions
+          description: Ordered collection of column definitions.
           type: array
           items:
             $ref: '#/components/schemas/MeasurementSchemaColumn'
@@ -3611,10 +3629,11 @@ components:
           format: date-time
           readOnly: true
     MeasurementSchemaColumn:
-      description: Definition of a measurement column
+      description: Definition of a measurement schema column.
       example:
         name: time
-        type: timestamp
+        type: integer
+        format: unix timestamp
       type: object
       required:
         - name
@@ -3627,13 +3646,14 @@ components:
         dataType:
           $ref: '#/components/schemas/ColumnDataType'
     MeasurementSchemaCreateRequest:
-      description: Create a new measurement schema
+      description: Create a new measurement schema.
       type: object
       example:
         name: cpu
         columns:
           - name: time
-            type: timestamp
+            type: integer
+            format: unix timestamp
           - name: host
             type: tag
           - name: region
@@ -3651,7 +3671,7 @@ components:
         name:
           type: string
         columns:
-          description: An ordered collection of column definitions
+          description: Ordered collection of column definitions.
           type: array
           items:
             $ref: '#/components/schemas/MeasurementSchemaColumn'
@@ -3691,7 +3711,8 @@ components:
       example:
         columns:
           - name: time
-            type: timestamp
+            type: integer
+            format: unix timestamp
           - name: host
             type: tag
           - name: region
@@ -3737,19 +3758,18 @@ components:
                   - unsupported media type
               message:
                 readOnly: true
-                description: message is a human-readable message.
+                description: Human-readable message.
                 type: string
               op:
                 readOnly: true
-                description: op describes the logical code operation during error. Useful for debugging.
+                description: Describes the logical code operation when the error occurred. Useful for debugging.
                 type: string
               err:
                 readOnly: true
-                description: err is a stack of errors that occurred during processing of the request. Useful for debugging.
+                description: Stack of errors that occurred during processing of the request. Useful for debugging.
                 type: string
             required:
               - code
-              - message
   securitySchemes:
     TokenAuthentication:
       type: apiKey

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -9357,11 +9357,12 @@
           "Limits"
         ],
         "summary": "Retrieve limits for an organization",
+        "operationId": "GetOrgLimitsID",
         "parameters": [
           {
             "in": "path",
             "name": "orgID",
-            "description": "The identifier of the organization.",
+            "description": "ID of the organization.",
             "required": true,
             "schema": {
               "type": "string"
@@ -9370,7 +9371,7 @@
         ],
         "responses": {
           "200": {
-            "description": "The Limits defined for the organization.",
+            "description": "Limits defined for the organization.",
             "content": {
               "application/json": {
                 "schema": {
@@ -9401,11 +9402,12 @@
           "Usage"
         ],
         "summary": "Retrieve usage for an organization",
+        "operationId": "GetOrgUsageID",
         "parameters": [
           {
             "in": "path",
             "name": "orgID",
-            "description": "The identifier of the organization.",
+            "description": "ID of the organization.",
             "required": true,
             "schema": {
               "type": "string"
@@ -9414,19 +9416,21 @@
           {
             "in": "query",
             "name": "start",
-            "description": "start time",
+            "description": "Earliest time to include in results.\nFor more information about timestamps, see [Manipulate timestamps with Flux]({{% INFLUXDB_DOCS_URL %}}/query-data/flux/manipulate-timestamps/).\n",
             "required": true,
             "schema": {
-              "type": "timestamp"
+              "type": "integer",
+              "format": "unix timestamp"
             }
           },
           {
             "in": "query",
             "name": "stop",
-            "description": "stop time",
+            "description": "Latest time to include in results.\nFor more information about timestamps, see [Manipulate timestamps with Flux]({{% INFLUXDB_DOCS_URL %}}/query-data/flux/manipulate-timestamps/).\n",
             "required": false,
             "schema": {
-              "type": "timestamp"
+              "type": "integer",
+              "format": "unix timestamp"
             }
           },
           {
@@ -9847,7 +9851,7 @@
         "schema": {
           "type": "string"
         },
-        "description": "The last resource ID from which to seek from (but not including). This is to be used instead of `offset`.\n"
+        "description": "Resource ID to seek from. Results are not inclusive of this ID. Use `after` instead of `offset`.\n"
       }
     },
     "schemas": {
@@ -10686,7 +10690,7 @@
       "AuthorizationUpdateRequest": {
         "properties": {
           "status": {
-            "description": "If inactive the token is inactive and requests using the token will be rejected.",
+            "description": "Status of the token. If `inactive`, requests using the token will be rejected.",
             "default": "active",
             "type": "string",
             "enum": [
@@ -10743,15 +10747,15 @@
             },
             "properties": {
               "labels": {
-                "description": "URL to retrieve labels for this bucket",
+                "description": "URL to retrieve labels for this bucket.",
                 "$ref": "#/components/schemas/Link"
               },
               "members": {
-                "description": "URL to retrieve members that can read this bucket",
+                "description": "URL to retrieve members that can read this bucket.",
                 "$ref": "#/components/schemas/Link"
               },
               "org": {
-                "description": "URL to retrieve parent organization for this bucket",
+                "description": "URL to retrieve parent organization for this bucket.",
                 "$ref": "#/components/schemas/Link"
               },
               "owners": {
@@ -10759,11 +10763,11 @@
                 "$ref": "#/components/schemas/Link"
               },
               "self": {
-                "description": "URL for this bucket",
+                "description": "URL for this bucket.",
                 "$ref": "#/components/schemas/Link"
               },
               "write": {
-                "description": "URL to write line protocol for this bucket",
+                "description": "URL to write line protocol to this bucket.",
                 "$ref": "#/components/schemas/Link"
               }
             }
@@ -12678,27 +12682,27 @@
             "type": "string"
           },
           "type": {
-            "description": "The type of task, this can be used for filtering tasks on list actions.",
+            "description": "Type of the task, useful for filtering a task list.",
             "type": "string"
           },
           "orgID": {
-            "description": "The ID of the organization that owns this Task.",
+            "description": "ID of the organization that owns the task.",
             "type": "string"
           },
           "org": {
-            "description": "The name of the organization that owns this Task.",
+            "description": "Name of the organization that owns the task.",
             "type": "string"
           },
           "name": {
-            "description": "The name of the task.",
+            "description": "Name of the task.",
             "type": "string"
           },
           "ownerID": {
-            "description": "The ID of the user who owns this Task.",
+            "description": "ID of the user who owns this Task.",
             "type": "string"
           },
           "description": {
-            "description": "An optional description of the task.",
+            "description": "Description of the task.",
             "type": "string"
           },
           "status": {
@@ -12708,27 +12712,29 @@
             "$ref": "#/components/schemas/Labels"
           },
           "authorizationID": {
-            "description": "The ID of the authorization used when this task communicates with the query engine.",
+            "description": "ID of the authorization used when the task communicates with the query engine.",
             "type": "string"
           },
           "flux": {
-            "description": "The Flux script to run for this task.",
+            "description": "Flux script to run for this task.",
             "type": "string"
           },
           "every": {
-            "description": "A simple task repetition schedule; parsed from Flux.",
-            "type": "string"
+            "description": "Interval at which the task runs. `every` also determines when the task first runs, depending on the specified time.\nValue is a [duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals)).",
+            "type": "string",
+            "format": "duration"
           },
           "cron": {
-            "description": "A task repetition schedule in the form '* * * * * *'; parsed from Flux.",
+            "description": "[Cron expression](https://en.wikipedia.org/wiki/Cron#Overview) that defines the schedule on which the task runs. Cron scheduling is based on system time.\nValue is a [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview).",
             "type": "string"
           },
           "offset": {
-            "description": "Duration to delay after the schedule, before executing the task; parsed from flux, if set to zero it will remove this option and use 0 as the default.",
-            "type": "string"
+            "description": "[Duration](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals) to delay execution of the task after the scheduled time has elapsed. `0` removes the offset.\nThe value is a [duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals).",
+            "type": "string",
+            "format": "duration"
           },
           "latestCompleted": {
-            "description": "Timestamp of latest scheduled, completed run, RFC3339.",
+            "description": "Timestamp of the latest scheduled and completed run.\nValue is a timestamp in [RFC3339 date/time format](https://docs.influxdata.com/flux/v0.x/data-types/basic/time/#time-syntax).",
             "type": "string",
             "format": "date-time",
             "readOnly": true
@@ -13084,23 +13090,22 @@
           },
           "message": {
             "readOnly": true,
-            "description": "message is a human-readable message.",
+            "description": "Human-readable message.",
             "type": "string"
           },
           "op": {
             "readOnly": true,
-            "description": "op describes the logical code operation during error. Useful for debugging.",
+            "description": "Describes the logical code operation when the error occurred. Useful for debugging.",
             "type": "string"
           },
           "err": {
             "readOnly": true,
-            "description": "err is a stack of errors that occurred during processing of the request. Useful for debugging.",
+            "description": "Stack of errors that occurred during processing of the request. Useful for debugging.",
             "type": "string"
           }
         },
         "required": [
-          "code",
-          "message"
+          "code"
         ]
       },
       "LineProtocolError": {
@@ -13120,31 +13125,28 @@
           },
           "message": {
             "readOnly": true,
-            "description": "Message is a human-readable message.",
+            "description": "Human-readable message.",
             "type": "string"
           },
           "op": {
             "readOnly": true,
-            "description": "Op describes the logical code operation during error. Useful for debugging.",
+            "description": "Describes the logical code operation when the error occurred. Useful for debugging.",
             "type": "string"
           },
           "err": {
             "readOnly": true,
-            "description": "Err is a stack of errors that occurred during processing of the request. Useful for debugging.",
+            "description": "Stack of errors that occurred during processing of the request. Useful for debugging.",
             "type": "string"
           },
           "line": {
             "readOnly": true,
-            "description": "First line within sent body containing malformed data",
+            "description": "First line in the request body that contains malformed data.",
             "type": "integer",
             "format": "int32"
           }
         },
         "required": [
-          "code",
-          "message",
-          "op",
-          "err"
+          "code"
         ]
       },
       "LineProtocolLengthError": {
@@ -13159,7 +13161,7 @@
           },
           "message": {
             "readOnly": true,
-            "description": "Message is a human-readable message.",
+            "description": "Human-readable message.",
             "type": "string"
           }
         },
@@ -13293,31 +13295,31 @@
       },
       "Axis": {
         "type": "object",
-        "description": "The description of a particular axis for a visualization.",
+        "description": "Axis used in a visualization.",
         "properties": {
           "bounds": {
             "type": "array",
             "minItems": 0,
             "maxItems": 2,
-            "description": "The extents of an axis in the form [lower, upper]. Clients determine whether bounds are to be inclusive or exclusive of their limits",
+            "description": "The extents of the axis in the form [lower, upper]. Clients determine whether bounds are inclusive or exclusive of their limits.",
             "items": {
               "type": "string"
             }
           },
           "label": {
-            "description": "Label is a description of this Axis",
+            "description": "Description of the axis.",
             "type": "string"
           },
           "prefix": {
-            "description": "Prefix represents a label prefix for formatting axis values.",
+            "description": "Label prefix for formatting axis values.",
             "type": "string"
           },
           "suffix": {
-            "description": "Suffix represents a label suffix for formatting axis values.",
+            "description": "Label suffix for formatting axis values.",
             "type": "string"
           },
           "base": {
-            "description": "Base represents the radix for formatting axis values.",
+            "description": "Radix for formatting axis values.",
             "type": "string",
             "enum": [
               "",
@@ -16188,8 +16190,7 @@
             "type": "string"
           },
           "latestCompleted": {
-            "description": "Timestamp of latest scheduled, completed run, RFC3339.",
-            "type": "string",
+            "description": "Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.",
             "format": "date-time",
             "readOnly": true
           },
@@ -16614,7 +16615,7 @@
         ],
         "properties": {
           "latestCompleted": {
-            "description": "Timestamp of latest scheduled, completed run, RFC3339.",
+            "description": "Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.",
             "type": "string",
             "format": "date-time",
             "readOnly": true
@@ -17236,16 +17237,16 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "the mapping identifier",
+            "description": "ID of the DBRP mapping.",
             "readOnly": true
           },
           "orgID": {
             "type": "string",
-            "description": "the organization ID that owns this mapping."
+            "description": "ID of the organization that owns this mapping."
           },
           "bucketID": {
             "type": "string",
-            "description": "the bucket ID used as target for the translation."
+            "description": "ID of the bucket used as the target for the translation."
           },
           "database": {
             "type": "string",
@@ -17257,7 +17258,7 @@
           },
           "default": {
             "type": "boolean",
-            "description": "Specify if this mapping represents the default retention policy for the database specificed."
+            "description": "Mapping represents the default retention policy for the database specified."
           },
           "links": {
             "$ref": "#/components/schemas/Links"
@@ -17298,15 +17299,15 @@
         "properties": {
           "orgID": {
             "type": "string",
-            "description": "the organization ID that owns this mapping."
+            "description": "ID of the organization that owns this mapping."
           },
           "org": {
             "type": "string",
-            "description": "the organization that owns this mapping."
+            "description": "Name of the organization that owns this mapping."
           },
           "bucketID": {
             "type": "string",
-            "description": "the bucket ID used as target for the translation."
+            "description": "ID of the bucket used as the target for the translation."
           },
           "database": {
             "type": "string",
@@ -17318,7 +17319,7 @@
           },
           "default": {
             "type": "boolean",
-            "description": "Specify if this mapping represents the default retention policy for the database specificed."
+            "description": "Mapping represents the default retention policy for the database specified."
           }
         },
         "required": [
@@ -17915,7 +17916,7 @@
         ]
       },
       "MeasurementSchema": {
-        "description": "The schema definition for a single measurement",
+        "description": "Definition of a measurement schema.",
         "type": "object",
         "example": {
           "id": "1a3c5e7f9b0a8642",
@@ -17925,7 +17926,8 @@
           "columns": [
             {
               "name": "time",
-              "type": "timestamp"
+              "type": "integer",
+              "format": "unix timestamp"
             },
             {
               "name": "host",
@@ -17963,7 +17965,7 @@
           },
           "orgID": {
             "type": "string",
-            "description": "ID of organization that the measurement schema is associated with."
+            "description": "ID of the organization that the measurement schema is associated with."
           },
           "bucketID": {
             "type": "string",
@@ -17974,7 +17976,7 @@
             "nullable": false
           },
           "columns": {
-            "description": "An ordered collection of column definitions",
+            "description": "Ordered collection of column definitions.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/MeasurementSchemaColumn"
@@ -17993,10 +17995,11 @@
         }
       },
       "MeasurementSchemaColumn": {
-        "description": "Definition of a measurement column",
+        "description": "Definition of a measurement schema column.",
         "example": {
           "name": "time",
-          "type": "timestamp"
+          "type": "integer",
+          "format": "unix timestamp"
         },
         "type": "object",
         "required": [
@@ -18016,14 +18019,15 @@
         }
       },
       "MeasurementSchemaCreateRequest": {
-        "description": "Create a new measurement schema",
+        "description": "Create a new measurement schema.",
         "type": "object",
         "example": {
           "name": "cpu",
           "columns": [
             {
               "name": "time",
-              "type": "timestamp"
+              "type": "integer",
+              "format": "unix timestamp"
             },
             {
               "name": "host",
@@ -18054,7 +18058,7 @@
             "type": "string"
           },
           "columns": {
-            "description": "An ordered collection of column definitions",
+            "description": "Ordered collection of column definitions.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/MeasurementSchemaColumn"
@@ -18112,7 +18116,8 @@
           "columns": [
             {
               "name": "time",
-              "type": "timestamp"
+              "type": "integer",
+              "format": "unix timestamp"
             },
             {
               "name": "host",

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -5839,16 +5839,17 @@ paths:
       tags:
         - Limits
       summary: Retrieve limits for an organization
+      operationId: GetOrgLimitsID
       parameters:
         - in: path
           name: orgID
-          description: The identifier of the organization.
+          description: ID of the organization.
           required: true
           schema:
             type: string
       responses:
         '200':
-          description: The Limits defined for the organization.
+          description: Limits defined for the organization.
           content:
             application/json:
               schema:
@@ -5867,25 +5868,32 @@ paths:
       tags:
         - Usage
       summary: Retrieve usage for an organization
+      operationId: GetOrgUsageID
       parameters:
         - in: path
           name: orgID
-          description: The identifier of the organization.
+          description: ID of the organization.
           required: true
           schema:
             type: string
         - in: query
           name: start
-          description: start time
+          description: |
+            Earliest time to include in results.
+            For more information about timestamps, see [Manipulate timestamps with Flux](https://docs.influxdata.com/influxdb/cloud/query-data/flux/manipulate-timestamps/).
           required: true
           schema:
-            type: timestamp
+            type: integer
+            format: unix timestamp
         - in: query
           name: stop
-          description: stop time
+          description: |
+            Latest time to include in results.
+            For more information about timestamps, see [Manipulate timestamps with Flux](https://docs.influxdata.com/influxdb/cloud/query-data/flux/manipulate-timestamps/).
           required: false
           schema:
-            type: timestamp
+            type: integer
+            format: unix timestamp
         - in: query
           name: raw
           description: return raw usage data
@@ -6155,7 +6163,7 @@ components:
       schema:
         type: string
       description: |
-        The last resource ID from which to seek from (but not including). This is to be used instead of `offset`.
+        Resource ID to seek from. Results are not inclusive of this ID. Use `after` instead of `offset`.
   schemas:
     LanguageRequest:
       description: Flux query to be analyzed.
@@ -6691,7 +6699,7 @@ components:
     AuthorizationUpdateRequest:
       properties:
         status:
-          description: If inactive the token is inactive and requests using the token will be rejected.
+          description: 'Status of the token. If `inactive`, requests using the token will be rejected.'
           default: active
           type: string
           enum:
@@ -6733,22 +6741,22 @@ components:
             write: /api/v2/write?org=2&bucket=1
           properties:
             labels:
-              description: URL to retrieve labels for this bucket
+              description: URL to retrieve labels for this bucket.
               $ref: '#/components/schemas/Link'
             members:
-              description: URL to retrieve members that can read this bucket
+              description: URL to retrieve members that can read this bucket.
               $ref: '#/components/schemas/Link'
             org:
-              description: URL to retrieve parent organization for this bucket
+              description: URL to retrieve parent organization for this bucket.
               $ref: '#/components/schemas/Link'
             owners:
               description: URL to retrieve owners that can read and write to this bucket.
               $ref: '#/components/schemas/Link'
             self:
-              description: URL for this bucket
+              description: URL for this bucket.
               $ref: '#/components/schemas/Link'
             write:
-              description: URL to write line protocol for this bucket
+              description: URL to write line protocol to this bucket.
               $ref: '#/components/schemas/Link'
         id:
           readOnly: true
@@ -8009,44 +8017,54 @@ components:
           readOnly: true
           type: string
         type:
-          description: 'The type of task, this can be used for filtering tasks on list actions.'
+          description: 'Type of the task, useful for filtering a task list.'
           type: string
         orgID:
-          description: The ID of the organization that owns this Task.
+          description: ID of the organization that owns the task.
           type: string
         org:
-          description: The name of the organization that owns this Task.
+          description: Name of the organization that owns the task.
           type: string
         name:
-          description: The name of the task.
+          description: Name of the task.
           type: string
         ownerID:
-          description: The ID of the user who owns this Task.
+          description: ID of the user who owns this Task.
           type: string
         description:
-          description: An optional description of the task.
+          description: Description of the task.
           type: string
         status:
           $ref: '#/components/schemas/TaskStatusType'
         labels:
           $ref: '#/components/schemas/Labels'
         authorizationID:
-          description: The ID of the authorization used when this task communicates with the query engine.
+          description: ID of the authorization used when the task communicates with the query engine.
           type: string
         flux:
-          description: The Flux script to run for this task.
+          description: Flux script to run for this task.
           type: string
         every:
-          description: A simple task repetition schedule; parsed from Flux.
+          description: |-
+            Interval at which the task runs. `every` also determines when the task first runs, depending on the specified time.
+            Value is a [duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals)).
           type: string
+          format: duration
         cron:
-          description: A task repetition schedule in the form '* * * * * *'; parsed from Flux.
+          description: |-
+            [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview) that defines the schedule on which the task runs. Cron scheduling is based on system time.
+            Value is a [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview).
           type: string
         offset:
-          description: 'Duration to delay after the schedule, before executing the task; parsed from flux, if set to zero it will remove this option and use 0 as the default.'
+          description: |-
+            [Duration](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals) to delay execution of the task after the scheduled time has elapsed. `0` removes the offset.
+            The value is a [duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals).
           type: string
+          format: duration
         latestCompleted:
-          description: 'Timestamp of latest scheduled, completed run, RFC3339.'
+          description: |-
+            Timestamp of the latest scheduled and completed run.
+            Value is a timestamp in [RFC3339 date/time format](https://docs.influxdata.com/flux/v0.x/data-types/basic/time/#time-syntax).
           type: string
           format: date-time
           readOnly: true
@@ -8295,19 +8313,18 @@ components:
             - unsupported media type
         message:
           readOnly: true
-          description: message is a human-readable message.
+          description: Human-readable message.
           type: string
         op:
           readOnly: true
-          description: op describes the logical code operation during error. Useful for debugging.
+          description: Describes the logical code operation when the error occurred. Useful for debugging.
           type: string
         err:
           readOnly: true
-          description: err is a stack of errors that occurred during processing of the request. Useful for debugging.
+          description: Stack of errors that occurred during processing of the request. Useful for debugging.
           type: string
       required:
         - code
-        - message
     LineProtocolError:
       properties:
         code:
@@ -8323,26 +8340,23 @@ components:
             - unavailable
         message:
           readOnly: true
-          description: Message is a human-readable message.
+          description: Human-readable message.
           type: string
         op:
           readOnly: true
-          description: Op describes the logical code operation during error. Useful for debugging.
+          description: Describes the logical code operation when the error occurred. Useful for debugging.
           type: string
         err:
           readOnly: true
-          description: Err is a stack of errors that occurred during processing of the request. Useful for debugging.
+          description: Stack of errors that occurred during processing of the request. Useful for debugging.
           type: string
         line:
           readOnly: true
-          description: First line within sent body containing malformed data
+          description: First line in the request body that contains malformed data.
           type: integer
           format: int32
       required:
         - code
-        - message
-        - op
-        - err
     LineProtocolLengthError:
       properties:
         code:
@@ -8353,7 +8367,7 @@ components:
             - invalid
         message:
           readOnly: true
-          description: Message is a human-readable message.
+          description: Human-readable message.
           type: string
       required:
         - code
@@ -8444,26 +8458,26 @@ components:
         - advanced
     Axis:
       type: object
-      description: The description of a particular axis for a visualization.
+      description: Axis used in a visualization.
       properties:
         bounds:
           type: array
           minItems: 0
           maxItems: 2
-          description: 'The extents of an axis in the form [lower, upper]. Clients determine whether bounds are to be inclusive or exclusive of their limits'
+          description: 'The extents of the axis in the form [lower, upper]. Clients determine whether bounds are inclusive or exclusive of their limits.'
           items:
             type: string
         label:
-          description: Label is a description of this Axis
+          description: Description of the axis.
           type: string
         prefix:
-          description: Prefix represents a label prefix for formatting axis values.
+          description: Label prefix for formatting axis values.
           type: string
         suffix:
-          description: Suffix represents a label suffix for formatting axis values.
+          description: Label suffix for formatting axis values.
           type: string
         base:
-          description: Base represents the radix for formatting axis values.
+          description: Radix for formatting axis values.
           type: string
           enum:
             - ''
@@ -10429,8 +10443,7 @@ components:
           description: An optional description of the check.
           type: string
         latestCompleted:
-          description: 'Timestamp of latest scheduled, completed run, RFC3339.'
-          type: string
+          description: 'Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.'
           format: date-time
           readOnly: true
         lastRunStatus:
@@ -10700,7 +10713,7 @@ components:
         - endpointID
       properties:
         latestCompleted:
-          description: 'Timestamp of latest scheduled, completed run, RFC3339.'
+          description: 'Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.'
           type: string
           format: date-time
           readOnly: true
@@ -11107,14 +11120,14 @@ components:
       properties:
         id:
           type: string
-          description: the mapping identifier
+          description: ID of the DBRP mapping.
           readOnly: true
         orgID:
           type: string
-          description: the organization ID that owns this mapping.
+          description: ID of the organization that owns this mapping.
         bucketID:
           type: string
-          description: the bucket ID used as target for the translation.
+          description: ID of the bucket used as the target for the translation.
         database:
           type: string
           description: InfluxDB v1 database
@@ -11123,7 +11136,7 @@ components:
           description: InfluxDB v1 retention policy
         default:
           type: boolean
-          description: Specify if this mapping represents the default retention policy for the database specificed.
+          description: Mapping represents the default retention policy for the database specified.
         links:
           $ref: '#/components/schemas/Links'
       required:
@@ -11151,13 +11164,13 @@ components:
       properties:
         orgID:
           type: string
-          description: the organization ID that owns this mapping.
+          description: ID of the organization that owns this mapping.
         org:
           type: string
-          description: the organization that owns this mapping.
+          description: Name of the organization that owns this mapping.
         bucketID:
           type: string
-          description: the bucket ID used as target for the translation.
+          description: ID of the bucket used as the target for the translation.
         database:
           type: string
           description: InfluxDB v1 database
@@ -11166,7 +11179,7 @@ components:
           description: InfluxDB v1 retention policy
         default:
           type: boolean
-          description: Specify if this mapping represents the default retention policy for the database specificed.
+          description: Mapping represents the default retention policy for the database specified.
       required:
         - bucketID
         - database
@@ -11588,7 +11601,7 @@ components:
         - tag
         - field
     MeasurementSchema:
-      description: The schema definition for a single measurement
+      description: Definition of a measurement schema.
       type: object
       example:
         id: 1a3c5e7f9b0a8642
@@ -11597,7 +11610,8 @@ components:
         name: cpu
         columns:
           - name: time
-            type: timestamp
+            type: integer
+            format: unix timestamp
           - name: host
             type: tag
           - name: region
@@ -11622,7 +11636,7 @@ components:
           readOnly: true
         orgID:
           type: string
-          description: ID of organization that the measurement schema is associated with.
+          description: ID of the organization that the measurement schema is associated with.
         bucketID:
           type: string
           description: ID of the bucket that the measurement schema is associated with.
@@ -11630,7 +11644,7 @@ components:
           type: string
           nullable: false
         columns:
-          description: An ordered collection of column definitions
+          description: Ordered collection of column definitions.
           type: array
           items:
             $ref: '#/components/schemas/MeasurementSchemaColumn'
@@ -11643,10 +11657,11 @@ components:
           format: date-time
           readOnly: true
     MeasurementSchemaColumn:
-      description: Definition of a measurement column
+      description: Definition of a measurement schema column.
       example:
         name: time
-        type: timestamp
+        type: integer
+        format: unix timestamp
       type: object
       required:
         - name
@@ -11659,13 +11674,14 @@ components:
         dataType:
           $ref: '#/components/schemas/ColumnDataType'
     MeasurementSchemaCreateRequest:
-      description: Create a new measurement schema
+      description: Create a new measurement schema.
       type: object
       example:
         name: cpu
         columns:
           - name: time
-            type: timestamp
+            type: integer
+            format: unix timestamp
           - name: host
             type: tag
           - name: region
@@ -11683,7 +11699,7 @@ components:
         name:
           type: string
         columns:
-          description: An ordered collection of column definitions
+          description: Ordered collection of column definitions.
           type: array
           items:
             $ref: '#/components/schemas/MeasurementSchemaColumn'
@@ -11723,7 +11739,8 @@ components:
       example:
         columns:
           - name: time
-            type: timestamp
+            type: integer
+            format: unix timestamp
           - name: host
             type: tag
           - name: region

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -5069,7 +5069,7 @@ components:
       schema:
         type: string
       description: |
-        The last resource ID from which to seek from (but not including). This is to be used instead of `offset`.
+        Resource ID to seek from. Results are not inclusive of this ID. Use `after` instead of `offset`.
   schemas:
     LanguageRequest:
       description: Flux query to be analyzed.
@@ -5605,7 +5605,7 @@ components:
     AuthorizationUpdateRequest:
       properties:
         status:
-          description: If inactive the token is inactive and requests using the token will be rejected.
+          description: 'Status of the token. If `inactive`, requests using the token will be rejected.'
           default: active
           type: string
           enum:
@@ -5647,22 +5647,22 @@ components:
             write: /api/v2/write?org=2&bucket=1
           properties:
             labels:
-              description: URL to retrieve labels for this bucket
+              description: URL to retrieve labels for this bucket.
               $ref: '#/components/schemas/Link'
             members:
-              description: URL to retrieve members that can read this bucket
+              description: URL to retrieve members that can read this bucket.
               $ref: '#/components/schemas/Link'
             org:
-              description: URL to retrieve parent organization for this bucket
+              description: URL to retrieve parent organization for this bucket.
               $ref: '#/components/schemas/Link'
             owners:
               description: URL to retrieve owners that can read and write to this bucket.
               $ref: '#/components/schemas/Link'
             self:
-              description: URL for this bucket
+              description: URL for this bucket.
               $ref: '#/components/schemas/Link'
             write:
-              description: URL to write line protocol for this bucket
+              description: URL to write line protocol to this bucket.
               $ref: '#/components/schemas/Link'
         id:
           readOnly: true
@@ -6923,44 +6923,54 @@ components:
           readOnly: true
           type: string
         type:
-          description: 'The type of task, this can be used for filtering tasks on list actions.'
+          description: 'Type of the task, useful for filtering a task list.'
           type: string
         orgID:
-          description: The ID of the organization that owns this Task.
+          description: ID of the organization that owns the task.
           type: string
         org:
-          description: The name of the organization that owns this Task.
+          description: Name of the organization that owns the task.
           type: string
         name:
-          description: The name of the task.
+          description: Name of the task.
           type: string
         ownerID:
-          description: The ID of the user who owns this Task.
+          description: ID of the user who owns this Task.
           type: string
         description:
-          description: An optional description of the task.
+          description: Description of the task.
           type: string
         status:
           $ref: '#/components/schemas/TaskStatusType'
         labels:
           $ref: '#/components/schemas/Labels'
         authorizationID:
-          description: The ID of the authorization used when this task communicates with the query engine.
+          description: ID of the authorization used when the task communicates with the query engine.
           type: string
         flux:
-          description: The Flux script to run for this task.
+          description: Flux script to run for this task.
           type: string
         every:
-          description: A simple task repetition schedule; parsed from Flux.
+          description: |-
+            Interval at which the task runs. `every` also determines when the task first runs, depending on the specified time.
+            Value is a [duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals)).
           type: string
+          format: duration
         cron:
-          description: A task repetition schedule in the form '* * * * * *'; parsed from Flux.
+          description: |-
+            [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview) that defines the schedule on which the task runs. Cron scheduling is based on system time.
+            Value is a [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview).
           type: string
         offset:
-          description: 'Duration to delay after the schedule, before executing the task; parsed from flux, if set to zero it will remove this option and use 0 as the default.'
+          description: |-
+            [Duration](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals) to delay execution of the task after the scheduled time has elapsed. `0` removes the offset.
+            The value is a [duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals).
           type: string
+          format: duration
         latestCompleted:
-          description: 'Timestamp of latest scheduled, completed run, RFC3339.'
+          description: |-
+            Timestamp of the latest scheduled and completed run.
+            Value is a timestamp in [RFC3339 date/time format](https://docs.influxdata.com/flux/v0.x/data-types/basic/time/#time-syntax).
           type: string
           format: date-time
           readOnly: true
@@ -7209,19 +7219,18 @@ components:
             - unsupported media type
         message:
           readOnly: true
-          description: message is a human-readable message.
+          description: Human-readable message.
           type: string
         op:
           readOnly: true
-          description: op describes the logical code operation during error. Useful for debugging.
+          description: Describes the logical code operation when the error occurred. Useful for debugging.
           type: string
         err:
           readOnly: true
-          description: err is a stack of errors that occurred during processing of the request. Useful for debugging.
+          description: Stack of errors that occurred during processing of the request. Useful for debugging.
           type: string
       required:
         - code
-        - message
     LineProtocolError:
       properties:
         code:
@@ -7237,26 +7246,23 @@ components:
             - unavailable
         message:
           readOnly: true
-          description: Message is a human-readable message.
+          description: Human-readable message.
           type: string
         op:
           readOnly: true
-          description: Op describes the logical code operation during error. Useful for debugging.
+          description: Describes the logical code operation when the error occurred. Useful for debugging.
           type: string
         err:
           readOnly: true
-          description: Err is a stack of errors that occurred during processing of the request. Useful for debugging.
+          description: Stack of errors that occurred during processing of the request. Useful for debugging.
           type: string
         line:
           readOnly: true
-          description: First line within sent body containing malformed data
+          description: First line in the request body that contains malformed data.
           type: integer
           format: int32
       required:
         - code
-        - message
-        - op
-        - err
     LineProtocolLengthError:
       properties:
         code:
@@ -7267,7 +7273,7 @@ components:
             - invalid
         message:
           readOnly: true
-          description: Message is a human-readable message.
+          description: Human-readable message.
           type: string
       required:
         - code
@@ -7358,26 +7364,26 @@ components:
         - advanced
     Axis:
       type: object
-      description: The description of a particular axis for a visualization.
+      description: Axis used in a visualization.
       properties:
         bounds:
           type: array
           minItems: 0
           maxItems: 2
-          description: 'The extents of an axis in the form [lower, upper]. Clients determine whether bounds are to be inclusive or exclusive of their limits'
+          description: 'The extents of the axis in the form [lower, upper]. Clients determine whether bounds are inclusive or exclusive of their limits.'
           items:
             type: string
         label:
-          description: Label is a description of this Axis
+          description: Description of the axis.
           type: string
         prefix:
-          description: Prefix represents a label prefix for formatting axis values.
+          description: Label prefix for formatting axis values.
           type: string
         suffix:
-          description: Suffix represents a label suffix for formatting axis values.
+          description: Label suffix for formatting axis values.
           type: string
         base:
-          description: Base represents the radix for formatting axis values.
+          description: Radix for formatting axis values.
           type: string
           enum:
             - ''
@@ -9343,8 +9349,7 @@ components:
           description: An optional description of the check.
           type: string
         latestCompleted:
-          description: 'Timestamp of latest scheduled, completed run, RFC3339.'
-          type: string
+          description: 'Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.'
           format: date-time
           readOnly: true
         lastRunStatus:
@@ -9614,7 +9619,7 @@ components:
         - endpointID
       properties:
         latestCompleted:
-          description: 'Timestamp of latest scheduled, completed run, RFC3339.'
+          description: 'Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.'
           type: string
           format: date-time
           readOnly: true
@@ -10021,14 +10026,14 @@ components:
       properties:
         id:
           type: string
-          description: the mapping identifier
+          description: ID of the DBRP mapping.
           readOnly: true
         orgID:
           type: string
-          description: the organization ID that owns this mapping.
+          description: ID of the organization that owns this mapping.
         bucketID:
           type: string
-          description: the bucket ID used as target for the translation.
+          description: ID of the bucket used as the target for the translation.
         database:
           type: string
           description: InfluxDB v1 database
@@ -10037,7 +10042,7 @@ components:
           description: InfluxDB v1 retention policy
         default:
           type: boolean
-          description: Specify if this mapping represents the default retention policy for the database specificed.
+          description: Mapping represents the default retention policy for the database specified.
         links:
           $ref: '#/components/schemas/Links'
       required:
@@ -10065,13 +10070,13 @@ components:
       properties:
         orgID:
           type: string
-          description: the organization ID that owns this mapping.
+          description: ID of the organization that owns this mapping.
         org:
           type: string
-          description: the organization that owns this mapping.
+          description: Name of the organization that owns this mapping.
         bucketID:
           type: string
-          description: the bucket ID used as target for the translation.
+          description: ID of the bucket used as the target for the translation.
         database:
           type: string
           description: InfluxDB v1 database
@@ -10080,7 +10085,7 @@ components:
           description: InfluxDB v1 retention policy
         default:
           type: boolean
-          description: Specify if this mapping represents the default retention policy for the database specificed.
+          description: Mapping represents the default retention policy for the database specified.
       required:
         - bucketID
         - database

--- a/contracts/invocable-scripts.yml
+++ b/contracts/invocable-scripts.yml
@@ -200,19 +200,18 @@ components:
             - unsupported media type
         message:
           readOnly: true
-          description: message is a human-readable message.
+          description: Human-readable message.
           type: string
         op:
           readOnly: true
-          description: op describes the logical code operation during error. Useful for debugging.
+          description: Describes the logical code operation when the error occurred. Useful for debugging.
           type: string
         err:
           readOnly: true
-          description: err is a stack of errors that occurred during processing of the request. Useful for debugging.
+          description: Stack of errors that occurred during processing of the request. Useful for debugging.
           type: string
       required:
         - code
-        - message
     Script:
       properties:
         id:

--- a/contracts/mapsd.yml
+++ b/contracts/mapsd.yml
@@ -7,10 +7,11 @@ servers:
 paths:
   /mapToken:
     get:
+      summary: Get a mapbox token
       operationId: getMapboxToken
       responses:
         '200':
-          description: A temp token for Mapbox
+          description: Temporary token for Mapbox.
           content:
             application/json:
               schema:
@@ -50,19 +51,18 @@ components:
             - unsupported media type
         message:
           readOnly: true
-          description: message is a human-readable message.
+          description: Human-readable message.
           type: string
         op:
           readOnly: true
-          description: op describes the logical code operation during error. Useful for debugging.
+          description: Describes the logical code operation when the error occurred. Useful for debugging.
           type: string
         err:
           readOnly: true
-          description: err is a stack of errors that occurred during processing of the request. Useful for debugging.
+          description: Stack of errors that occurred during processing of the request. Useful for debugging.
           type: string
       required:
         - code
-        - message
   responses:
     ServerError:
       description: Non 2XX error response from server.

--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -200,7 +200,8 @@ paths:
           content:
             text/plain:
               schema:
-                type: Prometheus text-based exposition
+                type: string
+                format: Prometheus text-based exposition
                 externalDocs:
                   description: Prometheus exposition formats
                   url: 'https://prometheus.io/docs/instrumenting/exposition_formats'
@@ -289,7 +290,7 @@ paths:
           schema:
             type: string
           description: |
-            The last resource ID from which to seek from (but not including). This is to be used instead of `offset`.
+            Resource ID to seek from. Results are not inclusive of this ID. Use `after` instead of `offset`.
         - in: query
           name: name
           schema:
@@ -2588,26 +2589,26 @@ paths:
                                               properties:
                                                 x:
                                                   type: object
-                                                  description: The description of a particular axis for a visualization.
+                                                  description: Axis used in a visualization.
                                                   properties:
                                                     bounds:
                                                       type: array
                                                       minItems: 0
                                                       maxItems: 2
-                                                      description: 'The extents of an axis in the form [lower, upper]. Clients determine whether bounds are to be inclusive or exclusive of their limits'
+                                                      description: 'The extents of the axis in the form [lower, upper]. Clients determine whether bounds are inclusive or exclusive of their limits.'
                                                       items:
                                                         type: string
                                                     label:
-                                                      description: Label is a description of this Axis
+                                                      description: Description of the axis.
                                                       type: string
                                                     prefix:
-                                                      description: Prefix represents a label prefix for formatting axis values.
+                                                      description: Label prefix for formatting axis values.
                                                       type: string
                                                     suffix:
-                                                      description: Suffix represents a label suffix for formatting axis values.
+                                                      description: Label suffix for formatting axis values.
                                                       type: string
                                                     base:
-                                                      description: Base represents the radix for formatting axis values.
+                                                      description: Radix for formatting axis values.
                                                       type: string
                                                       enum:
                                                         - ''
@@ -3150,8 +3151,7 @@ paths:
                                                               description: An optional description of the check.
                                                               type: string
                                                             latestCompleted:
-                                                              description: 'Timestamp of latest scheduled, completed run, RFC3339.'
-                                                              type: string
+                                                              description: 'Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.'
                                                               format: date-time
                                                               readOnly: true
                                                             lastRunStatus:
@@ -4211,44 +4211,54 @@ paths:
                     readOnly: true
                     type: string
                   type:
-                    description: 'The type of task, this can be used for filtering tasks on list actions.'
+                    description: 'Type of the task, useful for filtering a task list.'
                     type: string
                   orgID:
-                    description: The ID of the organization that owns this Task.
+                    description: ID of the organization that owns the task.
                     type: string
                   org:
-                    description: The name of the organization that owns this Task.
+                    description: Name of the organization that owns the task.
                     type: string
                   name:
-                    description: The name of the task.
+                    description: Name of the task.
                     type: string
                   ownerID:
-                    description: The ID of the user who owns this Task.
+                    description: ID of the user who owns this Task.
                     type: string
                   description:
-                    description: An optional description of the task.
+                    description: Description of the task.
                     type: string
                   status:
                     $ref: '#/paths/~1tasks/post/requestBody/content/application~1json/schema/properties/status'
                   labels:
                     $ref: '#/components/schemas/Variable/properties/labels'
                   authorizationID:
-                    description: The ID of the authorization used when this task communicates with the query engine.
+                    description: ID of the authorization used when the task communicates with the query engine.
                     type: string
                   flux:
-                    description: The Flux script to run for this task.
+                    description: Flux script to run for this task.
                     type: string
                   every:
-                    description: A simple task repetition schedule; parsed from Flux.
+                    description: |-
+                      Interval at which the task runs. `every` also determines when the task first runs, depending on the specified time.
+                      Value is a [duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals)).
                     type: string
+                    format: duration
                   cron:
-                    description: A task repetition schedule in the form '* * * * * *'; parsed from Flux.
+                    description: |-
+                      [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview) that defines the schedule on which the task runs. Cron scheduling is based on system time.
+                      Value is a [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview).
                     type: string
                   offset:
-                    description: 'Duration to delay after the schedule, before executing the task; parsed from flux, if set to zero it will remove this option and use 0 as the default.'
+                    description: |-
+                      [Duration](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals) to delay execution of the task after the scheduled time has elapsed. `0` removes the offset.
+                      The value is a [duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals).
                     type: string
+                    format: duration
                   latestCompleted:
-                    description: 'Timestamp of latest scheduled, completed run, RFC3339.'
+                    description: |-
+                      Timestamp of the latest scheduled and completed run.
+                      Value is a timestamp in [RFC3339 date/time format](https://docs.influxdata.com/flux/v0.x/data-types/basic/time/#time-syntax).
                     type: string
                     format: date-time
                     readOnly: true
@@ -4314,7 +4324,7 @@ components:
       allOf:
         - properties:
             status:
-              description: If inactive the token is inactive and requests using the token will be rejected.
+              description: 'Status of the token. If `inactive`, requests using the token will be rejected.'
               default: active
               type: string
               enum:
@@ -4335,11 +4345,11 @@ components:
               readOnly: true
             orgID:
               type: string
-              description: ID of org that authorization is scoped to.
+              description: ID of the organization that the authorization is scoped to.
             permissions:
               type: array
               minItems: 1
-              description: List of permissions for an auth.  An auth must have at least one Permission.
+              description: List of permissions for an authorization.  An authorization must have at least one permission.
               items:
                 $ref: '#/components/schemas/Permission'
             id:
@@ -4348,19 +4358,19 @@ components:
             token:
               readOnly: true
               type: string
-              description: Passed via the Authorization Header and Token Authentication type.
+              description: Token used to authenticate API requests.
             userID:
               readOnly: true
               type: string
-              description: ID of user that created and owns the token.
+              description: ID of the user that created and owns the token.
             user:
               readOnly: true
               type: string
-              description: Name of user that created and owns the token.
+              description: Name of the user that created and owns the token.
             org:
               readOnly: true
               type: string
-              description: Name of the org token is scoped to.
+              description: Name of the organization that the token is scoped to.
             links:
               type: object
               readOnly: true
@@ -4638,22 +4648,22 @@ components:
                 write: /api/v2/write?org=2&bucket=1
               properties:
                 labels:
-                  description: URL to retrieve labels for this bucket
+                  description: URL to retrieve labels for this bucket.
                   $ref: '#/components/schemas/ScraperTargetResponse/allOf/1/properties/links/properties/self'
                 members:
-                  description: URL to retrieve members that can read this bucket
+                  description: URL to retrieve members that can read this bucket.
                   $ref: '#/components/schemas/ScraperTargetResponse/allOf/1/properties/links/properties/self'
                 org:
-                  description: URL to retrieve parent organization for this bucket
+                  description: URL to retrieve parent organization for this bucket.
                   $ref: '#/components/schemas/ScraperTargetResponse/allOf/1/properties/links/properties/self'
                 owners:
                   description: URL to retrieve owners that can read and write to this bucket.
                   $ref: '#/components/schemas/ScraperTargetResponse/allOf/1/properties/links/properties/self'
                 self:
-                  description: URL for this bucket
+                  description: URL for this bucket.
                   $ref: '#/components/schemas/ScraperTargetResponse/allOf/1/properties/links/properties/self'
                 write:
-                  description: URL to write line protocol for this bucket
+                  description: URL to write line protocol to this bucket.
                   $ref: '#/components/schemas/ScraperTargetResponse/allOf/1/properties/links/properties/self'
             id:
               readOnly: true
@@ -5349,19 +5359,18 @@ components:
                   - unsupported media type
               message:
                 readOnly: true
-                description: message is a human-readable message.
+                description: Human-readable message.
                 type: string
               op:
                 readOnly: true
-                description: op describes the logical code operation during error. Useful for debugging.
+                description: Describes the logical code operation when the error occurred. Useful for debugging.
                 type: string
               err:
                 readOnly: true
-                description: err is a stack of errors that occurred during processing of the request. Useful for debugging.
+                description: Stack of errors that occurred during processing of the request. Useful for debugging.
                 type: string
             required:
               - code
-              - message
   securitySchemes:
     TokenAuthentication:
       type: apiKey

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -8313,7 +8313,8 @@
             "content": {
               "text/plain": {
                 "schema": {
-                  "type": "Prometheus text-based exposition",
+                  "type": "string",
+                  "format": "Prometheus text-based exposition",
                   "externalDocs": {
                     "description": "Prometheus exposition formats",
                     "url": "https://prometheus.io/docs/instrumenting/exposition_formats"
@@ -11865,7 +11866,7 @@
         "schema": {
           "type": "string"
         },
-        "description": "The last resource ID from which to seek from (but not including). This is to be used instead of `offset`.\n"
+        "description": "Resource ID to seek from. Results are not inclusive of this ID. Use `after` instead of `offset`.\n"
       }
     },
     "schemas": {
@@ -12704,7 +12705,7 @@
       "AuthorizationUpdateRequest": {
         "properties": {
           "status": {
-            "description": "If inactive the token is inactive and requests using the token will be rejected.",
+            "description": "Status of the token. If `inactive`, requests using the token will be rejected.",
             "default": "active",
             "type": "string",
             "enum": [
@@ -12761,15 +12762,15 @@
             },
             "properties": {
               "labels": {
-                "description": "URL to retrieve labels for this bucket",
+                "description": "URL to retrieve labels for this bucket.",
                 "$ref": "#/components/schemas/Link"
               },
               "members": {
-                "description": "URL to retrieve members that can read this bucket",
+                "description": "URL to retrieve members that can read this bucket.",
                 "$ref": "#/components/schemas/Link"
               },
               "org": {
-                "description": "URL to retrieve parent organization for this bucket",
+                "description": "URL to retrieve parent organization for this bucket.",
                 "$ref": "#/components/schemas/Link"
               },
               "owners": {
@@ -12777,11 +12778,11 @@
                 "$ref": "#/components/schemas/Link"
               },
               "self": {
-                "description": "URL for this bucket",
+                "description": "URL for this bucket.",
                 "$ref": "#/components/schemas/Link"
               },
               "write": {
-                "description": "URL to write line protocol for this bucket",
+                "description": "URL to write line protocol to this bucket.",
                 "$ref": "#/components/schemas/Link"
               }
             }
@@ -14696,27 +14697,27 @@
             "type": "string"
           },
           "type": {
-            "description": "The type of task, this can be used for filtering tasks on list actions.",
+            "description": "Type of the task, useful for filtering a task list.",
             "type": "string"
           },
           "orgID": {
-            "description": "The ID of the organization that owns this Task.",
+            "description": "ID of the organization that owns the task.",
             "type": "string"
           },
           "org": {
-            "description": "The name of the organization that owns this Task.",
+            "description": "Name of the organization that owns the task.",
             "type": "string"
           },
           "name": {
-            "description": "The name of the task.",
+            "description": "Name of the task.",
             "type": "string"
           },
           "ownerID": {
-            "description": "The ID of the user who owns this Task.",
+            "description": "ID of the user who owns this Task.",
             "type": "string"
           },
           "description": {
-            "description": "An optional description of the task.",
+            "description": "Description of the task.",
             "type": "string"
           },
           "status": {
@@ -14726,27 +14727,29 @@
             "$ref": "#/components/schemas/Labels"
           },
           "authorizationID": {
-            "description": "The ID of the authorization used when this task communicates with the query engine.",
+            "description": "ID of the authorization used when the task communicates with the query engine.",
             "type": "string"
           },
           "flux": {
-            "description": "The Flux script to run for this task.",
+            "description": "Flux script to run for this task.",
             "type": "string"
           },
           "every": {
-            "description": "A simple task repetition schedule; parsed from Flux.",
-            "type": "string"
+            "description": "Interval at which the task runs. `every` also determines when the task first runs, depending on the specified time.\nValue is a [duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals)).",
+            "type": "string",
+            "format": "duration"
           },
           "cron": {
-            "description": "A task repetition schedule in the form '* * * * * *'; parsed from Flux.",
+            "description": "[Cron expression](https://en.wikipedia.org/wiki/Cron#Overview) that defines the schedule on which the task runs. Cron scheduling is based on system time.\nValue is a [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview).",
             "type": "string"
           },
           "offset": {
-            "description": "Duration to delay after the schedule, before executing the task; parsed from flux, if set to zero it will remove this option and use 0 as the default.",
-            "type": "string"
+            "description": "[Duration](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals) to delay execution of the task after the scheduled time has elapsed. `0` removes the offset.\nThe value is a [duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals).",
+            "type": "string",
+            "format": "duration"
           },
           "latestCompleted": {
-            "description": "Timestamp of latest scheduled, completed run, RFC3339.",
+            "description": "Timestamp of the latest scheduled and completed run.\nValue is a timestamp in [RFC3339 date/time format](https://docs.influxdata.com/flux/v0.x/data-types/basic/time/#time-syntax).",
             "type": "string",
             "format": "date-time",
             "readOnly": true
@@ -15102,23 +15105,22 @@
           },
           "message": {
             "readOnly": true,
-            "description": "message is a human-readable message.",
+            "description": "Human-readable message.",
             "type": "string"
           },
           "op": {
             "readOnly": true,
-            "description": "op describes the logical code operation during error. Useful for debugging.",
+            "description": "Describes the logical code operation when the error occurred. Useful for debugging.",
             "type": "string"
           },
           "err": {
             "readOnly": true,
-            "description": "err is a stack of errors that occurred during processing of the request. Useful for debugging.",
+            "description": "Stack of errors that occurred during processing of the request. Useful for debugging.",
             "type": "string"
           }
         },
         "required": [
-          "code",
-          "message"
+          "code"
         ]
       },
       "LineProtocolError": {
@@ -15138,31 +15140,28 @@
           },
           "message": {
             "readOnly": true,
-            "description": "Message is a human-readable message.",
+            "description": "Human-readable message.",
             "type": "string"
           },
           "op": {
             "readOnly": true,
-            "description": "Op describes the logical code operation during error. Useful for debugging.",
+            "description": "Describes the logical code operation when the error occurred. Useful for debugging.",
             "type": "string"
           },
           "err": {
             "readOnly": true,
-            "description": "Err is a stack of errors that occurred during processing of the request. Useful for debugging.",
+            "description": "Stack of errors that occurred during processing of the request. Useful for debugging.",
             "type": "string"
           },
           "line": {
             "readOnly": true,
-            "description": "First line within sent body containing malformed data",
+            "description": "First line in the request body that contains malformed data.",
             "type": "integer",
             "format": "int32"
           }
         },
         "required": [
-          "code",
-          "message",
-          "op",
-          "err"
+          "code"
         ]
       },
       "LineProtocolLengthError": {
@@ -15177,7 +15176,7 @@
           },
           "message": {
             "readOnly": true,
-            "description": "Message is a human-readable message.",
+            "description": "Human-readable message.",
             "type": "string"
           }
         },
@@ -15311,31 +15310,31 @@
       },
       "Axis": {
         "type": "object",
-        "description": "The description of a particular axis for a visualization.",
+        "description": "Axis used in a visualization.",
         "properties": {
           "bounds": {
             "type": "array",
             "minItems": 0,
             "maxItems": 2,
-            "description": "The extents of an axis in the form [lower, upper]. Clients determine whether bounds are to be inclusive or exclusive of their limits",
+            "description": "The extents of the axis in the form [lower, upper]. Clients determine whether bounds are inclusive or exclusive of their limits.",
             "items": {
               "type": "string"
             }
           },
           "label": {
-            "description": "Label is a description of this Axis",
+            "description": "Description of the axis.",
             "type": "string"
           },
           "prefix": {
-            "description": "Prefix represents a label prefix for formatting axis values.",
+            "description": "Label prefix for formatting axis values.",
             "type": "string"
           },
           "suffix": {
-            "description": "Suffix represents a label suffix for formatting axis values.",
+            "description": "Label suffix for formatting axis values.",
             "type": "string"
           },
           "base": {
-            "description": "Base represents the radix for formatting axis values.",
+            "description": "Radix for formatting axis values.",
             "type": "string",
             "enum": [
               "",
@@ -18206,8 +18205,7 @@
             "type": "string"
           },
           "latestCompleted": {
-            "description": "Timestamp of latest scheduled, completed run, RFC3339.",
-            "type": "string",
+            "description": "Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.",
             "format": "date-time",
             "readOnly": true
           },
@@ -18632,7 +18630,7 @@
         ],
         "properties": {
           "latestCompleted": {
-            "description": "Timestamp of latest scheduled, completed run, RFC3339.",
+            "description": "Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.",
             "type": "string",
             "format": "date-time",
             "readOnly": true
@@ -19254,16 +19252,16 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "the mapping identifier",
+            "description": "ID of the DBRP mapping.",
             "readOnly": true
           },
           "orgID": {
             "type": "string",
-            "description": "the organization ID that owns this mapping."
+            "description": "ID of the organization that owns this mapping."
           },
           "bucketID": {
             "type": "string",
-            "description": "the bucket ID used as target for the translation."
+            "description": "ID of the bucket used as the target for the translation."
           },
           "database": {
             "type": "string",
@@ -19275,7 +19273,7 @@
           },
           "default": {
             "type": "boolean",
-            "description": "Specify if this mapping represents the default retention policy for the database specificed."
+            "description": "Mapping represents the default retention policy for the database specified."
           },
           "links": {
             "$ref": "#/components/schemas/Links"
@@ -19316,15 +19314,15 @@
         "properties": {
           "orgID": {
             "type": "string",
-            "description": "the organization ID that owns this mapping."
+            "description": "ID of the organization that owns this mapping."
           },
           "org": {
             "type": "string",
-            "description": "the organization that owns this mapping."
+            "description": "Name of the organization that owns this mapping."
           },
           "bucketID": {
             "type": "string",
-            "description": "the bucket ID used as target for the translation."
+            "description": "ID of the bucket used as the target for the translation."
           },
           "database": {
             "type": "string",
@@ -19336,7 +19334,7 @@
           },
           "default": {
             "type": "boolean",
-            "description": "Specify if this mapping represents the default retention policy for the database specificed."
+            "description": "Mapping represents the default retention policy for the database specified."
           }
         },
         "required": [
@@ -19398,12 +19396,12 @@
               },
               "orgID": {
                 "type": "string",
-                "description": "ID of org that authorization is scoped to."
+                "description": "ID of the organization that the authorization is scoped to."
               },
               "permissions": {
                 "type": "array",
                 "minItems": 1,
-                "description": "List of permissions for an auth.  An auth must have at least one Permission.",
+                "description": "List of permissions for an authorization.  An authorization must have at least one permission.",
                 "items": {
                   "$ref": "#/components/schemas/Permission"
                 }
@@ -19415,22 +19413,22 @@
               "token": {
                 "readOnly": true,
                 "type": "string",
-                "description": "Passed via the Authorization Header and Token Authentication type."
+                "description": "Token used to authenticate API requests."
               },
               "userID": {
                 "readOnly": true,
                 "type": "string",
-                "description": "ID of user that created and owns the token."
+                "description": "ID of the user that created and owns the token."
               },
               "user": {
                 "readOnly": true,
                 "type": "string",
-                "description": "Name of user that created and owns the token."
+                "description": "Name of the user that created and owns the token."
               },
               "org": {
                 "readOnly": true,
                 "type": "string",
-                "description": "Name of the org token is scoped to."
+                "description": "Name of the organization that the token is scoped to."
               },
               "links": {
                 "type": "object",

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -5193,7 +5193,8 @@ paths:
           content:
             text/plain:
               schema:
-                type: Prometheus text-based exposition
+                type: string
+                format: Prometheus text-based exposition
                 externalDocs:
                   description: Prometheus exposition formats
                   url: 'https://prometheus.io/docs/instrumenting/exposition_formats'
@@ -7400,7 +7401,7 @@ components:
       schema:
         type: string
       description: |
-        The last resource ID from which to seek from (but not including). This is to be used instead of `offset`.
+        Resource ID to seek from. Results are not inclusive of this ID. Use `after` instead of `offset`.
   schemas:
     LanguageRequest:
       description: Flux query to be analyzed.
@@ -7936,7 +7937,7 @@ components:
     AuthorizationUpdateRequest:
       properties:
         status:
-          description: If inactive the token is inactive and requests using the token will be rejected.
+          description: 'Status of the token. If `inactive`, requests using the token will be rejected.'
           default: active
           type: string
           enum:
@@ -7978,22 +7979,22 @@ components:
             write: /api/v2/write?org=2&bucket=1
           properties:
             labels:
-              description: URL to retrieve labels for this bucket
+              description: URL to retrieve labels for this bucket.
               $ref: '#/components/schemas/Link'
             members:
-              description: URL to retrieve members that can read this bucket
+              description: URL to retrieve members that can read this bucket.
               $ref: '#/components/schemas/Link'
             org:
-              description: URL to retrieve parent organization for this bucket
+              description: URL to retrieve parent organization for this bucket.
               $ref: '#/components/schemas/Link'
             owners:
               description: URL to retrieve owners that can read and write to this bucket.
               $ref: '#/components/schemas/Link'
             self:
-              description: URL for this bucket
+              description: URL for this bucket.
               $ref: '#/components/schemas/Link'
             write:
-              description: URL to write line protocol for this bucket
+              description: URL to write line protocol to this bucket.
               $ref: '#/components/schemas/Link'
         id:
           readOnly: true
@@ -9254,44 +9255,54 @@ components:
           readOnly: true
           type: string
         type:
-          description: 'The type of task, this can be used for filtering tasks on list actions.'
+          description: 'Type of the task, useful for filtering a task list.'
           type: string
         orgID:
-          description: The ID of the organization that owns this Task.
+          description: ID of the organization that owns the task.
           type: string
         org:
-          description: The name of the organization that owns this Task.
+          description: Name of the organization that owns the task.
           type: string
         name:
-          description: The name of the task.
+          description: Name of the task.
           type: string
         ownerID:
-          description: The ID of the user who owns this Task.
+          description: ID of the user who owns this Task.
           type: string
         description:
-          description: An optional description of the task.
+          description: Description of the task.
           type: string
         status:
           $ref: '#/components/schemas/TaskStatusType'
         labels:
           $ref: '#/components/schemas/Labels'
         authorizationID:
-          description: The ID of the authorization used when this task communicates with the query engine.
+          description: ID of the authorization used when the task communicates with the query engine.
           type: string
         flux:
-          description: The Flux script to run for this task.
+          description: Flux script to run for this task.
           type: string
         every:
-          description: A simple task repetition schedule; parsed from Flux.
+          description: |-
+            Interval at which the task runs. `every` also determines when the task first runs, depending on the specified time.
+            Value is a [duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals)).
           type: string
+          format: duration
         cron:
-          description: A task repetition schedule in the form '* * * * * *'; parsed from Flux.
+          description: |-
+            [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview) that defines the schedule on which the task runs. Cron scheduling is based on system time.
+            Value is a [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview).
           type: string
         offset:
-          description: 'Duration to delay after the schedule, before executing the task; parsed from flux, if set to zero it will remove this option and use 0 as the default.'
+          description: |-
+            [Duration](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals) to delay execution of the task after the scheduled time has elapsed. `0` removes the offset.
+            The value is a [duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals).
           type: string
+          format: duration
         latestCompleted:
-          description: 'Timestamp of latest scheduled, completed run, RFC3339.'
+          description: |-
+            Timestamp of the latest scheduled and completed run.
+            Value is a timestamp in [RFC3339 date/time format](https://docs.influxdata.com/flux/v0.x/data-types/basic/time/#time-syntax).
           type: string
           format: date-time
           readOnly: true
@@ -9540,19 +9551,18 @@ components:
             - unsupported media type
         message:
           readOnly: true
-          description: message is a human-readable message.
+          description: Human-readable message.
           type: string
         op:
           readOnly: true
-          description: op describes the logical code operation during error. Useful for debugging.
+          description: Describes the logical code operation when the error occurred. Useful for debugging.
           type: string
         err:
           readOnly: true
-          description: err is a stack of errors that occurred during processing of the request. Useful for debugging.
+          description: Stack of errors that occurred during processing of the request. Useful for debugging.
           type: string
       required:
         - code
-        - message
     LineProtocolError:
       properties:
         code:
@@ -9568,26 +9578,23 @@ components:
             - unavailable
         message:
           readOnly: true
-          description: Message is a human-readable message.
+          description: Human-readable message.
           type: string
         op:
           readOnly: true
-          description: Op describes the logical code operation during error. Useful for debugging.
+          description: Describes the logical code operation when the error occurred. Useful for debugging.
           type: string
         err:
           readOnly: true
-          description: Err is a stack of errors that occurred during processing of the request. Useful for debugging.
+          description: Stack of errors that occurred during processing of the request. Useful for debugging.
           type: string
         line:
           readOnly: true
-          description: First line within sent body containing malformed data
+          description: First line in the request body that contains malformed data.
           type: integer
           format: int32
       required:
         - code
-        - message
-        - op
-        - err
     LineProtocolLengthError:
       properties:
         code:
@@ -9598,7 +9605,7 @@ components:
             - invalid
         message:
           readOnly: true
-          description: Message is a human-readable message.
+          description: Human-readable message.
           type: string
       required:
         - code
@@ -9689,26 +9696,26 @@ components:
         - advanced
     Axis:
       type: object
-      description: The description of a particular axis for a visualization.
+      description: Axis used in a visualization.
       properties:
         bounds:
           type: array
           minItems: 0
           maxItems: 2
-          description: 'The extents of an axis in the form [lower, upper]. Clients determine whether bounds are to be inclusive or exclusive of their limits'
+          description: 'The extents of the axis in the form [lower, upper]. Clients determine whether bounds are inclusive or exclusive of their limits.'
           items:
             type: string
         label:
-          description: Label is a description of this Axis
+          description: Description of the axis.
           type: string
         prefix:
-          description: Prefix represents a label prefix for formatting axis values.
+          description: Label prefix for formatting axis values.
           type: string
         suffix:
-          description: Suffix represents a label suffix for formatting axis values.
+          description: Label suffix for formatting axis values.
           type: string
         base:
-          description: Base represents the radix for formatting axis values.
+          description: Radix for formatting axis values.
           type: string
           enum:
             - ''
@@ -11674,8 +11681,7 @@ components:
           description: An optional description of the check.
           type: string
         latestCompleted:
-          description: 'Timestamp of latest scheduled, completed run, RFC3339.'
-          type: string
+          description: 'Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.'
           format: date-time
           readOnly: true
         lastRunStatus:
@@ -11945,7 +11951,7 @@ components:
         - endpointID
       properties:
         latestCompleted:
-          description: 'Timestamp of latest scheduled, completed run, RFC3339.'
+          description: 'Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.'
           type: string
           format: date-time
           readOnly: true
@@ -12352,14 +12358,14 @@ components:
       properties:
         id:
           type: string
-          description: the mapping identifier
+          description: ID of the DBRP mapping.
           readOnly: true
         orgID:
           type: string
-          description: the organization ID that owns this mapping.
+          description: ID of the organization that owns this mapping.
         bucketID:
           type: string
-          description: the bucket ID used as target for the translation.
+          description: ID of the bucket used as the target for the translation.
         database:
           type: string
           description: InfluxDB v1 database
@@ -12368,7 +12374,7 @@ components:
           description: InfluxDB v1 retention policy
         default:
           type: boolean
-          description: Specify if this mapping represents the default retention policy for the database specificed.
+          description: Mapping represents the default retention policy for the database specified.
         links:
           $ref: '#/components/schemas/Links'
       required:
@@ -12396,13 +12402,13 @@ components:
       properties:
         orgID:
           type: string
-          description: the organization ID that owns this mapping.
+          description: ID of the organization that owns this mapping.
         org:
           type: string
-          description: the organization that owns this mapping.
+          description: Name of the organization that owns this mapping.
         bucketID:
           type: string
-          description: the bucket ID used as target for the translation.
+          description: ID of the bucket used as the target for the translation.
         database:
           type: string
           description: InfluxDB v1 database
@@ -12411,7 +12417,7 @@ components:
           description: InfluxDB v1 retention policy
         default:
           type: boolean
-          description: Specify if this mapping represents the default retention policy for the database specificed.
+          description: Mapping represents the default retention policy for the database specified.
       required:
         - bucketID
         - database
@@ -12455,11 +12461,11 @@ components:
               readOnly: true
             orgID:
               type: string
-              description: ID of org that authorization is scoped to.
+              description: ID of the organization that the authorization is scoped to.
             permissions:
               type: array
               minItems: 1
-              description: List of permissions for an auth.  An auth must have at least one Permission.
+              description: List of permissions for an authorization.  An authorization must have at least one permission.
               items:
                 $ref: '#/components/schemas/Permission'
             id:
@@ -12468,19 +12474,19 @@ components:
             token:
               readOnly: true
               type: string
-              description: Passed via the Authorization Header and Token Authentication type.
+              description: Token used to authenticate API requests.
             userID:
               readOnly: true
               type: string
-              description: ID of user that created and owns the token.
+              description: ID of the user that created and owns the token.
             user:
               readOnly: true
               type: string
-              description: Name of user that created and owns the token.
+              description: Name of the user that created and owns the token.
             org:
               readOnly: true
               type: string
-              description: Name of the org token is scoped to.
+              description: Name of the organization that the token is scoped to.
             links:
               type: object
               readOnly: true

--- a/contracts/priv/annotationd-oss.yml
+++ b/contracts/priv/annotationd-oss.yml
@@ -498,19 +498,18 @@ components:
             - unsupported media type
         message:
           readOnly: true
-          description: message is a human-readable message.
+          description: Human-readable message.
           type: string
         op:
           readOnly: true
-          description: op describes the logical code operation during error. Useful for debugging.
+          description: Describes the logical code operation when the error occurred. Useful for debugging.
           type: string
         err:
           readOnly: true
-          description: err is a stack of errors that occurred during processing of the request. Useful for debugging.
+          description: Stack of errors that occurred during processing of the request. Useful for debugging.
           type: string
       required:
         - code
-        - message
   responses:
     NoContent:
       description: No content

--- a/contracts/priv/annotationd.yml
+++ b/contracts/priv/annotationd.yml
@@ -474,19 +474,18 @@ components:
             - unsupported media type
         message:
           readOnly: true
-          description: message is a human-readable message.
+          description: Human-readable message.
           type: string
         op:
           readOnly: true
-          description: op describes the logical code operation during error. Useful for debugging.
+          description: Describes the logical code operation when the error occurred. Useful for debugging.
           type: string
         err:
           readOnly: true
-          description: err is a stack of errors that occurred during processing of the request. Useful for debugging.
+          description: Stack of errors that occurred during processing of the request. Useful for debugging.
           type: string
       required:
         - code
-        - message
   responses:
     NoContent:
       description: No content

--- a/contracts/priv/cloud-priv.yml
+++ b/contracts/priv/cloud-priv.yml
@@ -404,22 +404,22 @@ components:
                 write: /api/v2/write?org=2&bucket=1
               properties:
                 labels:
-                  description: URL to retrieve labels for this bucket
+                  description: URL to retrieve labels for this bucket.
                   $ref: '#/components/schemas/Link'
                 members:
-                  description: URL to retrieve members that can read this bucket
+                  description: URL to retrieve members that can read this bucket.
                   $ref: '#/components/schemas/Link'
                 org:
-                  description: URL to retrieve parent organization for this bucket
+                  description: URL to retrieve parent organization for this bucket.
                   $ref: '#/components/schemas/Link'
                 owners:
                   description: URL to retrieve owners that can read and write to this bucket.
                   $ref: '#/components/schemas/Link'
                 self:
-                  description: URL for this bucket
+                  description: URL for this bucket.
                   $ref: '#/components/schemas/Link'
                 write:
-                  description: URL to write line protocol for this bucket
+                  description: URL to write line protocol to this bucket.
                   $ref: '#/components/schemas/Link'
             id:
               readOnly: true
@@ -508,7 +508,7 @@ components:
           allOf:
             - properties:
                 status:
-                  description: If inactive the token is inactive and requests using the token will be rejected.
+                  description: 'Status of the token. If `inactive`, requests using the token will be rejected.'
                   default: active
                   type: string
                   enum:
@@ -677,19 +677,18 @@ components:
             - unsupported media type
         message:
           readOnly: true
-          description: message is a human-readable message.
+          description: Human-readable message.
           type: string
         op:
           readOnly: true
-          description: op describes the logical code operation during error. Useful for debugging.
+          description: Describes the logical code operation when the error occurred. Useful for debugging.
           type: string
         err:
           readOnly: true
-          description: err is a stack of errors that occurred during processing of the request. Useful for debugging.
+          description: Stack of errors that occurred during processing of the request. Useful for debugging.
           type: string
       required:
         - code
-        - message
     OAuthClientConfig:
       type: object
       properties:

--- a/contracts/priv/fluxdocsd.yml
+++ b/contracts/priv/fluxdocsd.yml
@@ -206,19 +206,18 @@ components:
             - unsupported media type
         message:
           readOnly: true
-          description: message is a human-readable message.
+          description: Human-readable message.
           type: string
         op:
           readOnly: true
-          description: op describes the logical code operation during error. Useful for debugging.
+          description: Describes the logical code operation when the error occurred. Useful for debugging.
           type: string
         err:
           readOnly: true
-          description: err is a stack of errors that occurred during processing of the request. Useful for debugging.
+          description: Stack of errors that occurred during processing of the request. Useful for debugging.
           type: string
       required:
         - code
-        - message
   responses:
     NoContent:
       description: No content

--- a/contracts/priv/notebooksd.yml
+++ b/contracts/priv/notebooksd.yml
@@ -406,19 +406,18 @@ components:
             - unsupported media type
         message:
           readOnly: true
-          description: message is a human-readable message.
+          description: Human-readable message.
           type: string
         op:
           readOnly: true
-          description: op describes the logical code operation during error. Useful for debugging.
+          description: Describes the logical code operation when the error occurred. Useful for debugging.
           type: string
         err:
           readOnly: true
-          description: err is a stack of errors that occurred during processing of the request. Useful for debugging.
+          description: Stack of errors that occurred during processing of the request. Useful for debugging.
           type: string
       required:
         - code
-        - message
   responses:
     NoContent:
       description: No content

--- a/contracts/priv/pinneditemsd.yml
+++ b/contracts/priv/pinneditemsd.yml
@@ -148,19 +148,18 @@ components:
             - unsupported media type
         message:
           readOnly: true
-          description: message is a human-readable message.
+          description: Human-readable message.
           type: string
         op:
           readOnly: true
-          description: op describes the logical code operation during error. Useful for debugging.
+          description: Describes the logical code operation when the error occurred. Useful for debugging.
           type: string
         err:
           readOnly: true
-          description: err is a stack of errors that occurred during processing of the request. Useful for debugging.
+          description: Stack of errors that occurred during processing of the request. Useful for debugging.
           type: string
       required:
         - code
-        - message
   responses:
     NoContent:
       description: No content

--- a/contracts/priv/quartz-oem.yml
+++ b/contracts/priv/quartz-oem.yml
@@ -249,19 +249,18 @@ components:
             - unsupported media type
         message:
           readOnly: true
-          description: message is a human-readable message.
+          description: Human-readable message.
           type: string
         op:
           readOnly: true
-          description: op describes the logical code operation during error. Useful for debugging.
+          description: Describes the logical code operation when the error occurred. Useful for debugging.
           type: string
         err:
           readOnly: true
-          description: err is a stack of errors that occurred during processing of the request. Useful for debugging.
+          description: Stack of errors that occurred during processing of the request. Useful for debugging.
           type: string
       required:
         - code
-        - message
     Limit:
       description: Limit of at least 1
       type: integer

--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -1129,19 +1129,18 @@ components:
             - unsupported media type
         message:
           readOnly: true
-          description: message is a human-readable message.
+          description: Human-readable message.
           type: string
         op:
           readOnly: true
-          description: op describes the logical code operation during error. Useful for debugging.
+          description: Describes the logical code operation when the error occurred. Useful for debugging.
           type: string
         err:
           readOnly: true
-          description: err is a stack of errors that occurred during processing of the request. Useful for debugging.
+          description: Stack of errors that occurred during processing of the request. Useful for debugging.
           type: string
       required:
         - code
-        - message
     Account:
       properties:
         id:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -2,7 +2,7 @@ components:
   parameters:
     After:
       description: |
-        The last resource ID from which to seek from (but not including). This is to be used instead of `offset`.
+        Resource ID to seek from. Results are not inclusive of this ID. Use `after` instead of `offset`.
       in: query
       name: after
       required: false
@@ -165,7 +165,7 @@ components:
           type: string
         status:
           default: active
-          description: If inactive the token is inactive and requests using the token
+          description: Status of the token. If `inactive`, requests using the token
             will be rejected.
           enum:
           - active
@@ -193,33 +193,33 @@ components:
       - "y"
       type: object
     Axis:
-      description: The description of a particular axis for a visualization.
+      description: Axis used in a visualization.
       properties:
         base:
-          description: Base represents the radix for formatting axis values.
+          description: Radix for formatting axis values.
           enum:
           - ""
           - "2"
           - "10"
           type: string
         bounds:
-          description: The extents of an axis in the form [lower, upper]. Clients
-            determine whether bounds are to be inclusive or exclusive of their limits
+          description: The extents of the axis in the form [lower, upper]. Clients
+            determine whether bounds are inclusive or exclusive of their limits.
           items:
             type: string
           maxItems: 2
           minItems: 0
           type: array
         label:
-          description: Label is a description of this Axis
+          description: Description of the axis.
           type: string
         prefix:
-          description: Prefix represents a label prefix for formatting axis values.
+          description: Label prefix for formatting axis values.
           type: string
         scale:
           $ref: '#/components/schemas/AxisScale'
         suffix:
-          description: Suffix represents a label suffix for formatting axis values.
+          description: Label suffix for formatting axis values.
           type: string
       type: object
     AxisScale:
@@ -385,23 +385,23 @@ components:
           properties:
             labels:
               $ref: '#/components/schemas/Link'
-              description: URL to retrieve labels for this bucket
+              description: URL to retrieve labels for this bucket.
             members:
               $ref: '#/components/schemas/Link'
-              description: URL to retrieve members that can read this bucket
+              description: URL to retrieve members that can read this bucket.
             org:
               $ref: '#/components/schemas/Link'
-              description: URL to retrieve parent organization for this bucket
+              description: URL to retrieve parent organization for this bucket.
             owners:
               $ref: '#/components/schemas/Link'
               description: URL to retrieve owners that can read and write to this
                 bucket.
             self:
               $ref: '#/components/schemas/Link'
-              description: URL for this bucket
+              description: URL for this bucket.
             write:
               $ref: '#/components/schemas/Link'
-              description: URL to write line protocol for this bucket
+              description: URL to write line protocol to this bucket.
           readOnly: true
           type: object
         name:
@@ -591,10 +591,10 @@ components:
           readOnly: true
           type: string
         latestCompleted:
-          description: Timestamp of latest scheduled, completed run, RFC3339.
+          description: Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339))
+            of the latest scheduled and completed run.
           format: date-time
           readOnly: true
-          type: string
         links:
           example:
             labels: /api/v2/checks/1/labels
@@ -820,23 +820,23 @@ components:
     DBRP:
       properties:
         bucketID:
-          description: the bucket ID used as target for the translation.
+          description: ID of the bucket used as the target for the translation.
           type: string
         database:
           description: InfluxDB v1 database
           type: string
         default:
-          description: Specify if this mapping represents the default retention policy
-            for the database specificed.
+          description: Mapping represents the default retention policy for the database
+            specified.
           type: boolean
         id:
-          description: the mapping identifier
+          description: ID of the DBRP mapping.
           readOnly: true
           type: string
         links:
           $ref: '#/components/schemas/Links'
         orgID:
-          description: the organization ID that owns this mapping.
+          description: ID of the organization that owns this mapping.
           type: string
         retention_policy:
           description: InfluxDB v1 retention policy
@@ -852,20 +852,20 @@ components:
     DBRPCreate:
       properties:
         bucketID:
-          description: the bucket ID used as target for the translation.
+          description: ID of the bucket used as the target for the translation.
           type: string
         database:
           description: InfluxDB v1 database
           type: string
         default:
-          description: Specify if this mapping represents the default retention policy
-            for the database specificed.
+          description: Mapping represents the default retention policy for the database
+            specified.
           type: boolean
         org:
-          description: the organization that owns this mapping.
+          description: Name of the organization that owns this mapping.
           type: string
         orgID:
-          description: the organization ID that owns this mapping.
+          description: ID of the organization that owns this mapping.
           type: string
         retention_policy:
           description: InfluxDB v1 retention policy
@@ -1223,22 +1223,21 @@ components:
           readOnly: true
           type: string
         err:
-          description: err is a stack of errors that occurred during processing of
-            the request. Useful for debugging.
+          description: Stack of errors that occurred during processing of the request.
+            Useful for debugging.
           readOnly: true
           type: string
         message:
-          description: message is a human-readable message.
+          description: Human-readable message.
           readOnly: true
           type: string
         op:
-          description: op describes the logical code operation during error. Useful
-            for debugging.
+          description: Describes the logical code operation when the error occurred.
+            Useful for debugging.
           readOnly: true
           type: string
       required:
       - code
-      - message
     Expression:
       oneOf:
       - $ref: '#/components/schemas/ArrayExpression'
@@ -2273,29 +2272,26 @@ components:
           readOnly: true
           type: string
         err:
-          description: Err is a stack of errors that occurred during processing of
-            the request. Useful for debugging.
+          description: Stack of errors that occurred during processing of the request.
+            Useful for debugging.
           readOnly: true
           type: string
         line:
-          description: First line within sent body containing malformed data
+          description: First line in the request body that contains malformed data.
           format: int32
           readOnly: true
           type: integer
         message:
-          description: Message is a human-readable message.
+          description: Human-readable message.
           readOnly: true
           type: string
         op:
-          description: Op describes the logical code operation during error. Useful
-            for debugging.
+          description: Describes the logical code operation when the error occurred.
+            Useful for debugging.
           readOnly: true
           type: string
       required:
       - code
-      - message
-      - op
-      - err
     LineProtocolLengthError:
       properties:
         code:
@@ -2305,7 +2301,7 @@ components:
           readOnly: true
           type: string
         message:
-          description: Message is a human-readable message.
+          description: Human-readable message.
           readOnly: true
           type: string
       required:
@@ -2393,12 +2389,13 @@ components:
       - note
       type: object
     MeasurementSchema:
-      description: The schema definition for a single measurement
+      description: Definition of a measurement schema.
       example:
         bucketID: ba3c5e7f9b0a0010
         columns:
-        - name: time
-          type: timestamp
+        - format: unix timestamp
+          name: time
+          type: integer
         - name: host
           type: tag
         - name: region
@@ -2420,7 +2417,7 @@ components:
             with.
           type: string
         columns:
-          description: An ordered collection of column definitions
+          description: Ordered collection of column definitions.
           items:
             $ref: '#/components/schemas/MeasurementSchemaColumn'
           type: array
@@ -2435,7 +2432,7 @@ components:
           nullable: false
           type: string
         orgID:
-          description: ID of organization that the measurement schema is associated
+          description: ID of the organization that the measurement schema is associated
             with.
           type: string
         updatedAt:
@@ -2450,10 +2447,11 @@ components:
       - updatedAt
       type: object
     MeasurementSchemaColumn:
-      description: Definition of a measurement column
+      description: Definition of a measurement schema column.
       example:
+        format: unix timestamp
         name: time
-        type: timestamp
+        type: integer
       properties:
         dataType:
           $ref: '#/components/schemas/ColumnDataType'
@@ -2466,11 +2464,12 @@ components:
       - type
       type: object
     MeasurementSchemaCreateRequest:
-      description: Create a new measurement schema
+      description: Create a new measurement schema.
       example:
         columns:
-        - name: time
-          type: timestamp
+        - format: unix timestamp
+          name: time
+          type: integer
         - name: host
           type: tag
         - name: region
@@ -2484,7 +2483,7 @@ components:
         name: cpu
       properties:
         columns:
-          description: An ordered collection of column definitions
+          description: Ordered collection of column definitions.
           items:
             $ref: '#/components/schemas/MeasurementSchemaColumn'
           type: array
@@ -2528,8 +2527,9 @@ components:
       description: Update an existing measurement schema
       example:
         columns:
-        - name: time
-          type: timestamp
+        - format: unix timestamp
+          name: time
+          type: integer
         - name: host
           type: tag
         - name: region
@@ -2820,7 +2820,8 @@ components:
           readOnly: true
           type: string
         latestCompleted:
-          description: Timestamp of latest scheduled, completed run, RFC3339.
+          description: Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339))
+            of the latest scheduled and completed run.
           format: date-time
           readOnly: true
           type: string
@@ -4197,25 +4198,29 @@ components:
     Task:
       properties:
         authorizationID:
-          description: The ID of the authorization used when this task communicates
-            with the query engine.
+          description: ID of the authorization used when the task communicates with
+            the query engine.
           type: string
         createdAt:
           format: date-time
           readOnly: true
           type: string
         cron:
-          description: A task repetition schedule in the form '* * * * * *'; parsed
-            from Flux.
+          description: |-
+            [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview) that defines the schedule on which the task runs. Cron scheduling is based on system time.
+            Value is a [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview).
           type: string
         description:
-          description: An optional description of the task.
+          description: Description of the task.
           type: string
         every:
-          description: A simple task repetition schedule; parsed from Flux.
+          description: |-
+            Interval at which the task runs. `every` also determines when the task first runs, depending on the specified time.
+            Value is a [duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals)).
+          format: duration
           type: string
         flux:
-          description: The Flux script to run for this task.
+          description: Flux script to run for this task.
           type: string
         id:
           readOnly: true
@@ -4233,7 +4238,9 @@ components:
           readOnly: true
           type: string
         latestCompleted:
-          description: Timestamp of latest scheduled, completed run, RFC3339.
+          description: |-
+            Timestamp of the latest scheduled and completed run.
+            Value is a timestamp in [RFC3339 date/time format](https://docs.influxdata.com/flux/v0.x/data-types/basic/time/#time-syntax).
           format: date-time
           readOnly: true
           type: string
@@ -4261,27 +4268,27 @@ components:
           readOnly: true
           type: object
         name:
-          description: The name of the task.
+          description: Name of the task.
           type: string
         offset:
-          description: Duration to delay after the schedule, before executing the
-            task; parsed from flux, if set to zero it will remove this option and
-            use 0 as the default.
+          description: |-
+            [Duration](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals) to delay execution of the task after the scheduled time has elapsed. `0` removes the offset.
+            The value is a [duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals).
+          format: duration
           type: string
         org:
-          description: The name of the organization that owns this Task.
+          description: Name of the organization that owns the task.
           type: string
         orgID:
-          description: The ID of the organization that owns this Task.
+          description: ID of the organization that owns the task.
           type: string
         ownerID:
-          description: The ID of the user who owns this Task.
+          description: ID of the user who owns this Task.
           type: string
         status:
           $ref: '#/components/schemas/TaskStatusType'
         type:
-          description: The type of task, this can be used for filtering tasks on list
-            actions.
+          description: Type of the task, useful for filtering a task list.
           type: string
         updatedAt:
           format: date-time
@@ -5839,7 +5846,7 @@ info:
   title: Complete InfluxDB Cloud API
 openapi: 3.0.0
 paths:
-  /api/v2/:
+  /api/v2:
     get:
       operationId: GetRoutes
       parameters:
@@ -8191,13 +8198,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Token'
-          description: A temp token for Mapbox
+          description: Temporary token for Mapbox.
         "401":
           $ref: '#/components/responses/ServerError'
         "500":
           $ref: '#/components/responses/ServerError'
         default:
           $ref: '#/components/responses/ServerError'
+      summary: Get a mapbox token
   /api/v2/me:
     get:
       operationId: GetMe
@@ -9020,8 +9028,9 @@ paths:
       - Organizations
   /api/v2/orgs/{orgID}/limits:
     get:
+      operationId: GetOrgLimitsID
       parameters:
-      - description: The identifier of the organization.
+      - description: ID of the organization.
         in: path
         name: orgID
         required: true
@@ -9040,7 +9049,7 @@ paths:
                   links:
                     $ref: '#/components/schemas/Links'
                 type: object
-          description: The Limits defined for the organization.
+          description: Limits defined for the organization.
         default:
           $ref: '#/components/responses/ServerError'
           description: unexpected error
@@ -9352,25 +9361,32 @@ paths:
       - Secrets
   /api/v2/orgs/{orgID}/usage:
     get:
+      operationId: GetOrgUsageID
       parameters:
-      - description: The identifier of the organization.
+      - description: ID of the organization.
         in: path
         name: orgID
         required: true
         schema:
           type: string
-      - description: start time
+      - description: |
+          Earliest time to include in results.
+          For more information about timestamps, see [Manipulate timestamps with Flux](https://docs.influxdata.com/influxdb/cloud/query-data/flux/manipulate-timestamps/).
         in: query
         name: start
         required: true
         schema:
-          type: timestamp
-      - description: stop time
+          format: unix timestamp
+          type: integer
+      - description: |
+          Latest time to include in results.
+          For more information about timestamps, see [Manipulate timestamps with Flux](https://docs.influxdata.com/influxdb/cloud/query-data/flux/manipulate-timestamps/).
         in: query
         name: stop
         required: false
         schema:
-          type: timestamp
+          format: unix timestamp
+          type: integer
       - description: return raw usage data
         in: query
         name: raw

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -2,7 +2,7 @@ components:
   parameters:
     After:
       description: |
-        The last resource ID from which to seek from (but not including). This is to be used instead of `offset`.
+        Resource ID to seek from. Results are not inclusive of this ID. Use `after` instead of `offset`.
       in: query
       name: after
       required: false
@@ -124,22 +124,21 @@ components:
             readOnly: true
             type: object
           org:
-            description: Name of the org token is scoped to.
+            description: Name of the organization that the token is scoped to.
             readOnly: true
             type: string
           orgID:
-            description: ID of org that authorization is scoped to.
+            description: ID of the organization that the authorization is scoped to.
             type: string
           permissions:
-            description: List of permissions for an auth.  An auth must have at least
-              one Permission.
+            description: List of permissions for an authorization.  An authorization
+              must have at least one permission.
             items:
               $ref: '#/components/schemas/Permission'
             minItems: 1
             type: array
           token:
-            description: Passed via the Authorization Header and Token Authentication
-              type.
+            description: Token used to authenticate API requests.
             readOnly: true
             type: string
           updatedAt:
@@ -147,11 +146,11 @@ components:
             readOnly: true
             type: string
           user:
-            description: Name of user that created and owns the token.
+            description: Name of the user that created and owns the token.
             readOnly: true
             type: string
           userID:
-            description: ID of user that created and owns the token.
+            description: ID of the user that created and owns the token.
             readOnly: true
             type: string
         type: object
@@ -186,7 +185,7 @@ components:
           type: string
         status:
           default: active
-          description: If inactive the token is inactive and requests using the token
+          description: Status of the token. If `inactive`, requests using the token
             will be rejected.
           enum:
           - active
@@ -214,33 +213,33 @@ components:
       - "y"
       type: object
     Axis:
-      description: The description of a particular axis for a visualization.
+      description: Axis used in a visualization.
       properties:
         base:
-          description: Base represents the radix for formatting axis values.
+          description: Radix for formatting axis values.
           enum:
           - ""
           - "2"
           - "10"
           type: string
         bounds:
-          description: The extents of an axis in the form [lower, upper]. Clients
-            determine whether bounds are to be inclusive or exclusive of their limits
+          description: The extents of the axis in the form [lower, upper]. Clients
+            determine whether bounds are inclusive or exclusive of their limits.
           items:
             type: string
           maxItems: 2
           minItems: 0
           type: array
         label:
-          description: Label is a description of this Axis
+          description: Description of the axis.
           type: string
         prefix:
-          description: Prefix represents a label prefix for formatting axis values.
+          description: Label prefix for formatting axis values.
           type: string
         scale:
           $ref: '#/components/schemas/AxisScale'
         suffix:
-          description: Suffix represents a label suffix for formatting axis values.
+          description: Label suffix for formatting axis values.
           type: string
       type: object
     AxisScale:
@@ -406,23 +405,23 @@ components:
           properties:
             labels:
               $ref: '#/components/schemas/Link'
-              description: URL to retrieve labels for this bucket
+              description: URL to retrieve labels for this bucket.
             members:
               $ref: '#/components/schemas/Link'
-              description: URL to retrieve members that can read this bucket
+              description: URL to retrieve members that can read this bucket.
             org:
               $ref: '#/components/schemas/Link'
-              description: URL to retrieve parent organization for this bucket
+              description: URL to retrieve parent organization for this bucket.
             owners:
               $ref: '#/components/schemas/Link'
               description: URL to retrieve owners that can read and write to this
                 bucket.
             self:
               $ref: '#/components/schemas/Link'
-              description: URL for this bucket
+              description: URL for this bucket.
             write:
               $ref: '#/components/schemas/Link'
-              description: URL to write line protocol for this bucket
+              description: URL to write line protocol to this bucket.
           readOnly: true
           type: object
         name:
@@ -656,10 +655,10 @@ components:
           readOnly: true
           type: string
         latestCompleted:
-          description: Timestamp of latest scheduled, completed run, RFC3339.
+          description: Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339))
+            of the latest scheduled and completed run.
           format: date-time
           readOnly: true
-          type: string
         links:
           example:
             labels: /api/v2/checks/1/labels
@@ -875,23 +874,23 @@ components:
     DBRP:
       properties:
         bucketID:
-          description: the bucket ID used as target for the translation.
+          description: ID of the bucket used as the target for the translation.
           type: string
         database:
           description: InfluxDB v1 database
           type: string
         default:
-          description: Specify if this mapping represents the default retention policy
-            for the database specificed.
+          description: Mapping represents the default retention policy for the database
+            specified.
           type: boolean
         id:
-          description: the mapping identifier
+          description: ID of the DBRP mapping.
           readOnly: true
           type: string
         links:
           $ref: '#/components/schemas/Links'
         orgID:
-          description: the organization ID that owns this mapping.
+          description: ID of the organization that owns this mapping.
           type: string
         retention_policy:
           description: InfluxDB v1 retention policy
@@ -907,20 +906,20 @@ components:
     DBRPCreate:
       properties:
         bucketID:
-          description: the bucket ID used as target for the translation.
+          description: ID of the bucket used as the target for the translation.
           type: string
         database:
           description: InfluxDB v1 database
           type: string
         default:
-          description: Specify if this mapping represents the default retention policy
-            for the database specificed.
+          description: Mapping represents the default retention policy for the database
+            specified.
           type: boolean
         org:
-          description: the organization that owns this mapping.
+          description: Name of the organization that owns this mapping.
           type: string
         orgID:
-          description: the organization ID that owns this mapping.
+          description: ID of the organization that owns this mapping.
           type: string
         retention_policy:
           description: InfluxDB v1 retention policy
@@ -1278,22 +1277,21 @@ components:
           readOnly: true
           type: string
         err:
-          description: err is a stack of errors that occurred during processing of
-            the request. Useful for debugging.
+          description: Stack of errors that occurred during processing of the request.
+            Useful for debugging.
           readOnly: true
           type: string
         message:
-          description: message is a human-readable message.
+          description: Human-readable message.
           readOnly: true
           type: string
         op:
-          description: op describes the logical code operation during error. Useful
-            for debugging.
+          description: Describes the logical code operation when the error occurred.
+            Useful for debugging.
           readOnly: true
           type: string
       required:
       - code
-      - message
     Expression:
       oneOf:
       - $ref: '#/components/schemas/ArrayExpression'
@@ -2249,29 +2247,26 @@ components:
           readOnly: true
           type: string
         err:
-          description: Err is a stack of errors that occurred during processing of
-            the request. Useful for debugging.
+          description: Stack of errors that occurred during processing of the request.
+            Useful for debugging.
           readOnly: true
           type: string
         line:
-          description: First line within sent body containing malformed data
+          description: First line in the request body that contains malformed data.
           format: int32
           readOnly: true
           type: integer
         message:
-          description: Message is a human-readable message.
+          description: Human-readable message.
           readOnly: true
           type: string
         op:
-          description: Op describes the logical code operation during error. Useful
-            for debugging.
+          description: Describes the logical code operation when the error occurred.
+            Useful for debugging.
           readOnly: true
           type: string
       required:
       - code
-      - message
-      - op
-      - err
     LineProtocolLengthError:
       properties:
         code:
@@ -2281,7 +2276,7 @@ components:
           readOnly: true
           type: string
         message:
-          description: Message is a human-readable message.
+          description: Human-readable message.
           readOnly: true
           type: string
       required:
@@ -2654,7 +2649,8 @@ components:
           readOnly: true
           type: string
         latestCompleted:
-          description: Timestamp of latest scheduled, completed run, RFC3339.
+          description: Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339))
+            of the latest scheduled and completed run.
           format: date-time
           readOnly: true
           type: string
@@ -4377,25 +4373,29 @@ components:
     Task:
       properties:
         authorizationID:
-          description: The ID of the authorization used when this task communicates
-            with the query engine.
+          description: ID of the authorization used when the task communicates with
+            the query engine.
           type: string
         createdAt:
           format: date-time
           readOnly: true
           type: string
         cron:
-          description: A task repetition schedule in the form '* * * * * *'; parsed
-            from Flux.
+          description: |-
+            [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview) that defines the schedule on which the task runs. Cron scheduling is based on system time.
+            Value is a [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview).
           type: string
         description:
-          description: An optional description of the task.
+          description: Description of the task.
           type: string
         every:
-          description: A simple task repetition schedule; parsed from Flux.
+          description: |-
+            Interval at which the task runs. `every` also determines when the task first runs, depending on the specified time.
+            Value is a [duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals)).
+          format: duration
           type: string
         flux:
-          description: The Flux script to run for this task.
+          description: Flux script to run for this task.
           type: string
         id:
           readOnly: true
@@ -4413,7 +4413,9 @@ components:
           readOnly: true
           type: string
         latestCompleted:
-          description: Timestamp of latest scheduled, completed run, RFC3339.
+          description: |-
+            Timestamp of the latest scheduled and completed run.
+            Value is a timestamp in [RFC3339 date/time format](https://docs.influxdata.com/flux/v0.x/data-types/basic/time/#time-syntax).
           format: date-time
           readOnly: true
           type: string
@@ -4441,27 +4443,27 @@ components:
           readOnly: true
           type: object
         name:
-          description: The name of the task.
+          description: Name of the task.
           type: string
         offset:
-          description: Duration to delay after the schedule, before executing the
-            task; parsed from flux, if set to zero it will remove this option and
-            use 0 as the default.
+          description: |-
+            [Duration](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals) to delay execution of the task after the scheduled time has elapsed. `0` removes the offset.
+            The value is a [duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals).
+          format: duration
           type: string
         org:
-          description: The name of the organization that owns this Task.
+          description: Name of the organization that owns the task.
           type: string
         orgID:
-          description: The ID of the organization that owns this Task.
+          description: ID of the organization that owns the task.
           type: string
         ownerID:
-          description: The ID of the user who owns this Task.
+          description: ID of the user who owns this Task.
           type: string
         status:
           $ref: '#/components/schemas/TaskStatusType'
         type:
-          description: The type of task, this can be used for filtering tasks on list
-            actions.
+          description: Type of the task, useful for filtering a task list.
           type: string
         updatedAt:
           format: date-time
@@ -6001,7 +6003,7 @@ info:
   title: Complete InfluxDB OSS API
 openapi: 3.0.0
 paths:
-  /api/v2/:
+  /api/v2:
     get:
       operationId: GetRoutes
       parameters:
@@ -8474,13 +8476,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Token'
-          description: A temp token for Mapbox
+          description: Temporary token for Mapbox.
         "401":
           $ref: '#/components/responses/ServerError'
         "500":
           $ref: '#/components/responses/ServerError'
         default:
           $ref: '#/components/responses/ServerError'
+      summary: Get a mapbox token
   /api/v2/me:
     get:
       operationId: GetMe
@@ -8553,7 +8556,8 @@ paths:
                 externalDocs:
                   description: Prometheus exposition formats
                   url: https://prometheus.io/docs/instrumenting/exposition_formats
-                type: Prometheus text-based exposition
+                format: Prometheus text-based exposition
+                type: string
           description: |
             Payload body contains metrics about the InfluxDB instance.
 

--- a/contracts/svc/annotationd-oss.yml
+++ b/contracts/svc/annotationd-oss.yml
@@ -498,19 +498,18 @@ components:
             - unsupported media type
         message:
           readOnly: true
-          description: message is a human-readable message.
+          description: Human-readable message.
           type: string
         op:
           readOnly: true
-          description: op describes the logical code operation during error. Useful for debugging.
+          description: Describes the logical code operation when the error occurred. Useful for debugging.
           type: string
         err:
           readOnly: true
-          description: err is a stack of errors that occurred during processing of the request. Useful for debugging.
+          description: Stack of errors that occurred during processing of the request. Useful for debugging.
           type: string
       required:
         - code
-        - message
   responses:
     NoContent:
       description: No content

--- a/contracts/svc/annotationd.yml
+++ b/contracts/svc/annotationd.yml
@@ -474,19 +474,18 @@ components:
             - unsupported media type
         message:
           readOnly: true
-          description: message is a human-readable message.
+          description: Human-readable message.
           type: string
         op:
           readOnly: true
-          description: op describes the logical code operation during error. Useful for debugging.
+          description: Describes the logical code operation when the error occurred. Useful for debugging.
           type: string
         err:
           readOnly: true
-          description: err is a stack of errors that occurred during processing of the request. Useful for debugging.
+          description: Stack of errors that occurred during processing of the request. Useful for debugging.
           type: string
       required:
         - code
-        - message
   responses:
     NoContent:
       description: No content

--- a/contracts/svc/fluxdocsd.yml
+++ b/contracts/svc/fluxdocsd.yml
@@ -206,19 +206,18 @@ components:
             - unsupported media type
         message:
           readOnly: true
-          description: message is a human-readable message.
+          description: Human-readable message.
           type: string
         op:
           readOnly: true
-          description: op describes the logical code operation during error. Useful for debugging.
+          description: Describes the logical code operation when the error occurred. Useful for debugging.
           type: string
         err:
           readOnly: true
-          description: err is a stack of errors that occurred during processing of the request. Useful for debugging.
+          description: Stack of errors that occurred during processing of the request. Useful for debugging.
           type: string
       required:
         - code
-        - message
   responses:
     NoContent:
       description: No content

--- a/contracts/svc/invocable-scripts.yml
+++ b/contracts/svc/invocable-scripts.yml
@@ -200,19 +200,18 @@ components:
             - unsupported media type
         message:
           readOnly: true
-          description: message is a human-readable message.
+          description: Human-readable message.
           type: string
         op:
           readOnly: true
-          description: op describes the logical code operation during error. Useful for debugging.
+          description: Describes the logical code operation when the error occurred. Useful for debugging.
           type: string
         err:
           readOnly: true
-          description: err is a stack of errors that occurred during processing of the request. Useful for debugging.
+          description: Stack of errors that occurred during processing of the request. Useful for debugging.
           type: string
       required:
         - code
-        - message
     Script:
       properties:
         id:

--- a/contracts/svc/mapsd.yml
+++ b/contracts/svc/mapsd.yml
@@ -7,10 +7,11 @@ servers:
 paths:
   /mapToken:
     get:
+      summary: Get a mapbox token
       operationId: getMapboxToken
       responses:
         '200':
-          description: A temp token for Mapbox
+          description: Temporary token for Mapbox.
           content:
             application/json:
               schema:
@@ -50,19 +51,18 @@ components:
             - unsupported media type
         message:
           readOnly: true
-          description: message is a human-readable message.
+          description: Human-readable message.
           type: string
         op:
           readOnly: true
-          description: op describes the logical code operation during error. Useful for debugging.
+          description: Describes the logical code operation when the error occurred. Useful for debugging.
           type: string
         err:
           readOnly: true
-          description: err is a stack of errors that occurred during processing of the request. Useful for debugging.
+          description: Stack of errors that occurred during processing of the request. Useful for debugging.
           type: string
       required:
         - code
-        - message
   responses:
     ServerError:
       description: Non 2XX error response from server.

--- a/contracts/svc/nifid.yml
+++ b/contracts/svc/nifid.yml
@@ -390,19 +390,18 @@ components:
             - unsupported media type
         message:
           readOnly: true
-          description: message is a human-readable message.
+          description: Human-readable message.
           type: string
         op:
           readOnly: true
-          description: op describes the logical code operation during error. Useful for debugging.
+          description: Describes the logical code operation when the error occurred. Useful for debugging.
           type: string
         err:
           readOnly: true
-          description: err is a stack of errors that occurred during processing of the request. Useful for debugging.
+          description: Stack of errors that occurred during processing of the request. Useful for debugging.
           type: string
       required:
         - code
-        - message
   responses:
     NoContent:
       description: No content

--- a/contracts/svc/notebooksd.yml
+++ b/contracts/svc/notebooksd.yml
@@ -406,19 +406,18 @@ components:
             - unsupported media type
         message:
           readOnly: true
-          description: message is a human-readable message.
+          description: Human-readable message.
           type: string
         op:
           readOnly: true
-          description: op describes the logical code operation during error. Useful for debugging.
+          description: Describes the logical code operation when the error occurred. Useful for debugging.
           type: string
         err:
           readOnly: true
-          description: err is a stack of errors that occurred during processing of the request. Useful for debugging.
+          description: Stack of errors that occurred during processing of the request. Useful for debugging.
           type: string
       required:
         - code
-        - message
   responses:
     NoContent:
       description: No content

--- a/contracts/svc/pinneditemsd.yml
+++ b/contracts/svc/pinneditemsd.yml
@@ -148,19 +148,18 @@ components:
             - unsupported media type
         message:
           readOnly: true
-          description: message is a human-readable message.
+          description: Human-readable message.
           type: string
         op:
           readOnly: true
-          description: op describes the logical code operation during error. Useful for debugging.
+          description: Describes the logical code operation when the error occurred. Useful for debugging.
           type: string
         err:
           readOnly: true
-          description: err is a stack of errors that occurred during processing of the request. Useful for debugging.
+          description: Stack of errors that occurred during processing of the request. Useful for debugging.
           type: string
       required:
         - code
-        - message
   responses:
     NoContent:
       description: No content

--- a/contracts/swaggerV1Compat.yml
+++ b/contracts/swaggerV1Compat.yml
@@ -37,7 +37,7 @@ paths:
           schema:
             type: string
           required: true
-          description: Bucket to write to. If none exists, a bucket will be created with a default 3-day retention policy.
+          description: Bucket to write to. If none exists, InfluxDB creates a bucket with a default 3-day retention policy.
         - in: query
           name: rp
           schema:

--- a/scripts/reference.sh
+++ b/scripts/reference.sh
@@ -12,6 +12,7 @@ swagrag \
   -file ${CONTRACTS}/invocable-scripts.yml \
   -api-title "Complete InfluxDB Cloud API" \
   | sed -e 's|^  /api/v2/ping|  /ping|' \
+  | sed -e 's|^  /api/v2/:|  /api/v2:|' \
   > ${TCONTRACTS}/ref/cloud.yml
 
 echo "Aggregating oss swaggers"
@@ -24,6 +25,7 @@ swagrag \
   | sed -e 's|^  /api/v2/metrics|  /metrics|' \
   | sed -e 's|^  /api/v2/ping|  /ping|' \
   | sed -e 's|^  /api/v2/ready|  /ready|' \
+  | sed -e 's|^  /api/v2/:|  /api/v2:|' \
   > ${TCONTRACTS}/ref/oss.yml
 
 diff -r ${CONTRACTS}/ref ${TCONTRACTS}/ref/

--- a/src/cloud/paths/orgs_orgID_limits_get.yml
+++ b/src/cloud/paths/orgs_orgID_limits_get.yml
@@ -2,16 +2,17 @@ get:
   tags:
     - Limits
   summary: Retrieve limits for an organization
+  operationId: GetOrgLimitsID
   parameters:
     - in: path
       name: orgID
-      description: The identifier of the organization.
+      description: ID of the organization.
       required: true
       schema:
         type: string
   responses:
     '200':
-      description: The Limits defined for the organization.
+      description: Limits defined for the organization.
       content:
         application/json:
           schema:

--- a/src/cloud/paths/orgs_orgID_usage.yml
+++ b/src/cloud/paths/orgs_orgID_usage.yml
@@ -2,25 +2,34 @@ get:
   tags:
     - Usage
   summary: Retrieve usage for an organization
+  operationId: GetOrgUsageID
   parameters:
     - in: path
       name: orgID
-      description: The identifier of the organization.
+      description: ID of the organization.
       required: true
       schema:
         type: string
     - in: query
       name: start
-      description: start time
+      description: >
+        Earliest time to include in results.
+
+        For more information about timestamps, see [Manipulate timestamps with Flux]({{% INFLUX_DOCS_URL}}/influxdb/cloud/query-data/flux/manipulate-timestamps/).
       required: true
       schema:
-        type: timestamp
+        type: integer
+        format: unix timestamp
     - in: query
       name: stop
-      description: stop time
+      description: >
+        Latest time to include in results.
+
+        For more information about timestamps, see [Manipulate timestamps with Flux]({{% INFLUX_DOCS_URL}}/influxdb/cloud/query-data/flux/manipulate-timestamps/).
       required: false
       schema:
-        type: timestamp
+        type: integer
+        format: unix timestamp
     - in: query
       name: raw
       description: return raw usage data

--- a/src/cloud/paths/orgs_orgID_usage.yml
+++ b/src/cloud/paths/orgs_orgID_usage.yml
@@ -15,7 +15,7 @@ get:
       description: >
         Earliest time to include in results.
 
-        For more information about timestamps, see [Manipulate timestamps with Flux]({{% INFLUX_DOCS_URL}}/influxdb/cloud/query-data/flux/manipulate-timestamps/).
+        For more information about timestamps, see [Manipulate timestamps with Flux]({{% INFLUXDB_DOCS_URL %}}/query-data/flux/manipulate-timestamps/).
       required: true
       schema:
         type: integer
@@ -25,7 +25,7 @@ get:
       description: >
         Latest time to include in results.
 
-        For more information about timestamps, see [Manipulate timestamps with Flux]({{% INFLUX_DOCS_URL}}/influxdb/cloud/query-data/flux/manipulate-timestamps/).
+        For more information about timestamps, see [Manipulate timestamps with Flux]({{% INFLUXDB_DOCS_URL %}}/query-data/flux/manipulate-timestamps/).
       required: false
       schema:
         type: integer

--- a/src/cloud/schemas/MeasurementSchema.yml
+++ b/src/cloud/schemas/MeasurementSchema.yml
@@ -1,4 +1,4 @@
-  description: The schema definition for a single measurement
+  description: Definition of a measurement schema.
   type: object
   example:
     id: 1a3c5e7f9b0a8642
@@ -7,7 +7,8 @@
     name: cpu
     columns:
       - name: time
-        type: timestamp
+        type: integer
+        format: unix timestamp
       - name: host
         type: tag
       - name: region
@@ -20,14 +21,19 @@
         dataType: float
     createdAt: "2021-01-21T00:48:40.993Z"
     updatedAt: "2021-01-21T00:48:40.993Z"
-  required: [ "id", "name", "columns", "createdAt", "updatedAt" ]
+  required:
+    - id
+    - name
+    - columns
+    - createdAt
+    - updatedAt
   properties:
     id:
       type: string
       readOnly: true
     orgID:
       type: string
-      description: ID of organization that the measurement schema is associated with.
+      description: ID of the organization that the measurement schema is associated with.
     bucketID:
       type: string
       description: ID of the bucket that the measurement schema is associated with.
@@ -36,7 +42,7 @@
       nullable: false
     columns:
       description: >-
-        An ordered collection of column definitions
+        Ordered collection of column definitions.
       type: array
       items:
         $ref: './MeasurementSchemaColumn.yml'

--- a/src/cloud/schemas/MeasurementSchemaColumn.yml
+++ b/src/cloud/schemas/MeasurementSchemaColumn.yml
@@ -1,9 +1,12 @@
-  description: Definition of a measurement column
+  description: Definition of a measurement schema column.
   example:
     name: time
-    type: timestamp
+    type: integer
+    format: unix timestamp
   type: object
-  required: ["name", "type"]
+  required:
+    - name
+    - type
   properties:
     name:
       type: string

--- a/src/cloud/schemas/MeasurementSchemaCreateRequest.yml
+++ b/src/cloud/schemas/MeasurementSchemaCreateRequest.yml
@@ -1,10 +1,11 @@
-  description: Create a new measurement schema
+  description: Create a new measurement schema.
   type: object
   example:
     name: cpu
     columns:
       - name: time
-        type: timestamp
+        type: integer
+        format: unix timestamp
       - name: host
         type: tag
       - name: region
@@ -15,13 +16,15 @@
       - name: usage_user
         type: field
         dataType: float
-  required: ["name", "columns"]
+  required:
+    - name
+    - columns
   properties:
     name:
       type: string
     columns:
       description: >-
-        An ordered collection of column definitions
+        Ordered collection of column definitions.
       type: array
       items:
         $ref: './MeasurementSchemaColumn.yml'

--- a/src/cloud/schemas/MeasurementSchemaUpdateRequest.yml
+++ b/src/cloud/schemas/MeasurementSchemaUpdateRequest.yml
@@ -3,7 +3,8 @@
   example:
     columns:
       - name: time
-        type: timestamp
+        type: integer
+        format: unix timestamp
       - name: host
         type: tag
       - name: region

--- a/src/common/parameters/After.yml
+++ b/src/common/parameters/After.yml
@@ -4,5 +4,5 @@ required: false
 schema:
   type: string
 description: >
-  The last resource ID from which to seek from (but not including).
-  This is to be used instead of `offset`.
+  Resource ID to seek from. Results are not inclusive of this ID.
+  Use `after` instead of `offset`.

--- a/src/common/schemas/Authorization.yml
+++ b/src/common/schemas/Authorization.yml
@@ -13,11 +13,11 @@
           readOnly: true
         orgID:
           type: string
-          description: ID of org that authorization is scoped to.
+          description: ID of the organization that the authorization is scoped to.
         permissions:
           type: array
           minItems: 1
-          description: List of permissions for an auth.  An auth must have at least one Permission.
+          description: List of permissions for an authorization.  An authorization must have at least one permission.
           items:
             $ref: "./Permission.yml"
         id:
@@ -26,19 +26,19 @@
         token:
           readOnly: true
           type: string
-          description: Passed via the Authorization Header and Token Authentication type.
+          description: Token used to authenticate API requests.
         userID:
           readOnly: true
           type: string
-          description: ID of user that created and owns the token.
+          description: ID of the user that created and owns the token.
         user:
           readOnly: true
           type: string
-          description: Name of user that created and owns the token.
+          description: Name of the user that created and owns the token.
         org:
           readOnly: true
           type: string
-          description: Name of the org token is scoped to.
+          description: Name of the organization that the token is scoped to.
         links:
           type: object
           readOnly: true

--- a/src/common/schemas/AuthorizationUpdateRequest.yml
+++ b/src/common/schemas/AuthorizationUpdateRequest.yml
@@ -1,6 +1,6 @@
   properties:
     status:
-      description: If inactive the token is inactive and requests using the token will be rejected.
+      description: Status of the token. If `inactive`, requests using the token will be rejected.
       default: active
       type: string
       enum:

--- a/src/common/schemas/Axis.yml
+++ b/src/common/schemas/Axis.yml
@@ -1,26 +1,26 @@
   type: object
-  description: The description of a particular axis for a visualization.
+  description: Axis used in a visualization.
   properties:
     bounds:
       type: array
       minItems: 0
       maxItems: 2
       description: >-
-        The extents of an axis in the form [lower, upper]. Clients determine
-        whether bounds are to be inclusive or exclusive of their limits
+        The extents of the axis in the form [lower, upper]. Clients determine
+        whether bounds are inclusive or exclusive of their limits.
       items:
         type: string
     label:
-      description: Label is a description of this Axis
+      description: Description of the axis.
       type: string
     prefix:
-      description: Prefix represents a label prefix for formatting axis values.
+      description: Label prefix for formatting axis values.
       type: string
     suffix:
-      description: Suffix represents a label suffix for formatting axis values.
+      description: Label suffix for formatting axis values.
       type: string
     base:
-      description: Base represents the radix for formatting axis values.
+      description: Radix for formatting axis values.
       type: string
       enum: ["", "2", "10"]
     scale:

--- a/src/common/schemas/Bucket.yml
+++ b/src/common/schemas/Bucket.yml
@@ -11,22 +11,22 @@
         write: "/api/v2/write?org=2&bucket=1"
       properties:
         labels:
-          description: URL to retrieve labels for this bucket
+          description: URL to retrieve labels for this bucket.
           $ref: "./Link.yml"
         members:
-          description: URL to retrieve members that can read this bucket
+          description: URL to retrieve members that can read this bucket.
           $ref: "./Link.yml"
         org:
-          description: URL to retrieve parent organization for this bucket
+          description: URL to retrieve parent organization for this bucket.
           $ref: "./Link.yml"
         owners:
           description: URL to retrieve owners that can read and write to this bucket.
           $ref: "./Link.yml"
         self:
-          description: URL for this bucket
+          description: URL for this bucket.
           $ref: "./Link.yml"
         write:
-          description: URL to write line protocol for this bucket
+          description: URL to write line protocol to this bucket.
           $ref: "./Link.yml"
     id:
       readOnly: true

--- a/src/common/schemas/CheckBase.yml
+++ b/src/common/schemas/CheckBase.yml
@@ -30,8 +30,7 @@
       description: An optional description of the check.
       type: string
     latestCompleted:
-      description: Timestamp of latest scheduled, completed run, RFC3339.
-      type: string
+      description: Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.
       format: date-time
       readOnly: true
     lastRunStatus:

--- a/src/common/schemas/DBRP.yml
+++ b/src/common/schemas/DBRP.yml
@@ -2,14 +2,14 @@
   properties:
     id:
       type: string
-      description: the mapping identifier
+      description: Mapping identifier
       readOnly: true
     orgID:
       type: string
-      description: the organization ID that owns this mapping.
+      description: ID of the organization that owns this mapping.
     bucketID:
       type: string
-      description: the bucket ID used as target for the translation.
+      description: ID of the bucket used as the target of the translation.
     database:
       type: string
       description: InfluxDB v1 database
@@ -18,7 +18,7 @@
       description: InfluxDB v1 retention policy
     default:
       type: boolean
-      description: Specify if this mapping represents the default retention policy for the database specificed.
+      description: Mapping represents the default retention policy for the database specified.
     links:
       $ref: "./Links.yml"
   required:

--- a/src/common/schemas/DBRP.yml
+++ b/src/common/schemas/DBRP.yml
@@ -2,14 +2,14 @@
   properties:
     id:
       type: string
-      description: Mapping identifier
+      description: ID of the DBRP mapping.
       readOnly: true
     orgID:
       type: string
       description: ID of the organization that owns this mapping.
     bucketID:
       type: string
-      description: ID of the bucket used as the target of the translation.
+      description: ID of the bucket used as the target for the translation.
     database:
       type: string
       description: InfluxDB v1 database

--- a/src/common/schemas/DBRPCreate.yml
+++ b/src/common/schemas/DBRPCreate.yml
@@ -2,13 +2,13 @@ type: object
 properties:
   orgID:
     type: string
-    description: the organization ID that owns this mapping.
+    description: ID of the organization that owns this mapping.
   org:
     type: string
-    description: the organization that owns this mapping.
+    description: Name of the organization that owns this mapping.
   bucketID:
     type: string
-    description: the bucket ID used as target for the translation.
+    description: ID of the bucket used as the target for the translation.
   database:
     type: string
     description: InfluxDB v1 database
@@ -17,7 +17,7 @@ properties:
     description: InfluxDB v1 retention policy
   default:
     type: boolean
-    description: Specify if this mapping represents the default retention policy for the database specificed.
+    description: Mapping represents the default retention policy for the database specified.
 required:
   - bucketID
   - database

--- a/src/common/schemas/Error.yml
+++ b/src/common/schemas/Error.yml
@@ -3,14 +3,15 @@
       $ref: "./ErrorCode.yml"
     message:
       readOnly: true
-      description: message is a human-readable message.
+      description: Human-readable message.
       type: string
     op:
       readOnly: true
-      description: op describes the logical code operation during error. Useful for debugging.
+      description: Describes the logical code operation when the error occurred. Useful for debugging.
       type: string
     err:
       readOnly: true
-      description: err is a stack of errors that occurred during processing of the request. Useful for debugging.
+      description: Stack of errors that occurred during processing of the request. Useful for debugging.
       type: string
-  required: [code, message]
+  required:
+    - code

--- a/src/common/schemas/LineProtocolError.yml
+++ b/src/common/schemas/LineProtocolError.yml
@@ -3,19 +3,20 @@
       $ref: "./LineProtocolErrorCode.yml"
     message:
       readOnly: true
-      description: Message is a human-readable message.
+      description: Human-readable message.
       type: string
     op:
       readOnly: true
-      description: Op describes the logical code operation during error. Useful for debugging.
+      description: Describes the logical code operation when the error occurred. Useful for debugging.
       type: string
     err:
       readOnly: true
-      description: Err is a stack of errors that occurred during processing of the request. Useful for debugging.
+      description: Stack of errors that occurred during processing of the request. Useful for debugging.
       type: string
     line:
       readOnly: true
-      description: First line within sent body containing malformed data
+      description: First line in the request body that contains malformed data.
       type: integer
       format: int32
-  required: [code, message, op, err]
+  required:
+    - code

--- a/src/common/schemas/LineProtocolLengthError.yml
+++ b/src/common/schemas/LineProtocolLengthError.yml
@@ -3,6 +3,8 @@
       $ref: "./LineProtocolLengthErrorCode.yml"
     message:
       readOnly: true
-      description: Message is a human-readable message.
+      description: Human-readable message.
       type: string
-  required: [code, message]
+  required:
+    - code
+    - message

--- a/src/common/schemas/NotificationRuleBase.yml
+++ b/src/common/schemas/NotificationRuleBase.yml
@@ -7,7 +7,7 @@
     - endpointID
   properties:
     latestCompleted:
-      description: Timestamp of latest scheduled, completed run, RFC3339.
+      description: Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.
       type: string
       format: date-time
       readOnly: true

--- a/src/common/schemas/Task.yml
+++ b/src/common/schemas/Task.yml
@@ -36,7 +36,7 @@
         Interval at which the task runs.
         `every` also determines when the task first runs, depending on the specified time.
 
-        Value is a [duration literal]({{% INFLUXDB_DOCS_URL %}}/flux/v0.x/spec/lexical-elements/#duration-literals)).
+        Value is a [duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals)).
       type: string
       format: duration
     cron:
@@ -48,17 +48,17 @@
       type: string
     offset:
       description: >-
-        [Duration]({{% INFLUXDB_DOCS_URL %}}/flux/v0.x/spec/lexical-elements/#duration-literals)) to delay execution of the task after the scheduled time has elapsed.
+        [Duration](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals) to delay execution of the task after the scheduled time has elapsed.
         `0` removes the offset.
 
-        The value is a [duration literal]({{% INFLUXDB_DOCS_URL %}}/flux/v0.x/spec/lexical-elements/#duration-literals).
+        The value is a [duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals).
       type: string
       format: duration
     latestCompleted:
       description: >-
         Timestamp of the latest scheduled and completed run.
 
-        Value is a timestamp in [RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/flux/v0.x/data-types/basic/time/#time-syntax).
+        Value is a timestamp in [RFC3339 date/time format](https://docs.influxdata.com/flux/v0.x/data-types/basic/time/#time-syntax).
       type: string
       format: date-time
       readOnly: true

--- a/src/common/schemas/Task.yml
+++ b/src/common/schemas/Task.yml
@@ -4,44 +4,46 @@
       readOnly: true
       type: string
     type:
-      description: The type of task, this can be used for filtering tasks on list actions.
+      description: Type of the task, useful for filtering a task list.
       type: string
     orgID:
-      description: The ID of the organization that owns this Task.
+      description: ID of the organization that owns the task.
       type: string
     org:
-      description: The name of the organization that owns this Task.
+      description: Name of the organization that owns the task.
       type: string
     name:
-      description: The name of the task.
+      description: Name of the task.
       type: string
     ownerID:
-      description: The ID of the user who owns this Task.
+      description: ID of the user who owns this Task.
       type: string
     description:
-      description: An optional description of the task.
+      description: Description of the task.
       type: string
     status:
       $ref: "./TaskStatusType.yml"
     labels:
       $ref: "./Labels.yml"
     authorizationID:
-      description: The ID of the authorization used when this task communicates with the query engine.
+      description: ID of the authorization used when the task communicates with the query engine.
       type: string
     flux:
-      description: The Flux script to run for this task.
+      description: Flux script to run for this task.
       type: string
     every:
-      description: A simple task repetition schedule; parsed from Flux.
+      description: Interval (as a [duration literal]({{% INFLUX_DOCS_URL %}}/flux/v0.x/spec/lexical-elements/#duration-literals)) at which the task runs. This option also determines when the task first starts to run, depending on the specified time.
       type: string
+      format: duration
     cron:
-      description: A task repetition schedule in the form '* * * * * *'; parsed from Flux.
+      description: [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview) that defines the schedule on which the task runs. Cron scheduling is based on system time.
       type: string
     offset:
-      description: Duration to delay after the schedule, before executing the task; parsed from flux, if set to zero it will remove this option and use 0 as the default.
+      description: [Duration]({{% INFLUX_DOCS_URL %}}/flux/v0.x/spec/lexical-elements/#duration-literals)) to delay execution of the task after the scheduled time has elapsed. `0` removes the offset.
       type: string
+      format: duration
     latestCompleted:
-      description: Timestamp of latest scheduled, completed run, RFC3339.
+      description: Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.
       type: string
       format: date-time
       readOnly: true

--- a/src/common/schemas/Task.yml
+++ b/src/common/schemas/Task.yml
@@ -32,14 +32,14 @@
       description: Flux script to run for this task.
       type: string
     every:
-      description: Interval (as a [duration literal]({{% INFLUX_DOCS_URL %}}/flux/v0.x/spec/lexical-elements/#duration-literals)) at which the task runs. This option also determines when the task first starts to run, depending on the specified time.
+      description: Interval (as a [duration literal]({{% INFLUXDB_DOCS_URL %}}/flux/v0.x/spec/lexical-elements/#duration-literals)) at which the task runs. This option also determines when the task first starts to run, depending on the specified time.
       type: string
       format: duration
     cron:
       description: [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview) that defines the schedule on which the task runs. Cron scheduling is based on system time.
       type: string
     offset:
-      description: [Duration]({{% INFLUX_DOCS_URL %}}/flux/v0.x/spec/lexical-elements/#duration-literals)) to delay execution of the task after the scheduled time has elapsed. `0` removes the offset.
+      description: [Duration]({{% INFLUXDB_DOCS_URL %}}/flux/v0.x/spec/lexical-elements/#duration-literals)) to delay execution of the task after the scheduled time has elapsed. `0` removes the offset.
       type: string
       format: duration
     latestCompleted:

--- a/src/common/schemas/Task.yml
+++ b/src/common/schemas/Task.yml
@@ -32,18 +32,33 @@
       description: Flux script to run for this task.
       type: string
     every:
-      description: Interval (as a [duration literal]({{% INFLUXDB_DOCS_URL %}}/flux/v0.x/spec/lexical-elements/#duration-literals)) at which the task runs. This option also determines when the task first starts to run, depending on the specified time.
+      description: >-
+        Interval at which the task runs.
+        `every` also determines when the task first runs, depending on the specified time.
+
+        Value is a [duration literal]({{% INFLUXDB_DOCS_URL %}}/flux/v0.x/spec/lexical-elements/#duration-literals)).
       type: string
       format: duration
     cron:
-      description: [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview) that defines the schedule on which the task runs. Cron scheduling is based on system time.
+      description: >-
+        [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview) that defines the schedule on which the task runs.
+        Cron scheduling is based on system time.
+
+        Value is a [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview).
       type: string
     offset:
-      description: [Duration]({{% INFLUXDB_DOCS_URL %}}/flux/v0.x/spec/lexical-elements/#duration-literals)) to delay execution of the task after the scheduled time has elapsed. `0` removes the offset.
+      description: >-
+        [Duration]({{% INFLUXDB_DOCS_URL %}}/flux/v0.x/spec/lexical-elements/#duration-literals)) to delay execution of the task after the scheduled time has elapsed.
+        `0` removes the offset.
+
+        The value is a [duration literal]({{% INFLUXDB_DOCS_URL %}}/flux/v0.x/spec/lexical-elements/#duration-literals).
       type: string
       format: duration
     latestCompleted:
-      description: Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.
+      description: >-
+        Timestamp of the latest scheduled and completed run.
+
+        Value is a timestamp in [RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/flux/v0.x/data-types/basic/time/#time-syntax).
       type: string
       format: date-time
       readOnly: true

--- a/src/oss/paths/metrics.yml
+++ b/src/oss/paths/metrics.yml
@@ -23,7 +23,8 @@ get:
       content:
         text/plain:
             schema:
-              type: "Prometheus text-based exposition"
+              type: string
+              format: "Prometheus text-based exposition"
               externalDocs:
                 description: Prometheus exposition formats
                 url: https://prometheus.io/docs/instrumenting/exposition_formats

--- a/src/svc/mapsd/paths/mapToken.yml
+++ b/src/svc/mapsd/paths/mapToken.yml
@@ -1,8 +1,9 @@
 get:
+  summary: Get a mapbox token
   operationId: getMapboxToken
   responses:
     '200':
-      description: A temp token for Mapbox
+      description: Temporary token for Mapbox.
       content:
         application/json:
           schema:


### PR DESCRIPTION
Fix invalid `type: timestamp` by replacing with `type: integer, format: unix timestamp`.
Remove "required" error response attributes that aren't in all errors.
Add missing OperationIDs.
Fix grammar in descriptions.