### PR TITLE
Chore/296 template

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ For information on what to do when platform APIs drift, see [src/README](./src/R
 ### Add tag content or describe a group of paths
 
 API reference docs
-([OSS](https://docs.influxdata.com/influxdb/v2.2/api/,
+([OSS](https://docs.influxdata.com/influxdb/v2.2/api/),
 [Cloud](https://docs.influxdata.com/influxdb/cloud/api/))
 rely on the following tag elements and vendor extensions:
 

--- a/README.md
+++ b/README.md
@@ -114,3 +114,53 @@ Everything (nearly) in the `contracts` directory is generated and should not be 
 ### Notes:
 
 There are some limitations to this work. It is important at this time to ensure any definitions consumable from our UI are compatible with, and consumable by [oats](https://github.com/influxdata/oats). One of the OpenAPI v3 compatible specifications `oats` cannot currently handle is the `servers` override, so we keep them in separate swagger files. This is exemplified in `cloud-priv.yml` and it's `servers` key; the major difference between `cloud-priv.yml` and `cloud.yml`.
+
+## How to contribute
+
+To update and generate contracts, do the following:
+
+1. Clone this repository (influxdata/openapi).
+2. If you haven't already, [install and run Docker](https://docs.docker.com/get-docker/).
+3. Review the [guidelines](#guidelines).
+4. Edit [`src`](./src) files.
+5. With Docker running, run `make generate-all` to generate new API contracts.
+6. Commit the result, including the generated `./contracts` files, and create a pull request.
+
+### Guidelines
+
+Follow these guidelines to add or update specifications:
+
+- [Add or update paths and operations](#add-or-update-paths-and-operations)
+- [Add or update service definitions](#add-or-update-service-definitions)
+- [What to do when Cloud and OSS diverge](#what-to-do-when-cloud-and-oss-diverge)
+
+### Add or update paths and operations
+
+If you're adding or updating paths and operations (`get`, `post`, etc.), follow our [path template](./docs/templates/pathTemplate.yml) for `summary`, `description`, and `example` elements.
+
+### Add or update service definitions
+
+To add a service API definition, add the service specific components to a subdirectory inside `src/svc` and reference them from a file in `src` with a prefix `svc-`. This allows product API maintainers to copy the service-specific ("internal") paths and components into the respective API definition (cloud, cloud-priv, or oss) without modifying references. For more information on how to add a new service api defnition, see [src/svc/README](./src/svc/README.md).
+
+### What to do when Cloud and OSS diverge
+
+For information on what to do when platform APIs drift, see [src/README](./src/README.md).
+
+### Add tag content or describe a group of paths
+
+API reference docs
+([OSS](https://docs.influxdata.com/influxdb/v2.2/api/,
+[Cloud](https://docs.influxdata.com/influxdb/cloud/api/))
+rely on the following tag elements and vendor extensions:
+
+- `description` Tag field: describes related endpoints (Paths) and their common
+  features.
+- `x-traitTag: true` Tag field: renders sections with information about general API features and use.
+- `x-tagGroups` Root element: renders endpoint (Path) groups in navigation menus.
+
+To edit these elements, see the platform-specific files:
+
+- `src/[platform]/tags.yml`
+- `src/[platform]/tag-groups.yml`
+
+For more information, see [influxdata/docs-v2 /api-docs README](https://github.com/influxdata/docs-v2/blob/master/api-docs/README.md).

--- a/docs/templates/pathTemplate.yml
+++ b/docs/templates/pathTemplate.yml
@@ -43,21 +43,21 @@ info:
       - Follow guidelines (`#` comments) and examples (`<!--- --->`` HTML comments).
       - In links to InfluxData documentation, use the 
         `{{% INFLUXDB_DOCS_URL %}}` variable to replace the domain and
-        platform-specific path in URLs, e.g.
+        platform-specific path in URLs, for example:
 
         - `[Authentication]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication)`. 
 
     For path and operation (method) descriptions:
-      - start with an active verb that describes what the operation does.
-      - see https://cloud.google.com/apis/design/documentation#api_description
+      - Start with an active verb that describes what the operation does.
+      - See https://cloud.google.com/apis/design/documentation#api_description
         for more examples.
 
     For parameter (path, query, header) descriptions:
-      - use a noun phrase that describes the field or parameter.
-      - see https://cloud.google.com/apis/design/documentation#field_and_parameter_descriptions
+      - Use a noun phrase that describes the field or parameter.
+      - See https://cloud.google.com/apis/design/documentation#field_and_parameter_descriptions
         for more examples.
     
-    This template isn't meant to be exhaustive -- the complete set of
+    This template isn't meant to be exhaustive--the complete set of
     child elements in your spec depends on the Operation.
     For example, each Operation (`get`, `put`, etc) should define
     response codes with descriptions and examples specific for the Operation.
@@ -142,7 +142,7 @@ x-influxdataPathTemplate:
     #    - Updates the authorization status and returns the active or inactive
     #      authorization.
     #
-    #    For more help, see https://developers.google.com/style/api-reference-comments?hl=en#description).
+    #    For more help, see https://developers.google.com/style/api-reference-comments?hl=en#description.
     #
     # 2. For deprecated operations, set the `deprecated` Operation field to
     #    `true` and add a link here to the new operation--for example:
@@ -183,7 +183,7 @@ x-influxdataPathTemplate:
 
       Creates a task and returns the new task.
 
-      Use this endpoint to schedule a [Flux script]() that takes a stream of 
+      Use this endpoint to schedule a [Flux script](https://docs.influxdata.com/flux/v0.x/) that takes a stream of 
       input data, modifies or analyzes it, and then writes the modified data
       to a bucket or performs some action.
 
@@ -200,7 +200,7 @@ x-influxdataPathTemplate:
       #### Rate limits (with InfluxDB Cloud)
 
       `write` rate limits apply.
-      For more information, see [limits and adjustable quotas]({/influxdb/cloud/account-management/limits/).
+      For more information, see [limits and adjustable quotas]({{% INFLUXDB_DOCS_URL %}}/influxdb/cloud/account-management/limits/).
       
       #### Related guides
 
@@ -234,7 +234,7 @@ x-influxdataPathTemplate:
 
         To send compressed data, do the following:
           
-          1. Use GZIP to compress the line protocol data.
+          1. Use [GZIP](https://www.gzip.org/) to compress the line protocol data.
           2. In your request, send the compressed data and the 
              `Content-Encoding: gzip` header.     
         
@@ -333,7 +333,7 @@ x-influxdataPathTemplate:
           If you provide both `orgID` and `org`, `org` takes precedence.
 
           To find your organization, see how to 
-          [view organizations]({{% INFLUXDB_DOCS_URL %}}/organizations/view-orgs/)
+          [view organizations]({{% INFLUXDB_DOCS_URL %}}/organizations/view-orgs/).
           --->
 
           <!--- Example: bucketID parameter description
@@ -356,9 +356,9 @@ x-influxdataPathTemplate:
         # 2. If it returns a body, briefly state what the response body contains.
         #
         # 3. For asynchronous operations, explain the following:
-        #    - what part was successful and what part is asynchronous
-        #    - how to check that the operation completed
-        #    - how to troubleshoot problems
+        #    - What part was successful and what part is asynchronous
+        #    - How to check that the operation completed
+        #    - How to troubleshoot problems
         description: |
           <!--- Example description for `PATCH /authorization` 200 response status
 
@@ -548,16 +548,16 @@ x-influxdataPathTemplate:
 
           #### InfluxDB Cloud
 
-            - returns this error if a **read** or **write** request exceeds your
+            - Returns this error if a **read** or **write** request exceeds your
               plan's [adjustable service quotas]({{% INFLUXDB_DOCS_URL %}}/account-management/limits/#adjustable-service-quotas)
               or if a **delete** request exceeds the maximum
               [global limit]({{% INFLUXDB_DOCS_URL %}}/account-management/limits/#global-limits).
-            - returns `Retry-After` header that describes when to try the write
+            - Returns `Retry-After` header that describes when to try the write
               again.
 
           #### InfluxDB OSS
 
-            - doesn't return this error.
+            - Doesn't return this error.
 
           --->
         headers:

--- a/docs/templates/pathTemplate.yml
+++ b/docs/templates/pathTemplate.yml
@@ -1,0 +1,605 @@
+openapi: '3.0.2'
+info:
+  title: InfluxData OpenAPI 3.x Path template
+  description: | 
+    This OpenAPI specification provides a template for OpenAPI 3.x Path elements
+    in influxdata/openapi.
+    The template provides guidelines for 
+    `summary`, `description`, and `response` elements in OpenAPI Paths and Operations.
+
+    # Usage
+    
+    The template in the `x-influxdataPathTemplate` vendor extension element defines a 
+    valid OpenAPI Path object that provides guidelines and examples for 
+    InfluxDB API endpoints.
+
+    You can use common OpenAPI tooling (e.g. OpenAPI Preview and Redocly OpenAPI)
+    to preview and validate this spec.
+    
+    ## How to use template guidelines
+   
+    - Follow guidelines provided in Bash-style comments (`#`) that precede
+      OpenAPI elements.
+    - Follow [Google styles for API methods](https://developers.google.com/style/api-reference-comments#methods).
+    
+    ## How to use template examples
+
+    - Fields that support Markdown (`description` and `value`)
+      contain examples in HTML comments (`<!--- --->`).
+
+      To use examples, do the following:
+
+        - Copy-paste examples into your spec and edit them as needed.
+        - Remove comment tags before generating contracts.
+        - Keep in mind, HTML comments might be preserved in downstream contracts
+          and HTML even if they're not rendered.
+
+    ## description fields
+
+    When writing `description` fields, do the following:
+
+      - Use [CommonMark syntax](https://spec.commonmark.org/0.30/).
+      - Include the template section headings (in Markdown `####` level 4 tags).
+      - Follow guidelines (`#` comments) and examples (`<!--- --->`` HTML comments).
+      - In links to InfluxData documentation, use the 
+        `{{% INFLUXDB_DOCS_URL %}}` variable to replace the domain and
+        platform-specific path in URLs, e.g.
+
+        - `[Authentication]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication)`. 
+
+    For path and operation (method) descriptions:
+      - start with an active verb that describes what the operation does.
+      - see https://cloud.google.com/apis/design/documentation#api_description
+        for more examples.
+
+    For parameter (path, query, header) descriptions:
+      - use a noun phrase that describes the field or parameter.
+      - see https://cloud.google.com/apis/design/documentation#field_and_parameter_descriptions
+        for more examples.
+    
+    This template isn't meant to be exhaustive -- the complete set of
+    child elements in your spec depends on the Operation.
+    For example, each Operation (`get`, `put`, etc) should define
+    response codes with descriptions and examples specific for the Operation.
+
+  version: '1.0'   
+servers:
+  - url: '' 
+paths:
+  /tasks:
+    $ref: '#/x-influxdataPathTemplate'
+x-influxdataPathTemplate:
+
+  # Path description
+  # 
+  # 1. In the first sentence, start with a verb and use present tense to briefly 
+  #    state what action the method performs.
+  # 
+  # 2. Provide the following context:
+  #  - Why a developer would use this path.
+  #  - Relationships to important resources or concepts, especially if they're
+  #    not obvious.
+  description: |
+    <!--- Example: Path description for `/authorizations`
+     
+    Creates and manages API tokens for access to InfluxDB resources.
+
+    An **authorization** associates a list of permissions to an **organization**
+    and provides a token for API access.
+    You can restrict an authorization and its token to a specific user.
+
+    #### Related guides
+
+      - [Authorize API requests]({{% INFLUXDB_DOCS_URL %}}/api-guide/api_intro/#authentication).
+      - [Manage API tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens/).
+      - [Assign a token to a specific user]({{% INFLUXDB_DOCS_URL %}}/security/tokens/create-token/).
+
+    --->
+
+  # Path parameters
+  # 
+  # - List Parameter objects that apply to *all* operations in this path.
+  parameters: []
+  
+  post:
+
+    # operationId
+    # Used in links.
+    #
+    # Use the convention OperationPathname.
+    operationId: PostTasks
+
+    # Operation tags
+    # Used for grouping and menus.
+    #
+    # Include the Pathname.
+    # To learn how tags are used, see the [README](../../README.md)
+    tags:
+      - Tasks
+
+    # Operation summary
+    # Used in section headings and nav menus.
+    #
+    # For the Operation summary, state the 
+    # developer's action, starting with the base form of the verb
+    # (Add, Create, Delete, List, Update, Retrieve)--for example:
+    #
+    # - Add an owner to a bucket
+    # - Create a bucket
+    # 
+    # For more guidance, see https://developers.google.com/style/headings?hl=en#heading-and-title-text
+    summary: Create a task
+
+    # Operation description
+    #
+    # 1. In the first sentence, start with a verb
+    #   (Adds, Creates, Deletes, Lists, Updates, Returns)
+    #    and briefly state in present tense what action the operation performs
+    #    --for example:
+    #
+    #    - Returns a task.
+    #    - Adds a new bucket to the organization and returns the bucket.   
+    #    - Updates the authorization status and returns the active or inactive
+    #      authorization.
+    #
+    #    For more help, see https://developers.google.com/style/api-reference-comments?hl=en#description).
+    #
+    # 2. For deprecated operations, set the `deprecated` Operation field to
+    #    `true` and add a link here to the new operation--for example:
+    #
+    #    - **Deprecated**.
+    #      Use [`PATCH /api/v2/tasks/{taskID}`](#operation/PatchTasksID) instead.
+    # 
+    # 3. Describe the following:
+    #   - Why and when to use this Operation
+    #   - Idempotency
+    #   - Side effects
+    #   - Requirements that are "hidden" or not obvious from the requestBody or
+    #   - parameter definitions
+    #   - Assumptions data sources, formats, I/O, or the state of a resource
+    #   - Nuances in requests, response codes, or payloads.
+    #
+    # 4. Describe unique relationships to other InfluxDB resources or concepts,
+    #    especially if they're not obvious--for example:
+
+    #    - Use `POST /api/v2/authorizations` to create InfluxDB API tokens.
+    # 
+    # #### Required permissions
+    #
+    # - List permissions required for the operation.
+    #
+    # #### Rate limits (with InfluxDB Cloud)
+    #   
+    # For Rate limits, include a link to rate limits documentation for
+    # InfluxDB Cloud.
+    # If an endpoint introduces a change to limits or quotas, create a PR or 
+    # issue at https://github.com/influxdata/docs-v2/.
+    # 
+    # #### Related guides
+    # 
+    # For Related guides, include links to documented procedures and tutorials.
+    description: |
+      <!--- Example: Operation description for `POST /task`
+
+      Creates a task and returns the new task.
+
+      Use this endpoint to schedule a [Flux script]() that takes a stream of 
+      input data, modifies or analyzes it, and then writes the modified data
+      to a bucket or performs some action.
+
+      #### Required permissions
+
+      - `write-tasks`
+      - 'read-buckets'
+      - `write-buckets` or `write-bucket BUCKET_ID`
+      
+      `BUCKET_ID` is the ID of the destination bucket.
+
+      #### Limitations
+      
+      #### Rate limits (with InfluxDB Cloud)
+
+      `write` rate limits apply.
+      For more information, see [limits and adjustable quotas]({/influxdb/cloud/account-management/limits/).
+      
+      #### Related guides
+
+      - [Create a task]({{% INFLUXDB_DOCS_URL %}}/manage-tasks/create-task/).
+      - [Process data with InfluxDB tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/).
+
+      --->
+
+    requestBody:
+      
+      # Request Body description
+      #
+      # 1. In the first line, briefly state what the body represents.
+      #
+      # 2. Describe options and encodings for sending the request payload.
+      #
+      # 3. If a header or query parameter influences handling of the body,
+      #    describe the parameter and its effect.
+      #
+      # 4. List default values.
+      description: | 
+        <!--- Example: Request Body description for `PATCH /tasks/{taskID}` 
+
+        Task with updates to apply
+
+        --->
+       
+        <!--- Example: Request Body description for `POST /write`
+
+        Data in line protocol format
+
+        To send compressed data, do the following:
+          
+          1. Use GZIP to compress the line protocol data.
+          2. In your request, send the compressed data and the 
+             `Content-Encoding: gzip` header.     
+        
+        #### Related guides
+        
+        - [Best practices for optimizing writes]({{% INFLUXDB_DOCS_URL%}}/write-data/best-practices/optimize-writes/).
+
+        --->
+
+      content:
+
+        # Request Body Media Type
+        #
+        # If the schema can't generate an example (e.g. for a non-JSON body),
+        # provide one.
+        text/plain:
+          schema:
+            type: string
+            format: byte
+            description: |
+              <!--- Example: line protocol schema
+
+              Line protocol
+
+              --->
+          examples:
+            line-protocol:
+              summary: Line protocol
+              description: Data in line protocol format.
+              value: |
+                airSensors,sensor_id=TLM0201 temperature=73.97038159354763,humidity=35.23103248356096,co=0.48445310567793615 1630424257000000000
+                airSensors,sensor_id=TLM0202 temperature=75.30007505999716,humidity=35.651929918691714,co=0.5141876544505826 1630424257000000000
+
+    # Parameters
+    #
+    # - Include request headers that are required for the operation.
+
+    # - Include request headers that use specific or unique values for the operation.
+
+    # - Include all HTTP request parameters.
+    parameters:
+      - in: header
+        name: Content-Type
+
+        # Header parameter description
+        # 
+        # If a value is required, how does it affect the following:
+        #  
+        #  1. handling of the request payload?
+        # 
+        #  2. the response?
+        description: |
+          <!--- Example --->
+
+        schema:
+          type: string
+          default: text/plain; charset=utf-8
+          enum:
+            - text/plain
+            - text/plain; charset=utf-8
+
+        # Header parameter examples
+        #
+        # 1. For the `summary`, provide a short name for the value.
+        #
+        # 2. Describe the effect on, or relationship, to the request body.
+        #
+        # 3. Provide an example with the header name and value.
+        examples:
+          default:
+            summary: Default content type for line protocol
+            description: |
+              <!--- Example: Line protocol default content type
+              `text/plain` is the content type for line protocol.
+              `UTF-8` is the default character set for line protocol.
+              --->
+            value: {"Content-Type": "text/plain; charset=utf-8"}
+          text-plain:
+            summary: Plain text, unspecified character set
+            value: {"Content-Type": "text/plain"}
+      - in: query
+        name: org
+
+        # Query parameter description
+        #
+        # 1. Describe how to find the value. Provide a link to additional
+        #    documentation.
+        #
+        # 2. Explain precedence or exclusivity when combined with other parameters.
+        description: |
+          <!--- Example: `org` parameter description
+
+          Organization that contains the bucket you want to write to.
+          InfluxDB writes all points in the batch to this organization. 
+          
+          If you provide both `orgID` and `org`, `org` takes precedence.
+
+          To find your organization, see how to 
+          [view organizations]({{% INFLUXDB_DOCS_URL %}}/organizations/view-orgs/)
+          --->
+
+          <!--- Example: bucketID parameter description
+
+          To find the bucket ID, use the [`buckets`]() endpoint.
+          If you provide both `bucketId` and `bucket`, `bucketId` takes precedence.
+
+          --->
+        required: true
+        schema:
+          type: string
+          description: Organization name or ID.
+    responses:
+      '200':
+
+        # 2xx Response description
+        #
+        # 1. For the first sentence, state "Success."
+        #
+        # 2. If it returns a body, briefly state what the response body contains.
+        #
+        # 3. For asynchronous operations, explain the following:
+        #    - what part was successful and what part is asynchronous
+        #    - how to check that the operation completed
+        #    - how to troubleshoot problems
+        description: |
+          <!--- Example description for `PATCH /authorization` 200 response status
+
+          Success. The response body contains the updated active or inactive 
+          authorization.
+
+          --->
+
+        # Response content
+        #
+        # If the response contains a (payload) body, provide the content field
+        # with a 
+        # [Media Type](https://swagger.io/docs/specification/media-types/).
+        # In the Media Type, include the response body schema and an example.
+        content:
+          text/csv:
+            schema:
+              type: string
+
+              # Response example
+              #
+              # If the schema can't generate an example
+              # (e.g. for a non-JSON body), provide one.
+              example: >
+                <!--- Example: CSV body for `POST /query` 200 response status
+
+                result,table,_start,_stop,_time,region,host,_value
+                mean,0,2018-05-08T20:50:00Z,2018-05-08T20:51:00Z,2018-05-08T20:50:00Z,east,A,15.43
+                mean,0,2018-05-08T20:50:00Z,2018-05-08T20:51:00Z,2018-05-08T20:50:20Z,east,B,59.25
+                mean,0,2018-05-08T20:50:00Z,2018-05-08T20:51:00Z,2018-05-08T20:50:40Z,east,C,52.62
+
+                --->
+      
+      "204":
+        description: |
+          <!--- Example: 204 Response description for asynchronous `POST /write`
+            
+          InfluxDB validated the request data format and accepted the data for
+          writing to the bucket.
+          Because data is written to InfluxDB asynchronously,
+          data may not yet be written to a bucket.
+
+          #### Error handling
+
+          - If some of your data didn’t write to the bucket,
+            see [how to check for write errors]({{% INFLUXDB_DOCS_URL %}}/write-data/troubleshoot/).
+          
+          --->
+        
+        # 204 Response content
+        #
+        # If the response contains a payload (a 204 response shouldn't),
+        # provide the content field with a [Media Type](https://swagger.io/docs/specification/media-types/)
+        # that contains the response schema and an example.
+        content:
+          text/csv:
+            schema:
+              type: string
+              example: >
+                <!--- Example: Response content
+
+                Success
+
+                --->
+
+      "400":
+        
+        # 4xx Response description
+        #
+        # 1. In the first sentence, provide the response status text.
+        #
+        # 2. Describe the following:
+        #    - cause of the error
+        #    - what the response payload contains - if platforms diverge, 
+        #       include platform headings--for example:
+        #      - **InfluxDB Cloud**
+        #      - **InfluxDB OSS**
+        #    - outcome of the error
+        #
+        # #### Error handling
+        #
+        # Link to error handling or troubleshooting documentation not included
+        # in the Operation description.
+        description: |
+          <!--- Example: 400 description for `POST /write`
+
+          Bad request.
+          Line protocol data in the request is malformed.
+          The response body contains the first malformed line in the data.
+
+          InfluxDB rejected the batch and did not write any data.
+          
+          #### Error handling
+
+          - [Troubleshoot issues writing data]({{% INFLUXDB_DOCS_URL %}}/write-data/troubleshoot/)
+       
+          --->
+        content:
+          application/json:
+            schema:
+              $ref: "../../src/common/schemas/LineProtocolError.yml"
+            examples:
+              measurementSchemaFieldTypeConflict:
+                summary: InfluxDB Cloud field type conflict thrown by an explicit bucket schema
+                value: {
+                  "code": "invalid",
+                  "message": "partial write error (2 written): unable to parse 'air_sensor,service=S1,sensor=L1 temperature=\"90.5\",humidity=70.0 1632850122': schema: field type for field \"temperature\" not permitted by schema; got String but expected Float",
+                  "op": "",
+                  "err": ""
+                  }
+      "401":
+        $ref: "../../src/common/responses/AuthorizationError.yml"
+      "404":
+        $ref: "../../src/common/responses/ResourceNotFoundError.yml"
+
+      "413":
+        description: |
+          <!--- Example: 413 description with platform divergence for `POST /write`
+
+          The request payload is too large.
+          InfluxDB rejected the batch and did not write any data.
+
+          #### InfluxDB Cloud:
+
+            - returns this error if the request exceeds the maximum 
+              [global limit]({{% INFLUXDB_DOCS_URL %}}/account-management/limits/#global-limits).
+            - returns `Content-Type: text/html` for this error.
+
+          #### InfluxDB OSS:
+
+            - returns this error only if the 
+              [Go (golang) `ioutil.ReadAll()`](https://pkg.go.dev/io/ioutil#ReadAll)
+              function raises an error.
+            - returns `Content-Type: application/json` for this error.
+          
+          #### Error handling
+
+            - [Troubleshoot issues writing data]({{% INFLUXDB_DOCS_URL %}}/write-data/troubleshoot/)
+
+          --->
+            
+        # 4xx Response content
+        #
+        # Provide a response example.
+        # If platforms (OSS and Cloud) differ in their responses, provide 
+        # examples with the following fields:
+        #
+        # - summary with "InfluxDB OSS response" or "InfluxDB Cloud response"
+        # - value with the response body
+        content:
+          # application/json must be listed first for the influx-cli codegen 
+          # to work properly, see https://github.com/influxdata/openapi/pull/253
+          application/json:
+            schema:
+              $ref: "../../src/common/schemas/LineProtocolLengthError.yml"
+            examples:
+              dataExceedsSizeLimitOSS:
+                summary: InfluxDB OSS response
+                value: |
+                  <!--- Example: 413 Response example value for OSS `POST /write`
+                  
+                  {"code":"request too large","message":"unable to read data: points batch is too large"}
+
+                  --->
+          text/html:
+            schema:
+              type: string
+            examples:
+              dataExceedsSizeLimit:
+                summary: InfluxDB Cloud response
+                value: |
+                  <!--- Example: 413 Response example value for Cloud `POST /write`
+
+                  <html>
+                    <head><title>413 Request Entity Too Large</title></head>
+                    <body>
+                      <center><h1>413 Request Entity Too Large</h1></center>
+                      <hr>
+                      <center>nginx</center>
+                    </body>
+                  </html>
+
+                  --->
+      "429":
+        description: >
+          <!--- Example: 429 Response description
+
+          #### InfluxDB Cloud
+
+            - returns this error if a **read** or **write** request exceeds your
+              plan's [adjustable service quotas]({{% INFLUXDB_DOCS_URL %}}/account-management/limits/#adjustable-service-quotas)
+              or if a **delete** request exceeds the maximum
+              [global limit]({{% INFLUXDB_DOCS_URL %}}/account-management/limits/#global-limits).
+            - returns `Retry-After` header that describes when to try the write
+              again.
+
+          #### InfluxDB OSS
+
+            - doesn't return this error.
+
+          --->
+        headers:
+          Retry-After:
+            description: |
+              <!--- Example: Response `Retry-After` header description
+
+                Non-negative decimal integer indicating seconds to wait before
+                retrying the request.
+
+              --->
+            schema:
+              type: integer
+              format: int32
+      "500":
+        $ref: "../../src/common/responses/InternalServerError.yml"
+      "503":
+        description: >
+          <!--- Example: 503 Response description with platform divergence
+
+          **InfluxDB Cloud** returns the following:
+
+            - `503` if series cardinality exceeds your plan's
+              [adjustable service quotas]({{% INFLUXDB_DOCS_URL %}}/account-management/limits/#adjustable-service-quotas).
+              See [how to resolve high series cardinality]({{% INFLUXDB_DOCS_URL %}}/write-data/best-practices/resolve-high-cardinality/).
+  
+          **InfluxDB OSS** returns the following:
+  
+            - `503` if the server is temporarily unavailable to accept writes.
+            - `Retry-After` header that describes when to try the write again.
+
+          --->
+        headers:
+          Retry-After:
+            description: |
+              <!--- Example: Response `Retry-After` header description
+
+              Non-negative decimal integer indicating seconds to wait before 
+              retrying the request.
+
+              --->
+            schema:
+              type: integer
+              format: int32
+  


### PR DESCRIPTION
- Add a template that provides guidelines and examples for documenting OpenAPI Paths and Operations.
- Update background and instructions in README.

![Screen Shot 2022-04-21 at 2 54 20 PM](https://user-images.githubusercontent.com/212227/164542407-e56ddd77-b89a-48a5-8ddc-a6bc6f7a563c.png)

