### PR TITLE
fix: ScriptInvocationParams should be key-value map

### DIFF
--- a/contracts/invocable-scripts.yml
+++ b/contracts/invocable-scripts.yml
@@ -286,6 +286,7 @@ components:
       properties:
         params:
           type: object
+          additionalProperties: true
     ScriptLanguage:
       type: string
       enum:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -3849,6 +3849,7 @@ components:
     ScriptInvocationParams:
       properties:
         params:
+          additionalProperties: true
           type: object
       type: object
     ScriptLanguage:

--- a/contracts/svc/invocable-scripts.yml
+++ b/contracts/svc/invocable-scripts.yml
@@ -286,6 +286,7 @@ components:
       properties:
         params:
           type: object
+          additionalProperties: true
     ScriptLanguage:
       type: string
       enum:

--- a/src/svc/invocable-scripts/schemas/ScriptInvocationParams.yml
+++ b/src/svc/invocable-scripts/schemas/ScriptInvocationParams.yml
@@ -2,3 +2,4 @@ type: object
 properties:
   params:
     type: object
+    additionalProperties: true


### PR DESCRIPTION
We use `invocable-scripts.yml` to generate an integration with `InvocableScripts` in our clients - `java`, `c#`, `php`, `ruby`, ... If the `additionalProperties` is not used then the `params` is generated as generic `object` type not key-value map:

#### Java without `additionalProperties `:

```java
public class ScriptInvocationParams {
  public static final String SERIALIZED_NAME_PARAMS = "params";
  @SerializedName(SERIALIZED_NAME_PARAMS)
  private Object params = null;
  ...
``` 

#### Java with `additionalProperties`:

```java
public class ScriptInvocationParams {
  public static final String SERIALIZED_NAME_PARAMS = "params";
  @SerializedName(SERIALIZED_NAME_PARAMS)
  private Map<String, Object> params = new HashMap<>();
  ...
``` 
