### PR TITLE
Update the OEM api /orgs endpoint to reflect Quartz

### DIFF
--- a/contracts/priv/quartz-oem.yml
+++ b/contracts/priv/quartz-oem.yml
@@ -410,10 +410,6 @@ components:
               description: Authentication token to manage the organization and its resources in IDPE
               readOnly: true
               type: string
-            userName:
-              description: Email of the org's user
-              readOnly: true
-              type: string
             links:
               description: Links to the IDPE resources for this organization
               readOnly: true
@@ -431,7 +427,7 @@ components:
           description: URL for talking to a specific cluster
           readOnly: true
           type: string
-        orgName:
+        name:
           description: name of the organization
           type: string
         region:

--- a/contracts/priv/quartz-oem.yml
+++ b/contracts/priv/quartz-oem.yml
@@ -104,7 +104,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Organization'
+                type: string
         '401':
           description: Unauthorized bearer token
           $ref: '#/components/responses/ServerError'
@@ -410,6 +410,10 @@ components:
               description: Authentication token to manage the organization and its resources in IDPE
               readOnly: true
               type: string
+            userName:
+              description: Email of the org's user
+              readOnly: true
+              type: string
             links:
               description: Links to the IDPE resources for this organization
               readOnly: true
@@ -426,6 +430,9 @@ components:
         apiUrl:
           description: URL for talking to a specific cluster
           readOnly: true
+          type: string
+        orgName:
+          description: name of the organization
           type: string
         region:
           description: name of the region within the cloud provider

--- a/src/quartz/paths/org.yml
+++ b/src/quartz/paths/org.yml
@@ -44,7 +44,7 @@ delete:
       content:
         application/json:
           schema:
-            $ref: "../schemas/Organization.yml"
+            type: string
     "401":
       description: Unauthorized bearer token
       $ref: "../../common/responses/ServerError.yml"

--- a/src/quartz/schemas/Organization.yml
+++ b/src/quartz/schemas/Organization.yml
@@ -8,7 +8,7 @@ properties:
     description: URL for talking to a specific cluster
     readOnly: true
     type: string
-  orgName:
+  name:
     description: name of the organization
     type: string
   region:

--- a/src/quartz/schemas/Organization.yml
+++ b/src/quartz/schemas/Organization.yml
@@ -8,6 +8,9 @@ properties:
     description: URL for talking to a specific cluster
     readOnly: true
     type: string
+  orgName:
+    description: name of the organization
+    type: string
   region:
     description: name of the region within the cloud provider
     type: string

--- a/src/quartz/schemas/OrganizationWithToken.yml
+++ b/src/quartz/schemas/OrganizationWithToken.yml
@@ -6,6 +6,10 @@ allOf:
         description: Authentication token to manage the organization and its resources in IDPE
         readOnly: true
         type: string
+      userName:
+        description: Email of the org's user
+        readOnly: true
+        type: string
       links:
         description: Links to the IDPE resources for this organization
         readOnly: true

--- a/src/quartz/schemas/OrganizationWithToken.yml
+++ b/src/quartz/schemas/OrganizationWithToken.yml
@@ -6,10 +6,6 @@ allOf:
         description: Authentication token to manage the organization and its resources in IDPE
         readOnly: true
         type: string
-      userName:
-        description: Email of the org's user
-        readOnly: true
-        type: string
       links:
         description: Links to the IDPE resources for this organization
         readOnly: true


### PR DESCRIPTION
We added the name field to the OEM orgs response in Quarz for the Multi-Org effort, and this updates the spec to match that. This also updates the spec for the other /orgs endpoints since they didn't match the existing behavior.