### PR TITLE
fix: missing specified type for `latestCompleted` property

### DIFF
--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -1768,6 +1768,7 @@ paths:
                                                               description: An optional description of the check.
                                                               type: string
                                                             latestCompleted:
+                                                              type: string
                                                               description: 'Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.'
                                                               format: date-time
                                                               readOnly: true

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -16190,6 +16190,7 @@
             "type": "string"
           },
           "latestCompleted": {
+            "type": "string",
             "description": "Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.",
             "format": "date-time",
             "readOnly": true

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -10443,6 +10443,7 @@ components:
           description: An optional description of the check.
           type: string
         latestCompleted:
+          type: string
           description: 'Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.'
           format: date-time
           readOnly: true

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -9349,6 +9349,7 @@ components:
           description: An optional description of the check.
           type: string
         latestCompleted:
+          type: string
           description: 'Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.'
           format: date-time
           readOnly: true

--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -3151,6 +3151,7 @@ paths:
                                                               description: An optional description of the check.
                                                               type: string
                                                             latestCompleted:
+                                                              type: string
                                                               description: 'Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.'
                                                               format: date-time
                                                               readOnly: true

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -18205,6 +18205,7 @@
             "type": "string"
           },
           "latestCompleted": {
+            "type": "string",
             "description": "Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.",
             "format": "date-time",
             "readOnly": true

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -11681,6 +11681,7 @@ components:
           description: An optional description of the check.
           type: string
         latestCompleted:
+          type: string
           description: 'Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.'
           format: date-time
           readOnly: true

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -595,6 +595,7 @@ components:
             of the latest scheduled and completed run.
           format: date-time
           readOnly: true
+          type: string
         links:
           example:
             labels: /api/v2/checks/1/labels

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -659,6 +659,7 @@ components:
             of the latest scheduled and completed run.
           format: date-time
           readOnly: true
+          type: string
         links:
           example:
             labels: /api/v2/checks/1/labels

--- a/src/common/schemas/CheckBase.yml
+++ b/src/common/schemas/CheckBase.yml
@@ -30,6 +30,7 @@
       description: An optional description of the check.
       type: string
     latestCompleted:
+      type: string
       description: Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.
       format: date-time
       readOnly: true


### PR DESCRIPTION
We use `oss.yml` to generate API in our clients - `java`, `c#`, `php`, `ruby`, ... If the `latestCompleted` property doesn't have specified type to `string` the [openapi-generator](https://github.com/OpenAPITools/openapi-generator) generates `latestCompleted` with generic type `object`. 


#### C# without type:

```csharp
/// <summary>
/// Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.
/// </summary>
/// <value>Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.</value>
[DataMember(Name="latestCompleted", EmitDefaultValue=false)]
public object LatestCompleted { get; private set; }
``` 

#### C# with type:

```csharp
/// <summary>
/// Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.
/// </summary>
/// <value>Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.</value>
[DataMember(Name = "latestCompleted", EmitDefaultValue = false)]
public DateTime? LatestCompleted { get; private set; }
``` 
