### PR TITLE
feat: add query parameters to tasks contract that fulfill the pagination, filtering, and sorting epic

### DIFF
--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -2765,6 +2765,20 @@ paths:
             default: 100
           description: The non-zero number of tasks to return
         - in: query
+          name: offset
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+          description: The number of records to skip
+        - in: query
+          name: sortBy
+          description: Field that records should be sorted by
+          schema:
+            type: string
+            enum:
+              - name
+        - in: query
           name: type
           description: 'Type of task, unset by default.'
           required: false

--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -2766,6 +2766,7 @@ paths:
           description: The non-zero number of tasks to return
         - in: query
           name: offset
+          required: false
           schema:
             type: integer
             minimum: 0
@@ -2774,6 +2775,7 @@ paths:
         - in: query
           name: sortBy
           description: Field that records should be sorted by
+          required: false
           schema:
             type: string
             enum:

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -9728,6 +9728,27 @@
           },
           {
             "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            },
+            "description": "The number of records to skip"
+          },
+          {
+            "in": "query",
+            "name": "sortBy",
+            "description": "Field that records should be sorted by",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "name"
+              ]
+            }
+          },
+          {
+            "in": "query",
             "name": "type",
             "description": "Type of task, unset by default.",
             "required": false,

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -9729,6 +9729,7 @@
           {
             "in": "query",
             "name": "offset",
+            "required": false,
             "schema": {
               "type": "integer",
               "minimum": 0,
@@ -9740,6 +9741,7 @@
             "in": "query",
             "name": "sortBy",
             "description": "Field that records should be sorted by",
+            "required": false,
             "schema": {
               "type": "string",
               "enum": [

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -6117,6 +6117,7 @@ paths:
           description: The non-zero number of tasks to return
         - in: query
           name: offset
+          required: false
           schema:
             type: integer
             minimum: 0
@@ -6125,6 +6126,7 @@ paths:
         - in: query
           name: sortBy
           description: Field that records should be sorted by
+          required: false
           schema:
             type: string
             enum:

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -6116,6 +6116,20 @@ paths:
             default: 100
           description: The non-zero number of tasks to return
         - in: query
+          name: offset
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+          description: The number of records to skip
+        - in: query
+          name: sortBy
+          description: Field that records should be sorted by
+          schema:
+            type: string
+            enum:
+              - name
+        - in: query
           name: type
           description: 'Type of task, unset by default.'
           required: false

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -10268,6 +10268,20 @@ paths:
           maximum: 500
           minimum: -1
           type: integer
+      - description: The number of records to skip
+        in: query
+        name: offset
+        schema:
+          default: 0
+          minimum: 0
+          type: integer
+      - description: Field that records should be sorted by
+        in: query
+        name: sortBy
+        schema:
+          enum:
+          - name
+          type: string
       - description: Type of task, unset by default.
         in: query
         name: type

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -10271,6 +10271,7 @@ paths:
       - description: The number of records to skip
         in: query
         name: offset
+        required: false
         schema:
           default: 0
           minimum: 0
@@ -10278,6 +10279,7 @@ paths:
       - description: Field that records should be sorted by
         in: query
         name: sortBy
+        required: false
         schema:
           enum:
           - name

--- a/src/cloud/paths/tasks.yml
+++ b/src/cloud/paths/tasks.yml
@@ -48,6 +48,7 @@ get:
       description: The non-zero number of tasks to return
     - in: query
       name: offset
+      required: false
       schema:
         type: integer
         minimum: 0
@@ -56,6 +57,7 @@ get:
     - in: query
       name: sortBy
       description: Field that records should be sorted by
+      required: false
       schema:
         type: string
         enum:

--- a/src/cloud/paths/tasks.yml
+++ b/src/cloud/paths/tasks.yml
@@ -47,6 +47,20 @@ get:
         default: 100
       description: The non-zero number of tasks to return
     - in: query
+      name: offset
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
+      description: The number of records to skip
+    - in: query
+      name: sortBy
+      description: Field that records should be sorted by
+      schema:
+        type: string
+        enum:
+          - name
+    - in: query
       name: type
       description: Type of task, unset by default.
       required: false


### PR DESCRIPTION
There has been an effort to support multiple changes on the server side for support of pagination, filtering, and sorting of tasks on the server side, to get away from doing that on the client side.

This PR adds some documentation for the parameters that were added for query on the API.