### PR TITLE
feat: provision delete org endpoint

### DIFF
--- a/contracts/priv/cloud-priv.yml
+++ b/contracts/priv/cloud-priv.yml
@@ -408,6 +408,34 @@ paths:
         default:
           $ref: '#/components/responses/ServerError'
           description: Unexpected error
+  /provision/delete:
+    post:
+      operationId: PostProvisionDelete
+      tags:
+        - ProvisionDelete
+      description: 'Delete an organization, associated resources, and all users belonging only to that single organization. Idempotent.'
+      requestBody:
+        description: Organization ID to delete
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProvisionDeleteRequest'
+      responses:
+        '204':
+          description: Organization deleted
+        '400':
+          $ref: '#/components/responses/ServerError'
+          description: Organization ID not provided
+        '401':
+          $ref: '#/components/responses/ServerError'
+          description: Credentials not provided or insufficient credentials to delete an organization
+        '422':
+          $ref: '#/components/responses/ServerError'
+          description: Invalid organization ID
+        default:
+          $ref: '#/components/responses/ServerError'
+          description: Unexpected error
   /provision/user:
     put:
       operationId: PutProvisionUser
@@ -853,6 +881,14 @@ components:
         - user
         - orgID
         - role
+    ProvisionDeleteRequest:
+      type: object
+      properties:
+        orgID:
+          type: string
+          description: organization id to delete
+      required:
+        - orgID
     ProvisionUserResponse:
       type: object
       properties:

--- a/src/cloud-priv.yml
+++ b/src/cloud-priv.yml
@@ -23,9 +23,11 @@ paths:
   /orgs/{orgID}/settings:
     $ref: './cloud/paths/orgs_orgID_settings.yml'
   /setup/user:
-      $ref: './cloud/paths/setup_user.yml'
+    $ref: './cloud/paths/setup_user.yml'
   /provision:
     $ref: './cloud/paths/provision.yml'
+  /provision/delete:
+    $ref: './cloud/paths/provision_delete.yml'
   /provision/user:
     $ref: './cloud/paths/provision_user.yml'
 components:
@@ -38,6 +40,8 @@ components:
       $ref: './cloud/schemas/ProvisionRequest.yml'
     ProvisionUserRequest:
       $ref: './cloud/schemas/ProvisionUserRequest.yml'
+    ProvisionDeleteRequest:
+      $ref: './cloud/schemas/ProvisionDeleteRequest.yml'
     ProvisionUserResponse:
       $ref: './cloud/schemas/ProvisionUserResponse.yml'
     ProvisionResponse:

--- a/src/cloud/paths/provision_delete.yml
+++ b/src/cloud/paths/provision_delete.yml
@@ -1,0 +1,27 @@
+post:
+  operationId: PostProvisionDelete
+  tags:
+    - ProvisionDelete
+  description: Delete an organization, associated resources, and all users belonging only to that single organization. Idempotent.
+  requestBody:
+    description: Organization ID to delete
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/ProvisionDeleteRequest.yml'
+  responses:
+    '204':
+      description: Organization deleted
+    '400':
+      $ref: '../../common/responses/ServerError.yml'
+      description: Organization ID not provided
+    '401':
+      $ref: '../../common/responses/ServerError.yml'
+      description: Credentials not provided or insufficient credentials to delete an organization
+    '422':
+      $ref: '../../common/responses/ServerError.yml'
+      description: Invalid organization ID
+    default:
+      $ref: '../../common/responses/ServerError.yml'
+      description: Unexpected error

--- a/src/cloud/schemas/ProvisionDeleteRequest.yml
+++ b/src/cloud/schemas/ProvisionDeleteRequest.yml
@@ -1,0 +1,7 @@
+type: object
+properties:
+  orgID:
+    type: string
+    description: organization id to delete
+required:
+  - orgID


### PR DESCRIPTION
Closes https://github.com/influxdata/openapi/issues/300
See discussion here: https://github.com/influxdata/quartz/discussions/6039

Adds the API definition for the new `POST api/v2private/provision/delete` endpoint, which will be used to completely delete an organization from IDPE.