### PR TITLE
✨ Add Users to OEM Org Endpoint

### DIFF
--- a/contracts/priv/quartz-oem.yml
+++ b/contracts/priv/quartz-oem.yml
@@ -181,6 +181,51 @@ paths:
         default:
           description: Unexpected error
           $ref: '#/components/responses/ServerError'
+  '/orgs/{orgId}/users':
+    post:
+      operationId: PostUsersToOrg
+      tags:
+        - Users
+      summary: Update the limits of an organization
+      parameters:
+        - in: path
+          name: orgID
+          schema:
+            type: string
+          required: true
+          description: The ID of the organization
+      requestBody:
+        description: A list of email address's to be invited to the organization
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              description: A list of email address's to be invited to the organization
+              items:
+                type: string
+      responses:
+        '200':
+          description: The email address's invited to the organization
+          content:
+            application/json:
+              schema:
+                type: array
+                description: A list of email address's invited to the organization
+                items:
+                  type: string
+        '400':
+          description: Invalid request
+          $ref: '#/components/responses/ServerError'
+        '401':
+          description: Unauthorized bearer token
+          $ref: '#/components/responses/ServerError'
+        '404':
+          description: Organization not found
+          $ref: '#/components/responses/ServerError'
+        default:
+          description: Unexpected error
+          $ref: '#/components/responses/ServerError'
 components:
   securitySchemes:
     bearerAuth:

--- a/contracts/priv/quartz-oem.yml
+++ b/contracts/priv/quartz-oem.yml
@@ -186,7 +186,7 @@ paths:
       operationId: PostUsersToOrg
       tags:
         - Users
-      summary: Update the limits of an organization
+      summary: Add users to an organization
       parameters:
         - in: path
           name: orgID

--- a/src/quartz-oem.yml
+++ b/src/quartz-oem.yml
@@ -1,4 +1,4 @@
-openapi: "3.0.0"
+openapi: '3.0.0'
 info:
   title: QuartzPublicAPI
   version: 0.1.0
@@ -7,12 +7,14 @@ servers:
 security:
   - bearerAuth: []
 paths:
-  "/orgs":
-    $ref: "./quartz/paths/orgs.yml"
-  "/orgs/{orgID}":
-    $ref: "./quartz/paths/org.yml"
-  "/orgs/{orgID}/limits":
-    $ref: "./quartz/paths/orgLimits.yml"
+  '/orgs':
+    $ref: './quartz/paths/orgs.yml'
+  '/orgs/{orgID}':
+    $ref: './quartz/paths/org.yml'
+  '/orgs/{orgID}/limits':
+    $ref: './quartz/paths/orgLimits.yml'
+  '/orgs/{orgId}/users':
+    $ref: './quartz/paths/orgUsers.yml'
 components:
   securitySchemes:
     bearerAuth:
@@ -20,40 +22,39 @@ components:
       scheme: bearer
   schemas:
     BucketLimits:
-      $ref: "./quartz/schemas/BucketLimits.yml"
+      $ref: './quartz/schemas/BucketLimits.yml'
     CheckLimits:
-      $ref: "./quartz/schemas/CheckLimits.yml"
+      $ref: './quartz/schemas/CheckLimits.yml'
     DashboardLimits:
-      $ref: "./quartz/schemas/DashboardLimits.yml"
+      $ref: './quartz/schemas/DashboardLimits.yml'
     Error:
-      $ref: "./common/schemas/Error.yml"
+      $ref: './common/schemas/Error.yml'
     Limit:
-      $ref: "./quartz/schemas/Limit.yml"
+      $ref: './quartz/schemas/Limit.yml'
     NotificationEndpointLimits:
-      $ref: "./quartz/schemas/NotificationEndpointLimits.yml"
+      $ref: './quartz/schemas/NotificationEndpointLimits.yml'
     NotificationRuleLimits:
-      $ref: "./quartz/schemas/NotificationRuleLimits.yml"
+      $ref: './quartz/schemas/NotificationRuleLimits.yml'
     OrganizationRequest:
-      $ref: "./quartz/schemas/OrganizationRequest.yml"
+      $ref: './quartz/schemas/OrganizationRequest.yml'
     OrganizationWithToken:
-      $ref: "./quartz/schemas/OrganizationWithToken.yml"
+      $ref: './quartz/schemas/OrganizationWithToken.yml'
     Organization:
-      $ref: "./quartz/schemas/Organization.yml"
+      $ref: './quartz/schemas/Organization.yml'
     Organizations:
-      $ref: "./quartz/schemas/Organizations.yml"
+      $ref: './quartz/schemas/Organizations.yml'
     OrgLimits:
-      $ref: "./quartz/schemas/OrgLimits.yml"
+      $ref: './quartz/schemas/OrgLimits.yml'
     RateLimits:
-      $ref: "./quartz/schemas/RateLimits.yml"
+      $ref: './quartz/schemas/RateLimits.yml'
     RestrictedLimit:
-      $ref: "./quartz/schemas/RestrictedLimit.yml"
+      $ref: './quartz/schemas/RestrictedLimit.yml'
     TaskLimits:
-      $ref: "./quartz/schemas/TaskLimits.yml"
+      $ref: './quartz/schemas/TaskLimits.yml'
     Unlimited:
-      $ref: "./quartz/schemas/Unlimited.yml"
+      $ref: './quartz/schemas/Unlimited.yml'
   responses:
     NoContent:
-      $ref: "./common/responses/NoContent.yml"
+      $ref: './common/responses/NoContent.yml'
     ServerError:
-      $ref: "./common/responses/ServerError.yml"
-
+      $ref: './common/responses/ServerError.yml'

--- a/src/quartz/paths/orgUsers.yml
+++ b/src/quartz/paths/orgUsers.yml
@@ -1,0 +1,44 @@
+post:
+  operationId: PostUsersToOrg
+  tags:
+    - Users
+  summary: Update the limits of an organization
+  parameters:
+    - in: path
+      name: orgID
+      schema:
+        type: string
+      required: true
+      description: The ID of the organization
+  requestBody:
+    description: A list of email address's to be invited to the organization
+    required: true
+    content:
+      application/json:
+        schema:
+          type: array
+          description: A list of email address's to be invited to the organization
+          items:
+            type: string
+  responses:
+    '200':
+      description: The email address's invited to the organization
+      content:
+        application/json:
+          schema:
+            type: array
+            description: A list of email address's invited to the organization
+            items:
+              type: string
+    '400':
+      description: Invalid request
+      $ref: '../../common/responses/ServerError.yml'
+    '401':
+      description: Unauthorized bearer token
+      $ref: '../../common/responses/ServerError.yml'
+    '404':
+      description: Organization not found
+      $ref: '../../common/responses/ServerError.yml'
+    default:
+      description: Unexpected error
+      $ref: '../../common/responses/ServerError.yml'

--- a/src/quartz/paths/orgUsers.yml
+++ b/src/quartz/paths/orgUsers.yml
@@ -2,7 +2,7 @@ post:
   operationId: PostUsersToOrg
   tags:
     - Users
-  summary: Update the limits of an organization
+  summary: Add users to an organization
   parameters:
     - in: path
       name: orgID


### PR DESCRIPTION
This adds a new endpoint for adding users to an organization. `POST /api/v2/orgs/:org_id/users` will receive a list of emails as strings.