### PR TITLE
Fix missing OSS Authorizations component

### DIFF
--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -1102,15 +1102,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  links:
-                    readOnly: true
-                    $ref: '#/paths/~1dashboards/get/responses/200/content/application~1json/schema/properties/links'
-                  authorizations:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Authorization'
+                $ref: '#/components/schemas/Authorizations'
         default:
           description: Unexpected error
           $ref: '#/paths/~1config/get/responses/401'
@@ -4866,6 +4858,16 @@ components:
                 user:
                   readOnly: true
                   $ref: '#/components/schemas/ScraperTargetResponse/allOf/1/properties/links/properties/self'
+    Authorizations:
+      type: object
+      properties:
+        links:
+          readOnly: true
+          $ref: '#/paths/~1dashboards/get/responses/200/content/application~1json/schema/properties/links'
+        authorizations:
+          type: array
+          items:
+            $ref: '#/components/schemas/Authorization'
     AuthorizationPostRequest:
       required:
         - orgID

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -9357,19 +9357,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "links": {
-                      "readOnly": true,
-                      "$ref": "#/components/schemas/Links"
-                    },
-                    "authorizations": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Authorization"
-                      }
-                    }
-                  }
+                  "$ref": "#/components/schemas/Authorizations"
                 }
               }
             }
@@ -19838,6 +19826,21 @@
             }
           }
         ]
+      },
+      "Authorizations": {
+        "type": "object",
+        "properties": {
+          "links": {
+            "readOnly": true,
+            "$ref": "#/components/schemas/Links"
+          },
+          "authorizations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Authorization"
+            }
+          }
+        }
       },
       "AuthorizationPostRequest": {
         "required": [

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -6427,15 +6427,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  links:
-                    readOnly: true
-                    $ref: '#/components/schemas/Links'
-                  authorizations:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Authorization'
+                $ref: '#/components/schemas/Authorizations'
         default:
           description: Unexpected error
           $ref: '#/components/responses/GeneralServerError'
@@ -13332,6 +13324,16 @@ components:
                 user:
                   readOnly: true
                   $ref: '#/components/schemas/Link'
+    Authorizations:
+      type: object
+      properties:
+        links:
+          readOnly: true
+          $ref: '#/components/schemas/Links'
+        authorizations:
+          type: array
+          items:
+            $ref: '#/components/schemas/Authorization'
     AuthorizationPostRequest:
       required:
         - orgID

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -270,6 +270,16 @@ components:
           - active
           - inactive
           type: string
+    Authorizations:
+      properties:
+        authorizations:
+          items:
+            $ref: '#/components/schemas/Authorization'
+          type: array
+        links:
+          $ref: '#/components/schemas/Links'
+          readOnly: true
+      type: object
     Axes:
       description: The viewport for a View's visualizations
       properties:
@@ -6233,15 +6243,7 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  authorizations:
-                    items:
-                      $ref: '#/components/schemas/Authorization'
-                    type: array
-                  links:
-                    $ref: '#/components/schemas/Links'
-                    readOnly: true
-                type: object
+                $ref: '#/components/schemas/Authorizations'
           description: A list of authorizations
         default:
           $ref: '#/components/responses/GeneralServerError'

--- a/src/oss.yml
+++ b/src/oss.yml
@@ -113,6 +113,8 @@ components:
   #REF_COMMON_SCHEMAS
     Authorization:
       $ref: "./common/schemas/Authorization.yml"
+    Authorizations:
+      $ref: "./common/schemas/Authorizations.yml"
     AuthorizationPostRequest:
       $ref: "./common/schemas/AuthorizationPostRequest.yml"
     Permission:


### PR DESCRIPTION
When moving components over to legacy in #330, I mistakenly left out `Authorizations` in `oss.yml` (which would be a breaking change). This PR adds that component back.