### PR TITLE
✨ Add `users` to create OEM Org endpoint

### DIFF
--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -11100,6 +11100,13 @@
           },
           "description": {
             "type": "string"
+          },
+          "users": {
+            "type": "array",
+            "description": "An optional list of email address's to be invited to the organization",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "required": [

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -7030,6 +7030,11 @@ components:
           type: string
         description:
           type: string
+        users:
+          type: array
+          description: An optional list of email address's to be invited to the organization
+          items:
+            type: string
       required:
         - name
     PatchOrganizationRequest:

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -5936,6 +5936,11 @@ components:
           type: string
         description:
           type: string
+        users:
+          type: array
+          description: An optional list of email address's to be invited to the organization
+          items:
+            type: string
       required:
         - name
     PatchOrganizationRequest:

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -13855,6 +13855,13 @@
           },
           "description": {
             "type": "string"
+          },
+          "users": {
+            "type": "array",
+            "description": "An optional list of email address's to be invited to the organization",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "required": [

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -9003,6 +9003,11 @@ components:
           type: string
         description:
           type: string
+        users:
+          type: array
+          description: An optional list of email address's to be invited to the organization
+          items:
+            type: string
       required:
         - name
     PatchOrganizationRequest:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -3236,6 +3236,11 @@ components:
           type: string
         name:
           type: string
+        users:
+          description: An optional list of email address's to be invited to the organization
+          items:
+            type: string
+          type: array
       required:
       - name
       type: object

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -3066,6 +3066,11 @@ components:
           type: string
         name:
           type: string
+        users:
+          description: An optional list of email address's to be invited to the organization
+          items:
+            type: string
+          type: array
       required:
       - name
       type: object

--- a/src/common/schemas/PostOrganizationRequest.yml
+++ b/src/common/schemas/PostOrganizationRequest.yml
@@ -4,4 +4,9 @@ properties:
     type: string
   description:
     type: string
+  users:
+    type: array
+    description: An optional list of email address's to be invited to the organization
+    items:
+      type: string
 required: [name]


### PR DESCRIPTION
This adds an optional list of user's emails to the OEM Post Organization request body.