### PR TITLE
Add missing properties to InfluxQL JSON response

### DIFF
--- a/contracts/legacy.yml
+++ b/contracts/legacy.yml
@@ -387,9 +387,18 @@ components:
           type: array
           items:
             type: object
+            oneOf:
+              - required:
+                  - statement_id
+                  - error
+              - required:
+                  - statement_id
+                  - series
             properties:
               statement_id:
                 type: integer
+              error:
+                type: string
               series:
                 type: array
                 items:

--- a/contracts/legacy.yml
+++ b/contracts/legacy.yml
@@ -399,6 +399,12 @@ components:
                   properties:
                     name:
                       type: string
+                    tags:
+                      type: object
+                      additionalProperties:
+                        type: string
+                    partial:
+                      type: boolean
                     columns:
                       type: array
                       items:

--- a/contracts/legacy.yml
+++ b/contracts/legacy.yml
@@ -387,13 +387,6 @@ components:
           type: array
           items:
             type: object
-            oneOf:
-              - required:
-                  - statement_id
-                  - error
-              - required:
-                  - statement_id
-                  - series
             properties:
               statement_id:
                 type: integer

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -2025,7 +2025,16 @@ components:
       properties:
         results:
           items:
+            oneOf:
+            - required:
+              - statement_id
+              - error
+            - required:
+              - statement_id
+              - series
             properties:
+              error:
+                type: string
               series:
                 items:
                   properties:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -2037,6 +2037,12 @@ components:
                       type: array
                     name:
                       type: string
+                    partial:
+                      type: boolean
+                    tags:
+                      additionalProperties:
+                        type: string
+                      type: object
                     values:
                       items:
                         items: {}

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -2025,13 +2025,6 @@ components:
       properties:
         results:
           items:
-            oneOf:
-            - required:
-              - statement_id
-              - error
-            - required:
-              - statement_id
-              - series
             properties:
               error:
                 type: string

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -2080,13 +2080,6 @@ components:
       properties:
         results:
           items:
-            oneOf:
-            - required:
-              - statement_id
-              - error
-            - required:
-              - statement_id
-              - series
             properties:
               error:
                 type: string

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -2080,7 +2080,16 @@ components:
       properties:
         results:
           items:
+            oneOf:
+            - required:
+              - statement_id
+              - error
+            - required:
+              - statement_id
+              - series
             properties:
+              error:
+                type: string
               series:
                 items:
                   properties:

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -2092,6 +2092,12 @@ components:
                       type: array
                     name:
                       type: string
+                    partial:
+                      type: boolean
+                    tags:
+                      additionalProperties:
+                        type: string
+                      type: object
                     values:
                       items:
                         items: {}

--- a/contracts/swaggerV1Compat.yml
+++ b/contracts/swaggerV1Compat.yml
@@ -262,6 +262,12 @@ components:
                   properties:
                     name:
                       type: string
+                    tags:
+                      type: object
+                      additionalProperties:
+                        type: string
+                    partial:
+                      type: boolean
                     columns:
                       type: array
                       items:

--- a/contracts/swaggerV1Compat.yml
+++ b/contracts/swaggerV1Compat.yml
@@ -245,11 +245,16 @@ components:
       properties:
         results:
           type: array
+          oneOf:
+            - required: [statement_id, error]
+            - required: [statement_id, series]
           items:
             type: object
             properties:
               statement_id:
                 type: integer
+              error:
+                type: string
               series:
                 type: array
                 items:

--- a/src/legacy/schemas/InfluxqlJsonResponse.yml
+++ b/src/legacy/schemas/InfluxqlJsonResponse.yml
@@ -5,9 +5,14 @@ properties:
     type: array
     items:
       type: object
+      oneOf:
+      - required: [statement_id, error]
+      - required: [statement_id, series]
       properties:
         statement_id:
           type: integer
+        error:
+          type: string
         series:
           type: array
           items:

--- a/src/legacy/schemas/InfluxqlJsonResponse.yml
+++ b/src/legacy/schemas/InfluxqlJsonResponse.yml
@@ -17,6 +17,12 @@ properties:
             properties:
               name:
                 type: string
+              tags:
+                type: object
+                additionalProperties:
+                  type: string
+              partial:
+                type: boolean
               columns:
                 type: array
                 items:

--- a/src/legacy/schemas/InfluxqlJsonResponse.yml
+++ b/src/legacy/schemas/InfluxqlJsonResponse.yml
@@ -5,9 +5,6 @@ properties:
     type: array
     items:
       type: object
-      oneOf:
-      - required: [statement_id, error]
-      - required: [statement_id, series]
       properties:
         statement_id:
           type: integer


### PR DESCRIPTION
The `error` field is missing for legacy query JSON responses, and `tags` and `partial` missing from the series response schema.