### PR TITLE
chore: remove v2private/tenant

### DIFF
--- a/contracts/priv/cloud-priv.yml
+++ b/contracts/priv/cloud-priv.yml
@@ -212,51 +212,6 @@ paths:
         default:
           description: unexpected error
           $ref: '#/components/responses/ServerError'
-  /tenants:
-    post:
-      summary: 'This is a temporary, experimental, soon to be depricated API for Quartz'
-      requestBody:
-        description: 'the parameters for the org to be created, including limits'
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/OrganizationRequest'
-      responses:
-        '201':
-          description: The created organization and the initial bucket
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  orgID:
-                    type: string
-                    description: the influxDB ID of the created organization
-                  userID:
-                    type: string
-                    description: the influxDB ID of the created IDPE User
-        '400':
-          description: The requested changes were invalid
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InvalidRequestError'
-        '401':
-          description: Credentials not provided
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UnauthorizedRequestError'
-        '403':
-          description: Insufficient credentials to create an organization
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ForbiddenRequestError'
-        default:
-          description: unexpected error
-          $ref: '#/components/responses/ServerError'
   /setup/user:
     post:
       operationId: PostSetupUser

--- a/src/cloud-priv.yml
+++ b/src/cloud-priv.yml
@@ -22,8 +22,6 @@ paths:
     $ref: './cloud/paths/orgs_orgID_limits_status.yml'
   /orgs/{orgID}/settings:
     $ref: './cloud/paths/orgs_orgID_settings.yml'
-  /tenants:
-    $ref: './cloud/paths/tenants.yml'
   /setup/user:
     $ref: './cloud/paths/setup_user.yml'
 components:


### PR DESCRIPTION
Part of https://github.com/influxdata/idpe/issues/13542

Removes the `/v2private/tenants` endpoint. This was originally a temporary endpoint, and is no longer used. It will be removed from IDPE as well.