### PR TITLE
fix: over cardinality status code

### DIFF
--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -1741,7 +1741,7 @@
             }
           },
           "429": {
-            "description": "Too many requests.\n\n#### InfluxDB Cloud\n\n  - Returns this error if a **read** or **write** request exceeds your\n    plan's [adjustable service quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#adjustable-service-quotas)\n    or if a **delete** request exceeds the maximum\n    [global limit](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#global-limits).\n  - Returns `Retry-After` header that describes when to try the write again.\n\n#### InfluxDB OSS\n\n  - Doesn't return this error.\n",
+            "description": "Too many requests.\n\n#### InfluxDB Cloud\n\n  - Returns this error if a **read** or **write** request exceeds your plan's [adjustable service quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#adjustable-service-quotas)\n    or if a **delete** request exceeds the maximum [global limit](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#global-limits).\n  - For rate limits that reset automatically, returns a `Retry-After` header that describes when to try the write again.\n  - For limits that can't reset (for example, **cardinality limit**), doesn't return a `Retry-After` header.\n\n  Rates (data-in (writes), queries (reads), and deletes) accrue within a fixed five-minute window.\n  Once a rate limit is exceeded, InfluxDB returns an error response until the current five-minute window resets.\n\n#### InfluxDB OSS\n\n  - Doesn't return this error.\n",
             "headers": {
               "Retry-After": {
                 "description": "Non-negative decimal integer indicating seconds to wait before retrying the request.",
@@ -1756,7 +1756,7 @@
             "$ref": "#/components/responses/InternalServerError"
           },
           "503": {
-            "description": "Service unavailable.\n\n#### InfluxDB Cloud\n\n  - Returns this error if series cardinality exceeds your plan's\n    [adjustable service quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#adjustable-service-quotas).\n    See [how to resolve high series cardinality]({{% INFLUXDB_DOCS_URL %}}/write-data/best-practices/resolve-high-cardinality/).\n\n#### InfluxDB OSS\n\n  - Returns this error if\n    the server is temporarily unavailable to accept writes.\n  - Returns `Retry-After` header that describes when to try the write again.\n",
+            "description": "Service unavailable.\n\n- Returns this error if\n  the server is temporarily unavailable to accept writes.\n- Returns a `Retry-After` header that describes when to try the write again.\n",
             "headers": {
               "Retry-After": {
                 "description": "Non-negative decimal integer indicating seconds to wait before retrying the request.",

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -1304,11 +1304,13 @@ paths:
 
             #### InfluxDB Cloud
 
-              - Returns this error if a **read** or **write** request exceeds your
-                plan's [adjustable service quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#adjustable-service-quotas)
-                or if a **delete** request exceeds the maximum
-                [global limit](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#global-limits).
-              - Returns `Retry-After` header that describes when to try the write again.
+              - Returns this error if a **read** or **write** request exceeds your plan's [adjustable service quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#adjustable-service-quotas)
+                or if a **delete** request exceeds the maximum [global limit](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#global-limits).
+              - For rate limits that reset automatically, returns a `Retry-After` header that describes when to try the write again.
+              - For limits that can't reset (for example, **cardinality limit**), doesn't return a `Retry-After` header.
+
+              Rates (data-in (writes), queries (reads), and deletes) accrue within a fixed five-minute window.
+              Once a rate limit is exceeded, InfluxDB returns an error response until the current five-minute window resets.
 
             #### InfluxDB OSS
 
@@ -1325,17 +1327,9 @@ paths:
           description: |
             Service unavailable.
 
-            #### InfluxDB Cloud
-
-              - Returns this error if series cardinality exceeds your plan's
-                [adjustable service quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#adjustable-service-quotas).
-                See [how to resolve high series cardinality](https://docs.influxdata.com/influxdb/cloud/write-data/best-practices/resolve-high-cardinality/).
-
-            #### InfluxDB OSS
-
-              - Returns this error if
-                the server is temporarily unavailable to accept writes.
-              - Returns `Retry-After` header that describes when to try the write again.
+            - Returns this error if
+              the server is temporarily unavailable to accept writes.
+            - Returns a `Retry-After` header that describes when to try the write again.
           headers:
             Retry-After:
               description: Non-negative decimal integer indicating seconds to wait before retrying the request.

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -1171,11 +1171,13 @@ paths:
 
             #### InfluxDB Cloud
 
-              - Returns this error if a **read** or **write** request exceeds your
-                plan's [adjustable service quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#adjustable-service-quotas)
-                or if a **delete** request exceeds the maximum
-                [global limit](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#global-limits).
-              - Returns `Retry-After` header that describes when to try the write again.
+              - Returns this error if a **read** or **write** request exceeds your plan's [adjustable service quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#adjustable-service-quotas)
+                or if a **delete** request exceeds the maximum [global limit](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#global-limits).
+              - For rate limits that reset automatically, returns a `Retry-After` header that describes when to try the write again.
+              - For limits that can't reset (for example, **cardinality limit**), doesn't return a `Retry-After` header.
+
+              Rates (data-in (writes), queries (reads), and deletes) accrue within a fixed five-minute window.
+              Once a rate limit is exceeded, InfluxDB returns an error response until the current five-minute window resets.
 
             #### InfluxDB OSS
 
@@ -1192,17 +1194,9 @@ paths:
           description: |
             Service unavailable.
 
-            #### InfluxDB Cloud
-
-              - Returns this error if series cardinality exceeds your plan's
-                [adjustable service quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#adjustable-service-quotas).
-                See [how to resolve high series cardinality](https://docs.influxdata.com/influxdb/v2.3/write-data/best-practices/resolve-high-cardinality/).
-
-            #### InfluxDB OSS
-
-              - Returns this error if
-                the server is temporarily unavailable to accept writes.
-              - Returns `Retry-After` header that describes when to try the write again.
+            - Returns this error if
+              the server is temporarily unavailable to accept writes.
+            - Returns a `Retry-After` header that describes when to try the write again.
           headers:
             Retry-After:
               description: Non-negative decimal integer indicating seconds to wait before retrying the request.

--- a/contracts/legacy.yml
+++ b/contracts/legacy.yml
@@ -67,7 +67,7 @@ paths:
           name: rp
           description: |
             The retention policy to query data from.
-            This is mapped to an InfluxDB [bucket]({{% INFLUXDB_DOCS_URL %}}/influxdb/v2.2/reference/glossary/#bucket).
+            This is mapped to an InfluxDB [bucket]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#bucket).
             For more information, see [Database and retention policy mapping]({{% INFLUXDB_DOCS_URL %}}/api/influxdb-1x/dbrp/).
           schema:
             type: string

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -1745,7 +1745,7 @@
             }
           },
           "429": {
-            "description": "Too many requests.\n\n#### InfluxDB Cloud\n\n  - Returns this error if a **read** or **write** request exceeds your\n    plan's [adjustable service quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#adjustable-service-quotas)\n    or if a **delete** request exceeds the maximum\n    [global limit](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#global-limits).\n  - Returns `Retry-After` header that describes when to try the write again.\n\n#### InfluxDB OSS\n\n  - Doesn't return this error.\n",
+            "description": "Too many requests.\n\n#### InfluxDB Cloud\n\n  - Returns this error if a **read** or **write** request exceeds your plan's [adjustable service quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#adjustable-service-quotas)\n    or if a **delete** request exceeds the maximum [global limit](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#global-limits).\n  - For rate limits that reset automatically, returns a `Retry-After` header that describes when to try the write again.\n  - For limits that can't reset (for example, **cardinality limit**), doesn't return a `Retry-After` header.\n\n  Rates (data-in (writes), queries (reads), and deletes) accrue within a fixed five-minute window.\n  Once a rate limit is exceeded, InfluxDB returns an error response until the current five-minute window resets.\n\n#### InfluxDB OSS\n\n  - Doesn't return this error.\n",
             "headers": {
               "Retry-After": {
                 "description": "Non-negative decimal integer indicating seconds to wait before retrying the request.",
@@ -1760,7 +1760,7 @@
             "$ref": "#/components/responses/InternalServerError"
           },
           "503": {
-            "description": "Service unavailable.\n\n#### InfluxDB Cloud\n\n  - Returns this error if series cardinality exceeds your plan's\n    [adjustable service quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#adjustable-service-quotas).\n    See [how to resolve high series cardinality]({{% INFLUXDB_DOCS_URL %}}/write-data/best-practices/resolve-high-cardinality/).\n\n#### InfluxDB OSS\n\n  - Returns this error if\n    the server is temporarily unavailable to accept writes.\n  - Returns `Retry-After` header that describes when to try the write again.\n",
+            "description": "Service unavailable.\n\n- Returns this error if\n  the server is temporarily unavailable to accept writes.\n- Returns a `Retry-After` header that describes when to try the write again.\n",
             "headers": {
               "Retry-After": {
                 "description": "Non-negative decimal integer indicating seconds to wait before retrying the request.",

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -1310,11 +1310,13 @@ paths:
 
             #### InfluxDB Cloud
 
-              - Returns this error if a **read** or **write** request exceeds your
-                plan's [adjustable service quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#adjustable-service-quotas)
-                or if a **delete** request exceeds the maximum
-                [global limit](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#global-limits).
-              - Returns `Retry-After` header that describes when to try the write again.
+              - Returns this error if a **read** or **write** request exceeds your plan's [adjustable service quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#adjustable-service-quotas)
+                or if a **delete** request exceeds the maximum [global limit](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#global-limits).
+              - For rate limits that reset automatically, returns a `Retry-After` header that describes when to try the write again.
+              - For limits that can't reset (for example, **cardinality limit**), doesn't return a `Retry-After` header.
+
+              Rates (data-in (writes), queries (reads), and deletes) accrue within a fixed five-minute window.
+              Once a rate limit is exceeded, InfluxDB returns an error response until the current five-minute window resets.
 
             #### InfluxDB OSS
 
@@ -1331,17 +1333,9 @@ paths:
           description: |
             Service unavailable.
 
-            #### InfluxDB Cloud
-
-              - Returns this error if series cardinality exceeds your plan's
-                [adjustable service quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#adjustable-service-quotas).
-                See [how to resolve high series cardinality](https://docs.influxdata.com/influxdb/v2.3/write-data/best-practices/resolve-high-cardinality/).
-
-            #### InfluxDB OSS
-
-              - Returns this error if
-                the server is temporarily unavailable to accept writes.
-              - Returns `Retry-After` header that describes when to try the write again.
+            - Returns this error if
+              the server is temporarily unavailable to accept writes.
+            - Returns a `Retry-After` header that describes when to try the write again.
           headers:
             Retry-After:
               description: Non-negative decimal integer indicating seconds to wait before retrying the request.

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -12486,11 +12486,13 @@ paths:
 
             #### InfluxDB Cloud
 
-              - Returns this error if a **read** or **write** request exceeds your
-                plan's [adjustable service quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#adjustable-service-quotas)
-                or if a **delete** request exceeds the maximum
-                [global limit](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#global-limits).
-              - Returns `Retry-After` header that describes when to try the write again.
+              - Returns this error if a **read** or **write** request exceeds your plan's [adjustable service quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#adjustable-service-quotas)
+                or if a **delete** request exceeds the maximum [global limit](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#global-limits).
+              - For rate limits that reset automatically, returns a `Retry-After` header that describes when to try the write again.
+              - For limits that can't reset (for example, **cardinality limit**), doesn't return a `Retry-After` header.
+
+              Rates (data-in (writes), queries (reads), and deletes) accrue within a fixed five-minute window.
+              Once a rate limit is exceeded, InfluxDB returns an error response until the current five-minute window resets.
 
             #### InfluxDB OSS
 
@@ -12508,17 +12510,9 @@ paths:
           description: |
             Service unavailable.
 
-            #### InfluxDB Cloud
-
-              - Returns this error if series cardinality exceeds your plan's
-                [adjustable service quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#adjustable-service-quotas).
-                See [how to resolve high series cardinality](https://docs.influxdata.com/influxdb/cloud/write-data/best-practices/resolve-high-cardinality/).
-
-            #### InfluxDB OSS
-
-              - Returns this error if
-                the server is temporarily unavailable to accept writes.
-              - Returns `Retry-After` header that describes when to try the write again.
+            - Returns this error if
+              the server is temporarily unavailable to accept writes.
+            - Returns a `Retry-After` header that describes when to try the write again.
           headers:
             Retry-After:
               description: Non-negative decimal integer indicating seconds to wait
@@ -12786,7 +12780,7 @@ paths:
           type: string
       - description: |
           The retention policy to query data from.
-          This is mapped to an InfluxDB [bucket]({{% INFLUXDB_DOCS_URL %}}/influxdb/v2.2/reference/glossary/#bucket).
+          This is mapped to an InfluxDB [bucket]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#bucket).
           For more information, see [Database and retention policy mapping]({{% INFLUXDB_DOCS_URL %}}/api/influxdb-1x/dbrp/).
         in: query
         name: rp

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -14257,11 +14257,13 @@ paths:
 
             #### InfluxDB Cloud
 
-              - Returns this error if a **read** or **write** request exceeds your
-                plan's [adjustable service quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#adjustable-service-quotas)
-                or if a **delete** request exceeds the maximum
-                [global limit](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#global-limits).
-              - Returns `Retry-After` header that describes when to try the write again.
+              - Returns this error if a **read** or **write** request exceeds your plan's [adjustable service quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#adjustable-service-quotas)
+                or if a **delete** request exceeds the maximum [global limit](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#global-limits).
+              - For rate limits that reset automatically, returns a `Retry-After` header that describes when to try the write again.
+              - For limits that can't reset (for example, **cardinality limit**), doesn't return a `Retry-After` header.
+
+              Rates (data-in (writes), queries (reads), and deletes) accrue within a fixed five-minute window.
+              Once a rate limit is exceeded, InfluxDB returns an error response until the current five-minute window resets.
 
             #### InfluxDB OSS
 
@@ -14279,17 +14281,9 @@ paths:
           description: |
             Service unavailable.
 
-            #### InfluxDB Cloud
-
-              - Returns this error if series cardinality exceeds your plan's
-                [adjustable service quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#adjustable-service-quotas).
-                See [how to resolve high series cardinality](https://docs.influxdata.com/influxdb/v2.3/write-data/best-practices/resolve-high-cardinality/).
-
-            #### InfluxDB OSS
-
-              - Returns this error if
-                the server is temporarily unavailable to accept writes.
-              - Returns `Retry-After` header that describes when to try the write again.
+            - Returns this error if
+              the server is temporarily unavailable to accept writes.
+            - Returns a `Retry-After` header that describes when to try the write again.
           headers:
             Retry-After:
               description: Non-negative decimal integer indicating seconds to wait
@@ -14557,7 +14551,7 @@ paths:
           type: string
       - description: |
           The retention policy to query data from.
-          This is mapped to an InfluxDB [bucket]({{% INFLUXDB_DOCS_URL %}}/influxdb/v2.2/reference/glossary/#bucket).
+          This is mapped to an InfluxDB [bucket]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#bucket).
           For more information, see [Database and retention policy mapping]({{% INFLUXDB_DOCS_URL %}}/api/influxdb-1x/dbrp/).
         in: query
         name: rp

--- a/src/common/paths/write.yml
+++ b/src/common/paths/write.yml
@@ -264,11 +264,13 @@ post:
 
         #### InfluxDB Cloud
 
-          - Returns this error if a **read** or **write** request exceeds your
-            plan's [adjustable service quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#adjustable-service-quotas)
-            or if a **delete** request exceeds the maximum
-            [global limit](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#global-limits).
-          - Returns `Retry-After` header that describes when to try the write again.
+          - Returns this error if a **read** or **write** request exceeds your plan's [adjustable service quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#adjustable-service-quotas)
+            or if a **delete** request exceeds the maximum [global limit](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#global-limits).
+          - For rate limits that reset automatically, returns a `Retry-After` header that describes when to try the write again.
+          - For limits that can't reset (for example, **cardinality limit**), doesn't return a `Retry-After` header.
+
+          Rates (data-in (writes), queries (reads), and deletes) accrue within a fixed five-minute window.
+          Once a rate limit is exceeded, InfluxDB returns an error response until the current five-minute window resets.
 
         #### InfluxDB OSS
 
@@ -283,17 +285,9 @@ post:
       description: |
         Service unavailable.
 
-        #### InfluxDB Cloud
-
-          - Returns this error if series cardinality exceeds your plan's
-            [adjustable service quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/#adjustable-service-quotas).
-            See [how to resolve high series cardinality]({{% INFLUXDB_DOCS_URL %}}/write-data/best-practices/resolve-high-cardinality/).
-
-        #### InfluxDB OSS
-
-          - Returns this error if
-            the server is temporarily unavailable to accept writes.
-          - Returns `Retry-After` header that describes when to try the write again.
+        - Returns this error if
+          the server is temporarily unavailable to accept writes.
+        - Returns a `Retry-After` header that describes when to try the write again.
       headers:
         Retry-After:
           description: Non-negative decimal integer indicating seconds to wait before retrying the request.

--- a/src/legacy/paths/query.yml
+++ b/src/legacy/paths/query.yml
@@ -59,7 +59,7 @@ get:
       name: rp
       description: |
         The retention policy to query data from.
-        This is mapped to an InfluxDB [bucket]({{% INFLUXDB_DOCS_URL %}}/influxdb/v2.2/reference/glossary/#bucket).
+        This is mapped to an InfluxDB [bucket]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#bucket).
         For more information, see [Database and retention policy mapping]({{% INFLUXDB_DOCS_URL %}}/api/influxdb-1x/dbrp/).
       schema:
         type: string


### PR DESCRIPTION
- If request exceeds cardinality limit, Cloud returns 429 instead of 503.

https://github.com/influxdata/DAR/issues/304