### PR TITLE
chore: add two options to xygeom

### DIFF
--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -1426,6 +1426,8 @@ paths:
                                                 - stacked
                                                 - bar
                                                 - monotoneX
+                                                - stepBefore
+                                                - stepAfter
                                             legendColorizeRows:
                                               type: boolean
                                             legendHide:

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -13568,7 +13568,9 @@
           "step",
           "stacked",
           "bar",
-          "monotoneX"
+          "monotoneX",
+          "stepBefore",
+          "stepAfter"
         ]
       },
       "BandViewProperties": {

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -8697,6 +8697,8 @@ components:
         - stacked
         - bar
         - monotoneX
+        - stepBefore
+        - stepAfter
     BandViewProperties:
       type: object
       required:

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -7603,6 +7603,8 @@ components:
         - stacked
         - bar
         - monotoneX
+        - stepBefore
+        - stepAfter
     BandViewProperties:
       type: object
       required:

--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -3544,6 +3544,8 @@ paths:
                                                 - stacked
                                                 - bar
                                                 - monotoneX
+                                                - stepBefore
+                                                - stepAfter
                                             legendColorizeRows:
                                               type: boolean
                                             legendHide:

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -16323,7 +16323,9 @@
           "step",
           "stacked",
           "bar",
-          "monotoneX"
+          "monotoneX",
+          "stepBefore",
+          "stepAfter"
         ]
       },
       "BandViewProperties": {

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -10670,6 +10670,8 @@ components:
         - stacked
         - bar
         - monotoneX
+        - stepBefore
+        - stepAfter
     BandViewProperties:
       type: object
       required:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -5708,6 +5708,8 @@ components:
       - stacked
       - bar
       - monotoneX
+      - stepBefore
+      - stepAfter
       type: string
     XYViewProperties:
       properties:

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -5879,6 +5879,8 @@ components:
       - stacked
       - bar
       - monotoneX
+      - stepBefore
+      - stepAfter
       type: string
     XYViewProperties:
       properties:

--- a/src/common/schemas/XYGeom.yml
+++ b/src/common/schemas/XYGeom.yml
@@ -1,2 +1,2 @@
   type: string
-  enum: [line, step, stacked, bar, monotoneX]
+  enum: [line, step, stacked, bar, monotoneX, stepBefore, stepAfter]


### PR DESCRIPTION
see [ui#2651](https://github.com/influxdata/ui/issues/2651)

pr adds stepbefore and stepafter in XYGeom to expose options for line graphs