### PR TITLE
chore: deleting task runs returns 405 method not allowed in cloud

### DIFF
--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -5737,7 +5737,7 @@
         "tags": [
           "Tasks"
         ],
-        "summary": "Retrieve a single run for a task",
+        "summary": "Retrieve a single run for a task.",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -5763,7 +5763,7 @@
         ],
         "responses": {
           "200": {
-            "description": "The run record",
+            "description": "Returns the run record.",
             "content": {
               "application/json": {
                 "schema": {
@@ -5773,7 +5773,7 @@
             }
           },
           "default": {
-            "description": "Unexpected error",
+            "description": "Unexpected error.",
             "content": {
               "application/json": {
                 "schema": {
@@ -5789,7 +5789,7 @@
         "tags": [
           "Tasks"
         ],
-        "summary": "Cancel a running task",
+        "summary": "Cancel a running task.\n\n#### InfluxDB Cloud\n\n  - Doesn't support this operation.\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -5815,10 +5815,10 @@
         ],
         "responses": {
           "204": {
-            "description": "Delete has been accepted"
+            "description": "Delete has been accepted."
           },
           "405": {
-            "description": "Cancelling task runs is not supported in InfluxDB Cloud and will return a Method Not Allowed error",
+            "description": "Method not allowed.\n\n#### InfluxDB Cloud\n\n  - Cancelling task runs is not supported in InfluxDB Cloud.\n\n#### InfluxDB OSS\n\n  - Doesn't return this error.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -5828,7 +5828,7 @@
             }
           },
           "default": {
-            "description": "Unexpected error",
+            "description": "Unexpected error.",
             "content": {
               "application/json": {
                 "schema": {

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -5817,6 +5817,16 @@
           "204": {
             "description": "Delete has been accepted"
           },
+          "405": {
+            "description": "Cancelling task runs is not supported in InfluxDB Cloud and will return a Method Not Allowed error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "default": {
             "description": "Unexpected error",
             "content": {

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -3960,6 +3960,12 @@ paths:
       responses:
         '204':
           description: Delete has been accepted
+        '405':
+          description: Cancelling task runs is not supported in InfluxDB Cloud and will return a Method Not Allowed error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         default:
           description: Unexpected error
           content:

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -3910,7 +3910,7 @@ paths:
       operationId: GetTasksIDRunsID
       tags:
         - Tasks
-      summary: Retrieve a single run for a task
+      summary: Retrieve a single run for a task.
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -3927,13 +3927,13 @@ paths:
           description: The run ID.
       responses:
         '200':
-          description: The run record
+          description: Returns the run record.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Run'
         default:
-          description: Unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -3942,7 +3942,12 @@ paths:
       operationId: DeleteTasksIDRunsID
       tags:
         - Tasks
-      summary: Cancel a running task
+      summary: |
+        Cancel a running task.
+
+        #### InfluxDB Cloud
+
+          - Doesn't support this operation.
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -3959,15 +3964,24 @@ paths:
           description: The run ID.
       responses:
         '204':
-          description: Delete has been accepted
+          description: Delete has been accepted.
         '405':
-          description: Cancelling task runs is not supported in InfluxDB Cloud and will return a Method Not Allowed error
+          description: |
+            Method not allowed.
+
+            #### InfluxDB Cloud
+
+              - Cancelling task runs is not supported in InfluxDB Cloud.
+
+            #### InfluxDB OSS
+
+              - Doesn't return this error.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
         default:
-          description: Unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -3777,7 +3777,7 @@ paths:
       operationId: GetTasksIDRunsID
       tags:
         - Tasks
-      summary: Retrieve a single run for a task
+      summary: Retrieve a single run for a task.
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -3794,13 +3794,13 @@ paths:
           description: The run ID.
       responses:
         '200':
-          description: The run record
+          description: Returns the run record.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Run'
         default:
-          description: Unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -3809,7 +3809,12 @@ paths:
       operationId: DeleteTasksIDRunsID
       tags:
         - Tasks
-      summary: Cancel a running task
+      summary: |
+        Cancel a running task.
+
+        #### InfluxDB Cloud
+
+          - Doesn't support this operation.
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -3826,15 +3831,24 @@ paths:
           description: The run ID.
       responses:
         '204':
-          description: Delete has been accepted
+          description: Delete has been accepted.
         '405':
-          description: Cancelling task runs is not supported in InfluxDB Cloud and will return a Method Not Allowed error
+          description: |
+            Method not allowed.
+
+            #### InfluxDB Cloud
+
+              - Cancelling task runs is not supported in InfluxDB Cloud.
+
+            #### InfluxDB OSS
+
+              - Doesn't return this error.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
         default:
-          description: Unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -3827,6 +3827,12 @@ paths:
       responses:
         '204':
           description: Delete has been accepted
+        '405':
+          description: Cancelling task runs is not supported in InfluxDB Cloud and will return a Method Not Allowed error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         default:
           description: Unexpected error
           content:

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -5741,7 +5741,7 @@
         "tags": [
           "Tasks"
         ],
-        "summary": "Retrieve a single run for a task",
+        "summary": "Retrieve a single run for a task.",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -5767,7 +5767,7 @@
         ],
         "responses": {
           "200": {
-            "description": "The run record",
+            "description": "Returns the run record.",
             "content": {
               "application/json": {
                 "schema": {
@@ -5777,7 +5777,7 @@
             }
           },
           "default": {
-            "description": "Unexpected error",
+            "description": "Unexpected error.",
             "content": {
               "application/json": {
                 "schema": {
@@ -5793,7 +5793,7 @@
         "tags": [
           "Tasks"
         ],
-        "summary": "Cancel a running task",
+        "summary": "Cancel a running task.\n\n#### InfluxDB Cloud\n\n  - Doesn't support this operation.\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -5819,10 +5819,10 @@
         ],
         "responses": {
           "204": {
-            "description": "Delete has been accepted"
+            "description": "Delete has been accepted."
           },
           "405": {
-            "description": "Cancelling task runs is not supported in InfluxDB Cloud and will return a Method Not Allowed error",
+            "description": "Method not allowed.\n\n#### InfluxDB Cloud\n\n  - Cancelling task runs is not supported in InfluxDB Cloud.\n\n#### InfluxDB OSS\n\n  - Doesn't return this error.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -5832,7 +5832,7 @@
             }
           },
           "default": {
-            "description": "Unexpected error",
+            "description": "Unexpected error.",
             "content": {
               "application/json": {
                 "schema": {

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -5821,6 +5821,16 @@
           "204": {
             "description": "Delete has been accepted"
           },
+          "405": {
+            "description": "Cancelling task runs is not supported in InfluxDB Cloud and will return a Method Not Allowed error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "default": {
             "description": "Unexpected error",
             "content": {

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -3966,6 +3966,12 @@ paths:
       responses:
         '204':
           description: Delete has been accepted
+        '405':
+          description: Cancelling task runs is not supported in InfluxDB Cloud and will return a Method Not Allowed error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         default:
           description: Unexpected error
           content:

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -3916,7 +3916,7 @@ paths:
       operationId: GetTasksIDRunsID
       tags:
         - Tasks
-      summary: Retrieve a single run for a task
+      summary: Retrieve a single run for a task.
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -3933,13 +3933,13 @@ paths:
           description: The run ID.
       responses:
         '200':
-          description: The run record
+          description: Returns the run record.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Run'
         default:
-          description: Unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -3948,7 +3948,12 @@ paths:
       operationId: DeleteTasksIDRunsID
       tags:
         - Tasks
-      summary: Cancel a running task
+      summary: |
+        Cancel a running task.
+
+        #### InfluxDB Cloud
+
+          - Doesn't support this operation.
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -3965,15 +3970,24 @@ paths:
           description: The run ID.
       responses:
         '204':
-          description: Delete has been accepted
+          description: Delete has been accepted.
         '405':
-          description: Cancelling task runs is not supported in InfluxDB Cloud and will return a Method Not Allowed error
+          description: |
+            Method not allowed.
+
+            #### InfluxDB Cloud
+
+              - Cancelling task runs is not supported in InfluxDB Cloud.
+
+            #### InfluxDB OSS
+
+              - Doesn't return this error.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
         default:
-          description: Unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -11001,6 +11001,13 @@ paths:
       responses:
         "204":
           description: Delete has been accepted
+        "405":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Cancelling task runs is not supported in InfluxDB Cloud and
+            will return a Method Not Allowed error
         default:
           content:
             application/json:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -11000,21 +11000,34 @@ paths:
           type: string
       responses:
         "204":
-          description: Delete has been accepted
+          description: Delete has been accepted.
         "405":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-          description: Cancelling task runs is not supported in InfluxDB Cloud and
-            will return a Method Not Allowed error
+          description: |
+            Method not allowed.
+
+            #### InfluxDB Cloud
+
+              - Cancelling task runs is not supported in InfluxDB Cloud.
+
+            #### InfluxDB OSS
+
+              - Doesn't return this error.
         default:
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-          description: Unexpected error
-      summary: Cancel a running task
+          description: Unexpected error.
+      summary: |
+        Cancel a running task.
+
+        #### InfluxDB Cloud
+
+          - Doesn't support this operation.
       tags:
       - Tasks
     get:
@@ -11039,14 +11052,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Run'
-          description: The run record
+          description: Returns the run record.
         default:
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-          description: Unexpected error
-      summary: Retrieve a single run for a task
+          description: Unexpected error.
+      summary: Retrieve a single run for a task.
       tags:
       - Tasks
   /api/v2/tasks/{taskID}/runs/{runID}/logs:

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -12968,21 +12968,34 @@ paths:
           type: string
       responses:
         "204":
-          description: Delete has been accepted
+          description: Delete has been accepted.
         "405":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-          description: Cancelling task runs is not supported in InfluxDB Cloud and
-            will return a Method Not Allowed error
+          description: |
+            Method not allowed.
+
+            #### InfluxDB Cloud
+
+              - Cancelling task runs is not supported in InfluxDB Cloud.
+
+            #### InfluxDB OSS
+
+              - Doesn't return this error.
         default:
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-          description: Unexpected error
-      summary: Cancel a running task
+          description: Unexpected error.
+      summary: |
+        Cancel a running task.
+
+        #### InfluxDB Cloud
+
+          - Doesn't support this operation.
       tags:
       - Tasks
     get:
@@ -13007,14 +13020,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Run'
-          description: The run record
+          description: Returns the run record.
         default:
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-          description: Unexpected error
-      summary: Retrieve a single run for a task
+          description: Unexpected error.
+      summary: Retrieve a single run for a task.
       tags:
       - Tasks
   /api/v2/tasks/{taskID}/runs/{runID}/logs:

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -12969,6 +12969,13 @@ paths:
       responses:
         "204":
           description: Delete has been accepted
+        "405":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Cancelling task runs is not supported in InfluxDB Cloud and
+            will return a Method Not Allowed error
         default:
           content:
             application/json:

--- a/src/common/paths/tasks_taskID_runs_runID.yml
+++ b/src/common/paths/tasks_taskID_runs_runID.yml
@@ -2,7 +2,7 @@ get:
   operationId: GetTasksIDRunsID
   tags:
     - Tasks
-  summary: Retrieve a single run for a task
+  summary: Retrieve a single run for a task.
   parameters:
     - $ref: "../parameters/TraceSpan.yml"
     - in: path
@@ -19,13 +19,13 @@ get:
       description: The run ID.
   responses:
     "200":
-      description: The run record
+      description: Returns the run record.
       content:
         application/json:
           schema:
             $ref: "../schemas/Run.yml"
     default:
-      description: Unexpected error
+      description: Unexpected error.
       content:
         application/json:
           schema:
@@ -34,7 +34,12 @@ delete:
   operationId: DeleteTasksIDRunsID
   tags:
     - Tasks
-  summary: Cancel a running task
+  summary: |
+    Cancel a running task.
+
+    #### InfluxDB Cloud
+
+      - Doesn't support this operation.
   parameters:
     - $ref: "../parameters/TraceSpan.yml"
     - in: path
@@ -51,15 +56,24 @@ delete:
       description: The run ID.
   responses:
     "204":
-      description: Delete has been accepted
+      description: Delete has been accepted.
     "405":
-      description: Cancelling task runs is not supported in InfluxDB Cloud and will return a Method Not Allowed error
+      description: |
+        Method not allowed.
+
+        #### InfluxDB Cloud
+
+          - Cancelling task runs is not supported in InfluxDB Cloud.
+
+        #### InfluxDB OSS
+
+          - Doesn't return this error.
       content:
         application/json:
           schema:
             $ref: "../schemas/Error.yml"
     default:
-      description: Unexpected error
+      description: Unexpected error.
       content:
         application/json:
           schema:

--- a/src/common/paths/tasks_taskID_runs_runID.yml
+++ b/src/common/paths/tasks_taskID_runs_runID.yml
@@ -52,6 +52,12 @@ delete:
   responses:
     "204":
       description: Delete has been accepted
+    "405":
+      description: Cancelling task runs is not supported in InfluxDB Cloud and will return a Method Not Allowed error
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/Error.yml"
     default:
       description: Unexpected error
       content:


### PR DESCRIPTION
Changing the contract to communicate that cancelling task runs will not be allowed in Cloud once https://github.com/influxdata/idpe/issues/14307 is complete.