### PR TITLE
feat: Add isUpgradeable field to Quartz identity endpoint

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -1877,6 +1877,9 @@ components:
         accountCreatedAt:
           type: string
           description: an ISO8601 timestamp that indicates when the account was created
+        isUpgradeable:
+          type: boolean
+          description: whether or not the account can be upgraded to payg
         paygCreditStartDate:
           type: string
           nullable: true

--- a/src/unity/schemas/IdentityAccount.yml
+++ b/src/unity/schemas/IdentityAccount.yml
@@ -10,6 +10,9 @@ properties:
   accountCreatedAt:
     type: string
     description: an ISO8601 timestamp that indicates when the account was created
+  isUpgradeable:
+    type: boolean
+    description: whether or not the account can be upgraded to payg
   paygCreditStartDate:
     type: string
     nullable: true


### PR DESCRIPTION
This adds an `isUpgradeable` field to the Quartz identity endpoint spec.