### PR TITLE
feat: add max age field to replications create

### DIFF
--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -5309,6 +5309,11 @@ components:
         dropNonRetryableData:
           type: boolean
           default: false
+        maxAge:
+          type: integer
+          format: int64
+          minimum: 0
+          default: 604800000000000
       required:
         - name
         - orgID
@@ -5316,6 +5321,7 @@ components:
         - localBucketID
         - remoteBucketID
         - maxQueueSizeBytes
+        - maxAge
     ReplicationUpdateRequest:
       type: object
       properties:

--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -5309,11 +5309,11 @@ components:
         dropNonRetryableData:
           type: boolean
           default: false
-        maxAge:
+        maxAgeSeconds:
           type: integer
           format: int64
           minimum: 0
-          default: 604800000000000
+          default: 604800
       required:
         - name
         - orgID
@@ -5321,7 +5321,7 @@ components:
         - localBucketID
         - remoteBucketID
         - maxQueueSizeBytes
-        - maxAge
+        - maxAgeSeconds
     ReplicationUpdateRequest:
       type: object
       properties:
@@ -5339,6 +5339,10 @@ components:
           minimum: 33554430
         dropNonRetryableData:
           type: boolean
+        maxAgeSeconds:
+          type: integer
+          format: int64
+          minimum: 0
   responses:
     ServerError:
       description: Non 2XX error response from server.

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -20515,11 +20515,11 @@
             "type": "boolean",
             "default": false
           },
-          "maxAge": {
+          "maxAgeSeconds": {
             "type": "integer",
             "format": "int64",
             "minimum": 0,
-            "default": 604800000000000
+            "default": 604800
           }
         },
         "required": [
@@ -20529,7 +20529,7 @@
           "localBucketID",
           "remoteBucketID",
           "maxQueueSizeBytes",
-          "maxAge"
+          "maxAgeSeconds"
         ]
       },
       "ReplicationUpdateRequest": {
@@ -20554,6 +20554,11 @@
           },
           "dropNonRetryableData": {
             "type": "boolean"
+          },
+          "maxAgeSeconds": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
           }
         }
       }

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -20514,6 +20514,12 @@
           "dropNonRetryableData": {
             "type": "boolean",
             "default": false
+          },
+          "maxAge": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0,
+            "default": 604800000000000
           }
         },
         "required": [
@@ -20522,7 +20528,8 @@
           "remoteID",
           "localBucketID",
           "remoteBucketID",
-          "maxQueueSizeBytes"
+          "maxQueueSizeBytes",
+          "maxAge"
         ]
       },
       "ReplicationUpdateRequest": {

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -13237,6 +13237,11 @@ components:
         dropNonRetryableData:
           type: boolean
           default: false
+        maxAge:
+          type: integer
+          format: int64
+          minimum: 0
+          default: 604800000000000
       required:
         - name
         - orgID
@@ -13244,6 +13249,7 @@ components:
         - localBucketID
         - remoteBucketID
         - maxQueueSizeBytes
+        - maxAge
     ReplicationUpdateRequest:
       type: object
       properties:

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -13237,11 +13237,11 @@ components:
         dropNonRetryableData:
           type: boolean
           default: false
-        maxAge:
+        maxAgeSeconds:
           type: integer
           format: int64
           minimum: 0
-          default: 604800000000000
+          default: 604800
       required:
         - name
         - orgID
@@ -13249,7 +13249,7 @@ components:
         - localBucketID
         - remoteBucketID
         - maxQueueSizeBytes
-        - maxAge
+        - maxAgeSeconds
     ReplicationUpdateRequest:
       type: object
       properties:
@@ -13267,6 +13267,10 @@ components:
           minimum: 33554430
         dropNonRetryableData:
           type: boolean
+        maxAgeSeconds:
+          type: integer
+          format: int64
+          minimum: 0
   responses:
     ServerError:
       description: Non 2XX error response from server.

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -3311,8 +3311,8 @@ components:
           type: boolean
         localBucketID:
           type: string
-        maxAge:
-          default: 604800000000000
+        maxAgeSeconds:
+          default: 604800
           format: int64
           minimum: 0
           type: integer
@@ -3336,7 +3336,7 @@ components:
       - localBucketID
       - remoteBucketID
       - maxQueueSizeBytes
-      - maxAge
+      - maxAgeSeconds
       type: object
     ReplicationUpdateRequest:
       properties:
@@ -3344,6 +3344,10 @@ components:
           type: string
         dropNonRetryableData:
           type: boolean
+        maxAgeSeconds:
+          format: int64
+          minimum: 0
+          type: integer
         maxQueueSizeBytes:
           format: int64
           minimum: 33554430

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -3311,6 +3311,11 @@ components:
           type: boolean
         localBucketID:
           type: string
+        maxAge:
+          default: 604800000000000
+          format: int64
+          minimum: 0
+          type: integer
         maxQueueSizeBytes:
           default: 67108860
           format: int64
@@ -3331,6 +3336,7 @@ components:
       - localBucketID
       - remoteBucketID
       - maxQueueSizeBytes
+      - maxAge
       type: object
     ReplicationUpdateRequest:
       properties:

--- a/src/oss/schemas/ReplicationCreationRequest.yml
+++ b/src/oss/schemas/ReplicationCreationRequest.yml
@@ -20,6 +20,11 @@ properties:
   dropNonRetryableData:
     type: boolean
     default: false
+  maxAge:
+    type: integer
+    format: int64
+    minimum: 0
+    default: 604800000000000 # 168 * time.Hour
 required:
   - name
   - orgID
@@ -27,3 +32,4 @@ required:
   - localBucketID
   - remoteBucketID
   - maxQueueSizeBytes
+  - maxAge

--- a/src/oss/schemas/ReplicationCreationRequest.yml
+++ b/src/oss/schemas/ReplicationCreationRequest.yml
@@ -20,11 +20,11 @@ properties:
   dropNonRetryableData:
     type: boolean
     default: false
-  maxAge:
+  maxAgeSeconds:
     type: integer
     format: int64
     minimum: 0
-    default: 604800000000000 # 168 * time.Hour
+    default: 604800 # 1 week in seconds
 required:
   - name
   - orgID
@@ -32,4 +32,4 @@ required:
   - localBucketID
   - remoteBucketID
   - maxQueueSizeBytes
-  - maxAge
+  - maxAgeSeconds

--- a/src/oss/schemas/ReplicationUpdateRequest.yml
+++ b/src/oss/schemas/ReplicationUpdateRequest.yml
@@ -14,3 +14,7 @@ properties:
     minimum: 33554430 # 32 MiB
   dropNonRetryableData:
     type: boolean
+  maxAgeSeconds:
+    type: integer
+    format: int64
+    minimum: 0


### PR DESCRIPTION
Part of https://github.com/influxdata/influxdb/issues/23109

The default chosen here, being `168 * time.Hour` (or 1 week) is adapted from Hinted Handoff, where this feature already exists