### PR TITLE
chore: added 2 options in XYGeom type

### DIFF
--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -7603,6 +7603,8 @@ components:
         - stacked
         - bar
         - monotoneX
+        - stepBefore
+        - stepAfter
     BandViewProperties:
       type: object
       required:


### PR DESCRIPTION
see ui#2651

pr adds stepbefore and stepafter in XYGeom to expose options for line graphs 