### PR TITLE
chore: remove provision/user/delete task transfer error

### DIFF
--- a/contracts/priv/cloud-priv.yml
+++ b/contracts/priv/cloud-priv.yml
@@ -525,9 +525,6 @@ paths:
         '422':
           $ref: '#/components/responses/ServerError'
           description: Unprocessable entry. Examples include invalid IDs or new owner ID being the same as current owner ID.
-        '501':
-          $ref: '#/components/responses/ServerError'
-          description: TaskOption of "transfer" is currently not implemented.
         default:
           $ref: '#/components/responses/ServerError'
           description: Unexpected error

--- a/src/cloud/paths/provision_user_delete.yml
+++ b/src/cloud/paths/provision_user_delete.yml
@@ -22,9 +22,6 @@ post:
     '422':
       $ref: '../../common/responses/ServerError.yml'
       description: Unprocessable entry. Examples include invalid IDs or new owner ID being the same as current owner ID.
-    '501':
-      $ref: '../../common/responses/ServerError.yml'
-      description: TaskOption of "transfer" is currently not implemented.
     default:
       $ref: '../../common/responses/ServerError.yml'
       description: Unexpected error


### PR DESCRIPTION
The `TaskOption` of `"transfer"` _is_ actually now implemented. I forgot to remove this from the spec when I did https://github.com/influxdata/idpe/pull/14909, so this PR takes care of that oversight.