### PR TITLE
fix: add 401 status code to idpe /me

### DIFF
--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -6217,6 +6217,9 @@
               }
             }
           },
+          "401": {
+            "$ref": "#/components/responses/AuthorizationError"
+          },
           "500": {
             "$ref": "#/components/responses/InternalServerError"
           },

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -4215,6 +4215,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/UserResponse'
+        '401':
+          $ref: '#/components/responses/AuthorizationError'
         '500':
           $ref: '#/components/responses/InternalServerError'
         default:

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -4082,6 +4082,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/UserResponse'
+        '401':
+          $ref: '#/components/responses/AuthorizationError'
         '500':
           $ref: '#/components/responses/InternalServerError'
         default:

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -6221,6 +6221,9 @@
               }
             }
           },
+          "401": {
+            "$ref": "#/components/responses/AuthorizationError"
+          },
           "500": {
             "$ref": "#/components/responses/InternalServerError"
           },

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -4221,6 +4221,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/UserResponse'
+        '401':
+          $ref: '#/components/responses/AuthorizationError'
         '500':
           $ref: '#/components/responses/InternalServerError'
         default:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -8507,6 +8507,8 @@ paths:
                 $ref: '#/components/schemas/UserResponse'
           description: Success. The response body contains the currently authenticated
             user.
+        "401":
+          $ref: '#/components/responses/AuthorizationError'
         "500":
           $ref: '#/components/responses/InternalServerError'
         default:

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -9325,6 +9325,8 @@ paths:
                 $ref: '#/components/schemas/UserResponse'
           description: Success. The response body contains the currently authenticated
             user.
+        "401":
+          $ref: '#/components/responses/AuthorizationError'
         "500":
           $ref: '#/components/responses/InternalServerError'
         default:

--- a/src/common/paths/me.yml
+++ b/src/common/paths/me.yml
@@ -4,17 +4,17 @@ get:
     - Users
   summary: Retrieve the currently authenticated user
   parameters:
-    - $ref: '../parameters/TraceSpan.yml'
+    - $ref: "../parameters/TraceSpan.yml"
   responses:
-    '200':
+    "200":
       description: Success. The response body contains the currently authenticated user.
       content:
         application/json:
           schema:
-            $ref: '../schemas/UserResponse.yml'
-    '401':
-      $ref: '../responses/AuthorizationError.yml'
-    '500':
-      $ref: '../responses/InternalServerError.yml'
+            $ref: "../schemas/UserResponse.yml"
+    "401":
+      $ref: "../responses/AuthorizationError.yml"
+    "500":
+      $ref: "../responses/InternalServerError.yml"
     default:
-      $ref: '../responses/ServerError.yml'
+      $ref: "../responses/ServerError.yml"

--- a/src/common/paths/me.yml
+++ b/src/common/paths/me.yml
@@ -4,15 +4,17 @@ get:
     - Users
   summary: Retrieve the currently authenticated user
   parameters:
-    - $ref: "../parameters/TraceSpan.yml"
+    - $ref: '../parameters/TraceSpan.yml'
   responses:
-    "200":
+    '200':
       description: Success. The response body contains the currently authenticated user.
       content:
         application/json:
           schema:
-            $ref: "../schemas/UserResponse.yml"
-    "500":
-      $ref: "../responses/InternalServerError.yml"
+            $ref: '../schemas/UserResponse.yml'
+    '401':
+      $ref: '../responses/AuthorizationError.yml'
+    '500':
+      $ref: '../responses/InternalServerError.yml'
     default:
-      $ref: "../responses/ServerError.yml"
+      $ref: '../responses/ServerError.yml'


### PR DESCRIPTION
IDPE's `/me` endpoint (`GetMe`) is able return a `401` status, but it is not reflected in the current path for `/me` (which reflects status codes `200` or `500` only). 

/me endpoint returning a `401` unauthorized status code
![Screen Shot 2022-06-22 at 4 45 16 PM](https://user-images.githubusercontent.com/91283923/175133462-aa0f5aeb-dede-43d3-a2c1-7c4bc574d5b1.png)

This adds `401` as a valid status code  so that we can acknowledge it in the API layer of the UI.