### PR TITLE
feat: Add Account types to operator get accounts/orgs

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -816,6 +816,14 @@ paths:
             type: string
           required: false
           description: The partial email of any user in an account
+        - in: query
+          name: accountTypes
+          schema:
+            type: array
+            items:
+              type: string
+          required: false
+          description: A list of account types to filter on
       responses:
         '200':
           description: Account
@@ -948,6 +956,14 @@ paths:
             type: string
           required: false
           description: The partial idpe id of the org being searched
+        - in: query
+          name: accountTypes
+          schema:
+            type: array
+            items:
+              type: string
+          required: false
+          description: A list of account types to filter on
       responses:
         '200':
           description: Organization

--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -821,7 +821,7 @@ paths:
           schema:
             type: array
             items:
-              type: string
+              $ref: '#/components/schemas/AccountType'
           required: false
           description: A list of account types to filter on
       responses:
@@ -961,7 +961,7 @@ paths:
           schema:
             type: array
             items:
-              type: string
+              $ref: '#/components/schemas/AccountType'
           required: false
           description: A list of account types to filter on
       responses:

--- a/src/unity/paths/operator_accounts.yml
+++ b/src/unity/paths/operator_accounts.yml
@@ -12,6 +12,14 @@ get:
         type: string
       required: false
       description: The partial email of any user in an account
+    - in: query
+      name: accountTypes
+      schema:
+        type: array
+        items:
+          type: string
+      required: false
+      description: A list of account types to filter on
   responses:
     '200':
       description: Account

--- a/src/unity/paths/operator_accounts.yml
+++ b/src/unity/paths/operator_accounts.yml
@@ -17,7 +17,7 @@ get:
       schema:
         type: array
         items:
-          type: string
+          $ref: '../schemas/AccountType.yml'
       required: false
       description: A list of account types to filter on
   responses:

--- a/src/unity/paths/operator_orgs.yml
+++ b/src/unity/paths/operator_orgs.yml
@@ -17,7 +17,7 @@ get:
       schema:
         type: array
         items:
-          type: string
+          $ref: '../schemas/AccountType.yml'
       required: false
       description: A list of account types to filter on
   responses:

--- a/src/unity/paths/operator_orgs.yml
+++ b/src/unity/paths/operator_orgs.yml
@@ -5,13 +5,21 @@ get:
     - Operators
   summary: Get the list of orgs by search term
   parameters:
-    - $ref: "../../common/parameters/TraceSpan.yml"
+    - $ref: '../../common/parameters/TraceSpan.yml'
     - in: query
       name: query
       schema:
         type: string
       required: false
       description: The partial idpe id of the org being searched
+    - in: query
+      name: accountTypes
+      schema:
+        type: array
+        items:
+          type: string
+      required: false
+      description: A list of account types to filter on
   responses:
     '200':
       description: Organization


### PR DESCRIPTION
In influxdata/ui#4218, I'm adding a dropdown to filter accounts by type in the operator UI. To support this change, the Quartz APIs for getting accounts and orgs for the operator UI has been updated to take an optional parameter of `accountTypes`, which is a list of available types given from the UI.