### PR TITLE
chore: Remove orgId from path of org default endpoint

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -593,18 +593,11 @@ paths:
         default:
           description: Unexpected error
           $ref: '#/components/responses/ServerError'
-  '/orgs/{orgId}/default':
+  /orgs/default:
     put:
       operationId: PutDefaultOrganization
       tags:
         - Organization
-      parameters:
-        - in: path
-          name: orgId
-          schema:
-            type: string
-          required: true
-          description: The IDPE ID of the organization to set as default.
       requestBody:
         description: The organization to set as the user's default organization
         required: true

--- a/src/unity.yml
+++ b/src/unity.yml
@@ -47,7 +47,7 @@ paths:
     $ref: './unity/paths/orgs.yml'
   '/orgs/{orgId}':
     $ref: './unity/paths/orgs_orgId.yml'
-  '/orgs/{orgId}/default':
+  '/orgs/default':
     $ref: './unity/paths/organization_default.yml'
   '/orgs/{orgId}/invites':
     $ref: './unity/paths/orgs_orgId_invites.yml'

--- a/src/unity/paths/organization_default.yml
+++ b/src/unity/paths/organization_default.yml
@@ -2,13 +2,6 @@ put:
   operationId: PutDefaultOrganization
   tags:
     - Organization
-  parameters:
-    - in: path
-      name: orgId
-      schema:
-        type: string
-      required: true
-      description: The IDPE ID of the organization to set as default.
   requestBody:
     description: The organization to set as the user's default organization
     required: true


### PR DESCRIPTION
Since we are passing the organization we want to be the new default in the body, we do not need it in the path.

Verified that this does not through errors for the ui by running `make generate` in the openapi repo, and then `yarn generate-local` followed by `yarn lint` in the UI repo without issue.