### PR TITLE
docs: Flatten taggings.

### DIFF
--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -2611,6 +2611,7 @@ paths:
     get:
       operationId: GetTasks
       tags:
+        - Data I/O endpoints
         - Tasks
       summary: List all tasks
       parameters:
@@ -2738,6 +2739,7 @@ paths:
     post:
       operationId: PostTasks
       tags:
+        - Data I/O endpoints
         - Tasks
       summary: Create a new task
       parameters:

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -68,37 +68,11 @@
       ]
     },
     {
-      "name": "Data I/O endpoints",
+      "name": "Popular endpoints",
       "tags": [
-        "Write",
-        "Query",
-        "Delete",
-        "Invokable Scripts",
-        "Tasks"
-      ]
-    },
-    {
-      "name": "Resource endpoints",
-      "tags": [
-        "Buckets",
-        "Dashboards",
-        "Tasks",
-        "Resources"
-      ]
-    },
-    {
-      "name": "Security and access endpoints",
-      "tags": [
-        "Authorizations",
-        "Organizations",
-        "Users"
-      ]
-    },
-    {
-      "name": "System information endpoints",
-      "tags": [
-        "Ping",
-        "Routes"
+        "Data I/O endpoints",
+        "Security and access endpoints",
+        "System information endpoints"
       ]
     },
     {
@@ -213,7 +187,8 @@
           }
         ],
         "tags": [
-          "Ping"
+          "Ping",
+          "System information endpoints"
         ],
         "responses": {
           "204": {
@@ -273,7 +248,8 @@
         "operationId": "GetRoutes",
         "summary": "List all top level routes",
         "tags": [
-          "Routes"
+          "Routes",
+          "System information endpoints"
         ],
         "parameters": [
           {
@@ -1576,6 +1552,7 @@
       "post": {
         "operationId": "PostWrite",
         "tags": [
+          "Data I/O endpoints",
           "Write"
         ],
         "summary": "Write data",
@@ -1781,6 +1758,7 @@
       "post": {
         "operationId": "PostDelete",
         "tags": [
+          "Data I/O endpoints",
           "Delete"
         ],
         "summary": "Delete data",
@@ -3340,6 +3318,7 @@
       "post": {
         "operationId": "PostQuery",
         "tags": [
+          "Data I/O endpoints",
           "Query"
         ],
         "summary": "Query data",
@@ -4205,7 +4184,8 @@
       "get": {
         "operationId": "GetOrgs",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "Security and access endpoints"
         ],
         "summary": "List all organizations",
         "parameters": [
@@ -4319,7 +4299,8 @@
       "get": {
         "operationId": "GetOrgsID",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "Security and access endpoints"
         ],
         "summary": "Retrieve an organization",
         "parameters": [
@@ -4464,7 +4445,8 @@
       "get": {
         "operationId": "GetOrgsIDSecrets",
         "tags": [
-          "Secrets"
+          "Secrets",
+          "Security and access endpoints"
         ],
         "summary": "List all secret keys for an organization",
         "parameters": [
@@ -4556,7 +4538,8 @@
       "get": {
         "operationId": "GetOrgsIDMembers",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "Security and access endpoints"
         ],
         "summary": "List all members of an organization",
         "parameters": [
@@ -4665,7 +4648,8 @@
       "delete": {
         "operationId": "DeleteOrgsIDMembersID",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "Security and access endpoints"
         ],
         "summary": "Remove a member from an organization",
         "parameters": [
@@ -4712,7 +4696,8 @@
       "get": {
         "operationId": "GetOrgsIDOwners",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "Security and access endpoints"
         ],
         "summary": "List all owners of an organization",
         "parameters": [
@@ -4821,7 +4806,8 @@
       "delete": {
         "operationId": "DeleteOrgsIDOwnersID",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "Security and access endpoints"
         ],
         "summary": "Remove an owner from an organization",
         "parameters": [
@@ -4869,7 +4855,8 @@
         "deprecated": true,
         "operationId": "PostOrgsIDSecrets",
         "tags": [
-          "Secrets"
+          "Secrets",
+          "Security and access endpoints"
         ],
         "summary": "Delete secrets from an organization",
         "parameters": [
@@ -4918,7 +4905,8 @@
       "delete": {
         "operationId": "DeleteOrgsIDSecretsID",
         "tags": [
-          "Secrets"
+          "Secrets",
+          "Security and access endpoints"
         ],
         "summary": "Delete a secret from an organization",
         "parameters": [
@@ -4959,7 +4947,8 @@
       "get": {
         "operationId": "GetResources",
         "tags": [
-          "Resources"
+          "Resources",
+          "System information endpoints"
         ],
         "summary": "List all known resources",
         "parameters": [
@@ -5483,6 +5472,7 @@
       "get": {
         "operationId": "GetTasksID",
         "tags": [
+          "Data I/O endpoints",
           "Tasks"
         ],
         "summary": "Retrieve a task",
@@ -5700,6 +5690,7 @@
       "post": {
         "operationId": "PostTasksIDRuns",
         "tags": [
+          "Data I/O endpoints",
           "Tasks"
         ],
         "summary": "Manually start a task run, overriding the current schedule",
@@ -6588,6 +6579,7 @@
       "post": {
         "operationId": "PostUsersIDPassword",
         "tags": [
+          "Security and access endpoints",
           "Users"
         ],
         "summary": "Update a password",
@@ -9580,6 +9572,7 @@
       "get": {
         "operationId": "GetTasks",
         "tags": [
+          "Data I/O endpoints",
           "Tasks"
         ],
         "summary": "List all tasks",
@@ -9714,6 +9707,7 @@
       "post": {
         "operationId": "PostTasks",
         "tags": [
+          "Data I/O endpoints",
           "Tasks"
         ],
         "summary": "Create a new task",

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -116,28 +116,11 @@ x-tagGroups:
       - Authentication
       - Headers
       - Response codes
-  - name: Data I/O endpoints
+  - name: Popular endpoints
     tags:
-      - Write
-      - Query
-      - Delete
-      - Invokable Scripts
-      - Tasks
-  - name: Resource endpoints
-    tags:
-      - Buckets
-      - Dashboards
-      - Tasks
-      - Resources
-  - name: Security and access endpoints
-    tags:
-      - Authorizations
-      - Organizations
-      - Users
-  - name: System information endpoints
-    tags:
-      - Ping
-      - Routes
+      - Data I/O endpoints
+      - Security and access endpoints
+      - System information endpoints
   - name: All endpoints
     tags: []
 paths:
@@ -206,6 +189,7 @@ paths:
         - url: ''
       tags:
         - Ping
+        - System information endpoints
       responses:
         '204':
           description: |
@@ -248,6 +232,7 @@ paths:
       summary: List all top level routes
       tags:
         - Routes
+        - System information endpoints
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
       responses:
@@ -1043,6 +1028,7 @@ paths:
     post:
       operationId: PostWrite
       tags:
+        - Data I/O endpoints
         - Write
       summary: Write data
       description: |
@@ -1345,6 +1331,7 @@ paths:
     post:
       operationId: PostDelete
       tags:
+        - Data I/O endpoints
         - Delete
       summary: Delete data
       description: |
@@ -2397,6 +2384,7 @@ paths:
     post:
       operationId: PostQuery
       tags:
+        - Data I/O endpoints
         - Query
       summary: Query data
       description: |
@@ -2984,6 +2972,7 @@ paths:
       operationId: GetOrgs
       tags:
         - Organizations
+        - Security and access endpoints
       summary: List all organizations
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3050,6 +3039,7 @@ paths:
       operationId: GetOrgsID
       tags:
         - Organizations
+        - Security and access endpoints
       summary: Retrieve an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3138,6 +3128,7 @@ paths:
       operationId: GetOrgsIDSecrets
       tags:
         - Secrets
+        - Security and access endpoints
       summary: List all secret keys for an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3194,6 +3185,7 @@ paths:
       operationId: GetOrgsIDMembers
       tags:
         - Organizations
+        - Security and access endpoints
       summary: List all members of an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3260,6 +3252,7 @@ paths:
       operationId: DeleteOrgsIDMembersID
       tags:
         - Organizations
+        - Security and access endpoints
       summary: Remove a member from an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3289,6 +3282,7 @@ paths:
       operationId: GetOrgsIDOwners
       tags:
         - Organizations
+        - Security and access endpoints
       summary: List all owners of an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3355,6 +3349,7 @@ paths:
       operationId: DeleteOrgsIDOwnersID
       tags:
         - Organizations
+        - Security and access endpoints
       summary: Remove an owner from an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3385,6 +3380,7 @@ paths:
       operationId: PostOrgsIDSecrets
       tags:
         - Secrets
+        - Security and access endpoints
       summary: Delete secrets from an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3415,6 +3411,7 @@ paths:
       operationId: DeleteOrgsIDSecretsID
       tags:
         - Secrets
+        - Security and access endpoints
       summary: Delete a secret from an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3441,6 +3438,7 @@ paths:
       operationId: GetResources
       tags:
         - Resources
+        - System information endpoints
       summary: List all known resources
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3766,6 +3764,7 @@ paths:
     get:
       operationId: GetTasksID
       tags:
+        - Data I/O endpoints
         - Tasks
       summary: Retrieve a task
       parameters:
@@ -3901,6 +3900,7 @@ paths:
     post:
       operationId: PostTasksIDRuns
       tags:
+        - Data I/O endpoints
         - Tasks
       summary: 'Manually start a task run, overriding the current schedule'
       parameters:
@@ -4452,6 +4452,7 @@ paths:
     post:
       operationId: PostUsersIDPassword
       tags:
+        - Security and access endpoints
         - Users
       summary: Update a password
       security:
@@ -6300,6 +6301,7 @@ paths:
     get:
       operationId: GetTasks
       tags:
+        - Data I/O endpoints
         - Tasks
       summary: List all tasks
       parameters:
@@ -6387,6 +6389,7 @@ paths:
     post:
       operationId: PostTasks
       tags:
+        - Data I/O endpoints
         - Tasks
       summary: Create a new task
       parameters:

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -70,6 +70,7 @@ paths:
         - url: ''
       tags:
         - Ping
+        - System information endpoints
       responses:
         '204':
           description: |
@@ -112,6 +113,7 @@ paths:
       summary: List all top level routes
       tags:
         - Routes
+        - System information endpoints
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
       responses:
@@ -907,6 +909,7 @@ paths:
     post:
       operationId: PostWrite
       tags:
+        - Data I/O endpoints
         - Write
       summary: Write data
       description: |
@@ -1209,6 +1212,7 @@ paths:
     post:
       operationId: PostDelete
       tags:
+        - Data I/O endpoints
         - Delete
       summary: Delete data
       description: |
@@ -2261,6 +2265,7 @@ paths:
     post:
       operationId: PostQuery
       tags:
+        - Data I/O endpoints
         - Query
       summary: Query data
       description: |
@@ -2848,6 +2853,7 @@ paths:
       operationId: GetOrgs
       tags:
         - Organizations
+        - Security and access endpoints
       summary: List all organizations
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -2914,6 +2920,7 @@ paths:
       operationId: GetOrgsID
       tags:
         - Organizations
+        - Security and access endpoints
       summary: Retrieve an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3002,6 +3009,7 @@ paths:
       operationId: GetOrgsIDSecrets
       tags:
         - Secrets
+        - Security and access endpoints
       summary: List all secret keys for an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3058,6 +3066,7 @@ paths:
       operationId: GetOrgsIDMembers
       tags:
         - Organizations
+        - Security and access endpoints
       summary: List all members of an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3124,6 +3133,7 @@ paths:
       operationId: DeleteOrgsIDMembersID
       tags:
         - Organizations
+        - Security and access endpoints
       summary: Remove a member from an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3153,6 +3163,7 @@ paths:
       operationId: GetOrgsIDOwners
       tags:
         - Organizations
+        - Security and access endpoints
       summary: List all owners of an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3219,6 +3230,7 @@ paths:
       operationId: DeleteOrgsIDOwnersID
       tags:
         - Organizations
+        - Security and access endpoints
       summary: Remove an owner from an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3249,6 +3261,7 @@ paths:
       operationId: PostOrgsIDSecrets
       tags:
         - Secrets
+        - Security and access endpoints
       summary: Delete secrets from an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3279,6 +3292,7 @@ paths:
       operationId: DeleteOrgsIDSecretsID
       tags:
         - Secrets
+        - Security and access endpoints
       summary: Delete a secret from an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3305,6 +3319,7 @@ paths:
       operationId: GetResources
       tags:
         - Resources
+        - System information endpoints
       summary: List all known resources
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3630,6 +3645,7 @@ paths:
     get:
       operationId: GetTasksID
       tags:
+        - Data I/O endpoints
         - Tasks
       summary: Retrieve a task
       parameters:
@@ -3765,6 +3781,7 @@ paths:
     post:
       operationId: PostTasksIDRuns
       tags:
+        - Data I/O endpoints
         - Tasks
       summary: 'Manually start a task run, overriding the current schedule'
       parameters:
@@ -4316,6 +4333,7 @@ paths:
     post:
       operationId: PostUsersIDPassword
       tags:
+        - Security and access endpoints
         - Users
       summary: Update a password
       security:

--- a/contracts/invocable-scripts.yml
+++ b/contracts/invocable-scripts.yml
@@ -20,6 +20,7 @@ paths:
     get:
       operationId: GetScripts
       tags:
+        - Data I/O endpoints
         - Invokable Scripts
       summary: List scripts
       parameters:
@@ -71,6 +72,7 @@ paths:
     get:
       operationId: GetScriptsID
       tags:
+        - Data I/O endpoints
         - Invokable Scripts
       summary: Retrieve a script
       description: Uses script ID to retrieve details of an invokable script.
@@ -145,6 +147,7 @@ paths:
     post:
       operationId: PostScriptsIDInvoke
       tags:
+        - Data I/O endpoints
         - Invokable Scripts
       summary: Invoke a script
       description: Invokes a script and substitutes `params` keys referenced in the script with `params` key-values sent in the request body.

--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -12,6 +12,7 @@ paths:
       operationId: GetDebugPprofAllProfiles
       tags:
         - Debug
+        - System information endpoints
       summary: Retrieve all runtime profiles
       description: |
         Collects samples and returns reports for the following [Go runtime profiles](https://pkg.go.dev/runtime/pprof):
@@ -98,6 +99,7 @@ paths:
       operationId: GetDebugPprofAllocs
       tags:
         - Debug
+        - System information endpoints
       summary: Retrieve the memory allocations runtime profile
       description: |
         Returns a [Go runtime profile](https://pkg.go.dev/runtime/pprof) report of
@@ -183,6 +185,7 @@ paths:
       operationId: GetDebugPprofBlock
       tags:
         - Debug
+        - System information endpoints
       summary: Retrieve the block runtime profile
       description: |
         Collects samples and returns a [Go runtime profile](https://pkg.go.dev/runtime/pprof)
@@ -264,6 +267,7 @@ paths:
       operationId: GetDebugPprofCmdline
       tags:
         - Debug
+        - System information endpoints
       summary: Retrieve the command line invocation
       description: |
         Returns the command line that invoked InfluxDB.
@@ -287,6 +291,7 @@ paths:
       operationId: GetDebugPprofGoroutine
       tags:
         - Debug
+        - System information endpoints
       summary: Retrieve the goroutines runtime profile
       description: |
         Collects statistics and returns a [Go runtime profile](https://pkg.go.dev/runtime/pprof)
@@ -369,6 +374,7 @@ paths:
       operationId: GetDebugPprofHeap
       tags:
         - Debug
+        - System information endpoints
       summary: Retrieve the heap runtime profile
       description: |
         Collects statistics and returns a [Go runtime profile](https://pkg.go.dev/runtime/pprof)
@@ -473,6 +479,7 @@ paths:
       operationId: GetDebugPprofMutex
       tags:
         - Debug
+        - System information endpoints
       summary: Retrieve the mutual exclusion (mutex) runtime profile
       description: |
         Collects statistics and returns a [Go runtime profile](https://pkg.go.dev/runtime/pprof) report of
@@ -555,6 +562,7 @@ paths:
       operationId: GetDebugPprofProfile
       tags:
         - Debug
+        - System information endpoints
       summary: Retrieve the CPU runtime profile
       description: |
         Collects statistics and returns a [Go runtime profile](https://pkg.go.dev/runtime/pprof)
@@ -608,6 +616,7 @@ paths:
       operationId: GetDebugPprofThreadCreate
       tags:
         - Debug
+        - System information endpoints
       summary: Retrieve the threadcreate runtime profile
       description: |
         Collects statistics and returns a [Go runtime profile](https://pkg.go.dev/runtime/pprof)
@@ -693,6 +702,7 @@ paths:
       operationId: GetDebugPprofTrace
       tags:
         - Debug
+        - System information endpoints
       summary: Retrieve the runtime execution trace
       description: |
         Collects profile data and returns trace execution events for the current program.
@@ -738,6 +748,7 @@ paths:
       operationId: GetHealth
       tags:
         - Health
+        - System information endpoints
       summary: Retrieve the health of the instance
       description: Returns the health of the instance.
       servers:
@@ -788,6 +799,7 @@ paths:
       operationId: GetMetrics
       tags:
         - Metrics
+        - System information endpoints
       summary: Retrieve workload performance metrics
       description: |
         Returns metrics about the workload performance of an InfluxDB instance.
@@ -842,6 +854,7 @@ paths:
       operationId: GetReady
       tags:
         - Ready
+        - System information endpoints
       summary: Get the readiness of an instance at startup
       servers:
         - url: ''
@@ -883,6 +896,7 @@ paths:
     get:
       operationId: GetUsers
       tags:
+        - Security and access endpoints
         - Users
       summary: List all users
       parameters:
@@ -954,6 +968,7 @@ paths:
     get:
       operationId: GetUsersID
       tags:
+        - Security and access endpoints
         - Users
       summary: Retrieve a user
       parameters:
@@ -1073,6 +1088,7 @@ paths:
       operationId: GetAuthorizations
       tags:
         - Authorizations
+        - Security and access endpoints
       summary: List all authorizations
       parameters:
         - $ref: '#/paths/~1ready/get/parameters/0'
@@ -1138,6 +1154,7 @@ paths:
       operationId: GetAuthorizationsID
       tags:
         - Authorizations
+        - Security and access endpoints
       summary: Retrieve an authorization
       parameters:
         - $ref: '#/paths/~1ready/get/parameters/0'
@@ -2422,6 +2439,7 @@ paths:
       operationId: GetConfig
       tags:
         - Config
+        - System information endpoints
       summary: Retrieve runtime configuration
       description: |
         Returns the active runtime configuration of the InfluxDB instance.
@@ -4539,6 +4557,7 @@ paths:
     get:
       operationId: GetTasks
       tags:
+        - Data I/O endpoints
         - Tasks
       summary: List tasks
       description: |
@@ -4773,6 +4792,7 @@ paths:
     post:
       operationId: PostTasks
       tags:
+        - Data I/O endpoints
         - Tasks
       summary: Create a task
       description: |

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -68,41 +68,11 @@
       ]
     },
     {
-      "name": "Data I/O endpoints",
+      "name": "Popular endpoints",
       "tags": [
-        "Write",
-        "Query",
-        "Delete",
-        "Tasks"
-      ]
-    },
-    {
-      "name": "Resource endpoints",
-      "tags": [
-        "Buckets",
-        "Dashboards",
-        "Tasks",
-        "Resources"
-      ]
-    },
-    {
-      "name": "Security and access endpoints",
-      "tags": [
-        "Authorizations",
-        "Organizations",
-        "Users"
-      ]
-    },
-    {
-      "name": "System information endpoints",
-      "tags": [
-        "Config",
-        "Debug",
-        "Health",
-        "Metrics",
-        "Ping",
-        "Ready",
-        "Routes"
+        "Data I/O endpoints",
+        "Security and access endpoints",
+        "System information endpoints"
       ]
     },
     {
@@ -217,7 +187,8 @@
           }
         ],
         "tags": [
-          "Ping"
+          "Ping",
+          "System information endpoints"
         ],
         "responses": {
           "204": {
@@ -277,7 +248,8 @@
         "operationId": "GetRoutes",
         "summary": "List all top level routes",
         "tags": [
-          "Routes"
+          "Routes",
+          "System information endpoints"
         ],
         "parameters": [
           {
@@ -1580,6 +1552,7 @@
       "post": {
         "operationId": "PostWrite",
         "tags": [
+          "Data I/O endpoints",
           "Write"
         ],
         "summary": "Write data",
@@ -1785,6 +1758,7 @@
       "post": {
         "operationId": "PostDelete",
         "tags": [
+          "Data I/O endpoints",
           "Delete"
         ],
         "summary": "Delete data",
@@ -3344,6 +3318,7 @@
       "post": {
         "operationId": "PostQuery",
         "tags": [
+          "Data I/O endpoints",
           "Query"
         ],
         "summary": "Query data",
@@ -4209,7 +4184,8 @@
       "get": {
         "operationId": "GetOrgs",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "Security and access endpoints"
         ],
         "summary": "List all organizations",
         "parameters": [
@@ -4323,7 +4299,8 @@
       "get": {
         "operationId": "GetOrgsID",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "Security and access endpoints"
         ],
         "summary": "Retrieve an organization",
         "parameters": [
@@ -4468,7 +4445,8 @@
       "get": {
         "operationId": "GetOrgsIDSecrets",
         "tags": [
-          "Secrets"
+          "Secrets",
+          "Security and access endpoints"
         ],
         "summary": "List all secret keys for an organization",
         "parameters": [
@@ -4560,7 +4538,8 @@
       "get": {
         "operationId": "GetOrgsIDMembers",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "Security and access endpoints"
         ],
         "summary": "List all members of an organization",
         "parameters": [
@@ -4669,7 +4648,8 @@
       "delete": {
         "operationId": "DeleteOrgsIDMembersID",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "Security and access endpoints"
         ],
         "summary": "Remove a member from an organization",
         "parameters": [
@@ -4716,7 +4696,8 @@
       "get": {
         "operationId": "GetOrgsIDOwners",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "Security and access endpoints"
         ],
         "summary": "List all owners of an organization",
         "parameters": [
@@ -4825,7 +4806,8 @@
       "delete": {
         "operationId": "DeleteOrgsIDOwnersID",
         "tags": [
-          "Organizations"
+          "Organizations",
+          "Security and access endpoints"
         ],
         "summary": "Remove an owner from an organization",
         "parameters": [
@@ -4873,7 +4855,8 @@
         "deprecated": true,
         "operationId": "PostOrgsIDSecrets",
         "tags": [
-          "Secrets"
+          "Secrets",
+          "Security and access endpoints"
         ],
         "summary": "Delete secrets from an organization",
         "parameters": [
@@ -4922,7 +4905,8 @@
       "delete": {
         "operationId": "DeleteOrgsIDSecretsID",
         "tags": [
-          "Secrets"
+          "Secrets",
+          "Security and access endpoints"
         ],
         "summary": "Delete a secret from an organization",
         "parameters": [
@@ -4963,7 +4947,8 @@
       "get": {
         "operationId": "GetResources",
         "tags": [
-          "Resources"
+          "Resources",
+          "System information endpoints"
         ],
         "summary": "List all known resources",
         "parameters": [
@@ -5487,6 +5472,7 @@
       "get": {
         "operationId": "GetTasksID",
         "tags": [
+          "Data I/O endpoints",
           "Tasks"
         ],
         "summary": "Retrieve a task",
@@ -5704,6 +5690,7 @@
       "post": {
         "operationId": "PostTasksIDRuns",
         "tags": [
+          "Data I/O endpoints",
           "Tasks"
         ],
         "summary": "Manually start a task run, overriding the current schedule",
@@ -6592,6 +6579,7 @@
       "post": {
         "operationId": "PostUsersIDPassword",
         "tags": [
+          "Security and access endpoints",
           "Users"
         ],
         "summary": "Update a password",
@@ -8192,7 +8180,8 @@
       "get": {
         "operationId": "GetDebugPprofAllProfiles",
         "tags": [
-          "Debug"
+          "Debug",
+          "System information endpoints"
         ],
         "summary": "Retrieve all runtime profiles",
         "description": "Collects samples and returns reports for the following [Go runtime profiles](https://pkg.go.dev/runtime/pprof):\n\n- **allocs**: All past memory allocations\n- **block**: Stack traces that led to blocking on synchronization primitives\n- **cpu**: (Optional) Program counters sampled from the executing stack.\n  Include by passing the `cpu` query parameter with a [duration]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#duration) value.\n  Equivalent to the report from [`GET /debug/pprof/profile?seconds=NUMBER_OF_SECONDS`](#operation/GetDebugPprofProfile).\n- **goroutine**: All current goroutines\n- **heap**: Memory allocations for live objects\n- **mutex**: Holders of contended mutexes\n- **threadcreate**: Stack traces that led to the creation of new OS threads\n",
@@ -8259,7 +8248,8 @@
       "get": {
         "operationId": "GetDebugPprofAllocs",
         "tags": [
-          "Debug"
+          "Debug",
+          "System information endpoints"
         ],
         "summary": "Retrieve the memory allocations runtime profile",
         "description": "Returns a [Go runtime profile](https://pkg.go.dev/runtime/pprof) report of\nall past memory allocations.\n**allocs** is the same as the **heap** profile,\nbut changes the default [pprof](https://pkg.go.dev/runtime/pprof)\ndisplay to __-alloc_space__,\nthe total number of bytes allocated since the program began (including garbage-collected bytes).\n",
@@ -8341,7 +8331,8 @@
       "get": {
         "operationId": "GetDebugPprofBlock",
         "tags": [
-          "Debug"
+          "Debug",
+          "System information endpoints"
         ],
         "summary": "Retrieve the block runtime profile",
         "description": "Collects samples and returns a [Go runtime profile](https://pkg.go.dev/runtime/pprof)\nreport of stack traces that led to blocking on synchronization primitives.\n",
@@ -8423,7 +8414,8 @@
       "get": {
         "operationId": "GetDebugPprofCmdline",
         "tags": [
-          "Debug"
+          "Debug",
+          "System information endpoints"
         ],
         "summary": "Retrieve the command line invocation",
         "description": "Returns the command line that invoked InfluxDB.\n",
@@ -8460,7 +8452,8 @@
       "get": {
         "operationId": "GetDebugPprofGoroutine",
         "tags": [
-          "Debug"
+          "Debug",
+          "System information endpoints"
         ],
         "summary": "Retrieve the goroutines runtime profile",
         "description": "Collects statistics and returns a [Go runtime profile](https://pkg.go.dev/runtime/pprof)\nreport of all current goroutines.\n",
@@ -8542,7 +8535,8 @@
       "get": {
         "operationId": "GetDebugPprofHeap",
         "tags": [
-          "Debug"
+          "Debug",
+          "System information endpoints"
         ],
         "summary": "Retrieve the heap runtime profile",
         "description": "Collects statistics and returns a [Go runtime profile](https://pkg.go.dev/runtime/pprof)\nreport of memory allocations for live objects.\n\nTo run **garbage collection** before sampling,\npass the `gc` query parameter with a value of `1`.\n",
@@ -8643,7 +8637,8 @@
       "get": {
         "operationId": "GetDebugPprofMutex",
         "tags": [
-          "Debug"
+          "Debug",
+          "System information endpoints"
         ],
         "summary": "Retrieve the mutual exclusion (mutex) runtime profile",
         "description": "Collects statistics and returns a [Go runtime profile](https://pkg.go.dev/runtime/pprof) report of\nlock contentions.\nThe profile contains stack traces of holders of contended mutual exclusions (mutexes).\n",
@@ -8725,7 +8720,8 @@
       "get": {
         "operationId": "GetDebugPprofProfile",
         "tags": [
-          "Debug"
+          "Debug",
+          "System information endpoints"
         ],
         "summary": "Retrieve the CPU runtime profile",
         "description": "Collects statistics and returns a [Go runtime profile](https://pkg.go.dev/runtime/pprof)\nreport of program counters on the executing stack.\n",
@@ -8783,7 +8779,8 @@
       "get": {
         "operationId": "GetDebugPprofThreadCreate",
         "tags": [
-          "Debug"
+          "Debug",
+          "System information endpoints"
         ],
         "summary": "Retrieve the threadcreate runtime profile",
         "description": "Collects statistics and returns a [Go runtime profile](https://pkg.go.dev/runtime/pprof)\nreport of stack traces that led to the creation of new OS threads.\n",
@@ -8871,7 +8868,8 @@
       "get": {
         "operationId": "GetDebugPprofTrace",
         "tags": [
-          "Debug"
+          "Debug",
+          "System information endpoints"
         ],
         "summary": "Retrieve the runtime execution trace",
         "description": "Collects profile data and returns trace execution events for the current program.\n",
@@ -8928,7 +8926,8 @@
       "get": {
         "operationId": "GetHealth",
         "tags": [
-          "Health"
+          "Health",
+          "System information endpoints"
         ],
         "summary": "Retrieve the health of the instance",
         "description": "Returns the health of the instance.",
@@ -8974,7 +8973,8 @@
       "get": {
         "operationId": "GetMetrics",
         "tags": [
-          "Metrics"
+          "Metrics",
+          "System information endpoints"
         ],
         "summary": "Retrieve workload performance metrics",
         "description": "Returns metrics about the workload performance of an InfluxDB instance.\n\nUse this endpoint to get performance, resource, and usage metrics.\n\n#### Related guides\n\n- For the list of metrics categories, see [InfluxDB OSS metrics]({{% INFLUXDB_DOCS_URL %}}/reference/internals/metrics/).\n- Learn how to use InfluxDB to [scrape Prometheus metrics]({{% INFLUXDB_DOCS_URL %}}/write-data/developer-tools/scrape-prometheus-metrics/).\n- Learn how InfluxDB [parses the Prometheus exposition format]({{% INFLUXDB_DOCS_URL %}}/reference/prometheus-metrics/).\n",
@@ -9021,7 +9021,8 @@
       "get": {
         "operationId": "GetReady",
         "tags": [
-          "Ready"
+          "Ready",
+          "System information endpoints"
         ],
         "summary": "Get the readiness of an instance at startup",
         "servers": [
@@ -9056,6 +9057,7 @@
       "get": {
         "operationId": "GetUsers",
         "tags": [
+          "Security and access endpoints",
           "Users"
         ],
         "summary": "List all users",
@@ -9148,6 +9150,7 @@
       "get": {
         "operationId": "GetUsersID",
         "tags": [
+          "Security and access endpoints",
           "Users"
         ],
         "summary": "Retrieve a user",
@@ -9332,7 +9335,8 @@
       "get": {
         "operationId": "GetAuthorizations",
         "tags": [
-          "Authorizations"
+          "Authorizations",
+          "Security and access endpoints"
         ],
         "summary": "List all authorizations",
         "parameters": [
@@ -9437,7 +9441,8 @@
       "get": {
         "operationId": "GetAuthorizationsID",
         "tags": [
-          "Authorizations"
+          "Authorizations",
+          "Security and access endpoints"
         ],
         "summary": "Retrieve an authorization",
         "parameters": [
@@ -11362,7 +11367,8 @@
       "get": {
         "operationId": "GetConfig",
         "tags": [
-          "Config"
+          "Config",
+          "System information endpoints"
         ],
         "summary": "Retrieve runtime configuration",
         "description": "Returns the active runtime configuration of the InfluxDB instance.\n\nIn InfluxDB v2.2+, use this endpoint to view your active runtime configuration,\nincluding flags and environment variables.\n\n#### Related guides\n\n- [View your runtime server configuration]({{% INFLUXDB_DOCS_URL %}}/reference/config-options/#view-your-runtime-server-configuration)\n",
@@ -12035,6 +12041,7 @@
       "get": {
         "operationId": "GetTasks",
         "tags": [
+          "Data I/O endpoints",
           "Tasks"
         ],
         "summary": "List tasks",
@@ -12260,6 +12267,7 @@
       "post": {
         "operationId": "PostTasks",
         "tags": [
+          "Data I/O endpoints",
           "Tasks"
         ],
         "summary": "Create a task",

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -118,32 +118,11 @@ x-tagGroups:
       - Authentication
       - Headers
       - Response codes
-  - name: Data I/O endpoints
+  - name: Popular endpoints
     tags:
-      - Write
-      - Query
-      - Delete
-      - Tasks
-  - name: Resource endpoints
-    tags:
-      - Buckets
-      - Dashboards
-      - Tasks
-      - Resources
-  - name: Security and access endpoints
-    tags:
-      - Authorizations
-      - Organizations
-      - Users
-  - name: System information endpoints
-    tags:
-      - Config
-      - Debug
-      - Health
-      - Metrics
-      - Ping
-      - Ready
-      - Routes
+      - Data I/O endpoints
+      - Security and access endpoints
+      - System information endpoints
   - name: All endpoints
     tags: []
 paths:
@@ -212,6 +191,7 @@ paths:
         - url: ''
       tags:
         - Ping
+        - System information endpoints
       responses:
         '204':
           description: |
@@ -254,6 +234,7 @@ paths:
       summary: List all top level routes
       tags:
         - Routes
+        - System information endpoints
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
       responses:
@@ -1049,6 +1030,7 @@ paths:
     post:
       operationId: PostWrite
       tags:
+        - Data I/O endpoints
         - Write
       summary: Write data
       description: |
@@ -1351,6 +1333,7 @@ paths:
     post:
       operationId: PostDelete
       tags:
+        - Data I/O endpoints
         - Delete
       summary: Delete data
       description: |
@@ -2403,6 +2386,7 @@ paths:
     post:
       operationId: PostQuery
       tags:
+        - Data I/O endpoints
         - Query
       summary: Query data
       description: |
@@ -2990,6 +2974,7 @@ paths:
       operationId: GetOrgs
       tags:
         - Organizations
+        - Security and access endpoints
       summary: List all organizations
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3056,6 +3041,7 @@ paths:
       operationId: GetOrgsID
       tags:
         - Organizations
+        - Security and access endpoints
       summary: Retrieve an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3144,6 +3130,7 @@ paths:
       operationId: GetOrgsIDSecrets
       tags:
         - Secrets
+        - Security and access endpoints
       summary: List all secret keys for an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3200,6 +3187,7 @@ paths:
       operationId: GetOrgsIDMembers
       tags:
         - Organizations
+        - Security and access endpoints
       summary: List all members of an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3266,6 +3254,7 @@ paths:
       operationId: DeleteOrgsIDMembersID
       tags:
         - Organizations
+        - Security and access endpoints
       summary: Remove a member from an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3295,6 +3284,7 @@ paths:
       operationId: GetOrgsIDOwners
       tags:
         - Organizations
+        - Security and access endpoints
       summary: List all owners of an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3361,6 +3351,7 @@ paths:
       operationId: DeleteOrgsIDOwnersID
       tags:
         - Organizations
+        - Security and access endpoints
       summary: Remove an owner from an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3391,6 +3382,7 @@ paths:
       operationId: PostOrgsIDSecrets
       tags:
         - Secrets
+        - Security and access endpoints
       summary: Delete secrets from an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3421,6 +3413,7 @@ paths:
       operationId: DeleteOrgsIDSecretsID
       tags:
         - Secrets
+        - Security and access endpoints
       summary: Delete a secret from an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3447,6 +3440,7 @@ paths:
       operationId: GetResources
       tags:
         - Resources
+        - System information endpoints
       summary: List all known resources
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3772,6 +3766,7 @@ paths:
     get:
       operationId: GetTasksID
       tags:
+        - Data I/O endpoints
         - Tasks
       summary: Retrieve a task
       parameters:
@@ -3907,6 +3902,7 @@ paths:
     post:
       operationId: PostTasksIDRuns
       tags:
+        - Data I/O endpoints
         - Tasks
       summary: 'Manually start a task run, overriding the current schedule'
       parameters:
@@ -4458,6 +4454,7 @@ paths:
     post:
       operationId: PostUsersIDPassword
       tags:
+        - Security and access endpoints
         - Users
       summary: Update a password
       security:
@@ -5427,6 +5424,7 @@ paths:
       operationId: GetDebugPprofAllProfiles
       tags:
         - Debug
+        - System information endpoints
       summary: Retrieve all runtime profiles
       description: |
         Collects samples and returns reports for the following [Go runtime profiles](https://pkg.go.dev/runtime/pprof):
@@ -5513,6 +5511,7 @@ paths:
       operationId: GetDebugPprofAllocs
       tags:
         - Debug
+        - System information endpoints
       summary: Retrieve the memory allocations runtime profile
       description: |
         Returns a [Go runtime profile](https://pkg.go.dev/runtime/pprof) report of
@@ -5598,6 +5597,7 @@ paths:
       operationId: GetDebugPprofBlock
       tags:
         - Debug
+        - System information endpoints
       summary: Retrieve the block runtime profile
       description: |
         Collects samples and returns a [Go runtime profile](https://pkg.go.dev/runtime/pprof)
@@ -5679,6 +5679,7 @@ paths:
       operationId: GetDebugPprofCmdline
       tags:
         - Debug
+        - System information endpoints
       summary: Retrieve the command line invocation
       description: |
         Returns the command line that invoked InfluxDB.
@@ -5702,6 +5703,7 @@ paths:
       operationId: GetDebugPprofGoroutine
       tags:
         - Debug
+        - System information endpoints
       summary: Retrieve the goroutines runtime profile
       description: |
         Collects statistics and returns a [Go runtime profile](https://pkg.go.dev/runtime/pprof)
@@ -5784,6 +5786,7 @@ paths:
       operationId: GetDebugPprofHeap
       tags:
         - Debug
+        - System information endpoints
       summary: Retrieve the heap runtime profile
       description: |
         Collects statistics and returns a [Go runtime profile](https://pkg.go.dev/runtime/pprof)
@@ -5888,6 +5891,7 @@ paths:
       operationId: GetDebugPprofMutex
       tags:
         - Debug
+        - System information endpoints
       summary: Retrieve the mutual exclusion (mutex) runtime profile
       description: |
         Collects statistics and returns a [Go runtime profile](https://pkg.go.dev/runtime/pprof) report of
@@ -5970,6 +5974,7 @@ paths:
       operationId: GetDebugPprofProfile
       tags:
         - Debug
+        - System information endpoints
       summary: Retrieve the CPU runtime profile
       description: |
         Collects statistics and returns a [Go runtime profile](https://pkg.go.dev/runtime/pprof)
@@ -6023,6 +6028,7 @@ paths:
       operationId: GetDebugPprofThreadCreate
       tags:
         - Debug
+        - System information endpoints
       summary: Retrieve the threadcreate runtime profile
       description: |
         Collects statistics and returns a [Go runtime profile](https://pkg.go.dev/runtime/pprof)
@@ -6108,6 +6114,7 @@ paths:
       operationId: GetDebugPprofTrace
       tags:
         - Debug
+        - System information endpoints
       summary: Retrieve the runtime execution trace
       description: |
         Collects profile data and returns trace execution events for the current program.
@@ -6153,6 +6160,7 @@ paths:
       operationId: GetHealth
       tags:
         - Health
+        - System information endpoints
       summary: Retrieve the health of the instance
       description: Returns the health of the instance.
       servers:
@@ -6182,6 +6190,7 @@ paths:
       operationId: GetMetrics
       tags:
         - Metrics
+        - System information endpoints
       summary: Retrieve workload performance metrics
       description: |
         Returns metrics about the workload performance of an InfluxDB instance.
@@ -6236,6 +6245,7 @@ paths:
       operationId: GetReady
       tags:
         - Ready
+        - System information endpoints
       summary: Get the readiness of an instance at startup
       servers:
         - url: ''
@@ -6255,6 +6265,7 @@ paths:
     get:
       operationId: GetUsers
       tags:
+        - Security and access endpoints
         - Users
       summary: List all users
       parameters:
@@ -6308,6 +6319,7 @@ paths:
     get:
       operationId: GetUsersID
       tags:
+        - Security and access endpoints
         - Users
       summary: Retrieve a user
       parameters:
@@ -6423,6 +6435,7 @@ paths:
       operationId: GetAuthorizations
       tags:
         - Authorizations
+        - Security and access endpoints
       summary: List all authorizations
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -6488,6 +6501,7 @@ paths:
       operationId: GetAuthorizationsID
       tags:
         - Authorizations
+        - Security and access endpoints
       summary: Retrieve an authorization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -7689,6 +7703,7 @@ paths:
       operationId: GetConfig
       tags:
         - Config
+        - System information endpoints
       summary: Retrieve runtime configuration
       description: |
         Returns the active runtime configuration of the InfluxDB instance.
@@ -8104,6 +8119,7 @@ paths:
     get:
       operationId: GetTasks
       tags:
+        - Data I/O endpoints
         - Tasks
       summary: List tasks
       description: |
@@ -8309,6 +8325,7 @@ paths:
     post:
       operationId: PostTasks
       tags:
+        - Data I/O endpoints
         - Tasks
       summary: Create a task
       description: |

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -6087,6 +6087,7 @@ paths:
       summary: List all top level routes
       tags:
       - Routes
+      - System information endpoints
   /api/v2/authorizations:
     get:
       operationId: GetAuthorizations
@@ -8324,6 +8325,7 @@ paths:
           $ref: '#/components/responses/GeneralServerError'
       summary: Delete data
       tags:
+      - Data I/O endpoints
       - Delete
       x-codeSamples:
       - label: cURL
@@ -9212,6 +9214,7 @@ paths:
       summary: List all organizations
       tags:
       - Organizations
+      - Security and access endpoints
     post:
       operationId: PostOrgs
       parameters:
@@ -9294,6 +9297,7 @@ paths:
       summary: Retrieve an organization
       tags:
       - Organizations
+      - Security and access endpoints
     patch:
       operationId: PatchOrgsID
       parameters:
@@ -9390,6 +9394,7 @@ paths:
       summary: List all members of an organization
       tags:
       - Organizations
+      - Security and access endpoints
     post:
       operationId: PostOrgsIDMembers
       parameters:
@@ -9452,6 +9457,7 @@ paths:
       summary: Remove a member from an organization
       tags:
       - Organizations
+      - Security and access endpoints
   /api/v2/orgs/{orgID}/owners:
     get:
       operationId: GetOrgsIDOwners
@@ -9485,6 +9491,7 @@ paths:
       summary: List all owners of an organization
       tags:
       - Organizations
+      - Security and access endpoints
     post:
       operationId: PostOrgsIDOwners
       parameters:
@@ -9547,6 +9554,7 @@ paths:
       summary: Remove an owner from an organization
       tags:
       - Organizations
+      - Security and access endpoints
   /api/v2/orgs/{orgID}/secrets:
     get:
       operationId: GetOrgsIDSecrets
@@ -9574,6 +9582,7 @@ paths:
       summary: List all secret keys for an organization
       tags:
       - Secrets
+      - Security and access endpoints
     patch:
       operationId: PatchOrgsIDSecrets
       parameters:
@@ -9629,6 +9638,7 @@ paths:
       summary: Delete a secret from an organization
       tags:
       - Secrets
+      - Security and access endpoints
   /api/v2/orgs/{orgID}/secrets/delete:
     post:
       deprecated: true
@@ -9660,6 +9670,7 @@ paths:
       summary: Delete secrets from an organization
       tags:
       - Secrets
+      - Security and access endpoints
   /api/v2/orgs/{orgID}/usage:
     get:
       operationId: GetOrgUsageID
@@ -9745,6 +9756,7 @@ paths:
       summary: Get the status and version of the instance
       tags:
       - Ping
+      - System information endpoints
     head:
       description: Returns the status and InfluxDB version of the instance.
       operationId: HeadPing
@@ -9907,6 +9919,7 @@ paths:
           $ref: '#/components/responses/GeneralServerError'
       summary: Query data
       tags:
+      - Data I/O endpoints
       - Query
       x-codeSamples:
       - label: cURL
@@ -10067,6 +10080,7 @@ paths:
       summary: List all known resources
       tags:
       - Resources
+      - System information endpoints
   /api/v2/scripts:
     get:
       operationId: GetScripts
@@ -10095,6 +10109,7 @@ paths:
           description: Unexpected error
       summary: List scripts
       tags:
+      - Data I/O endpoints
       - Invokable Scripts
     post:
       operationId: PostScripts
@@ -10160,6 +10175,7 @@ paths:
           description: Unexpected error
       summary: Retrieve a script
       tags:
+      - Data I/O endpoints
       - Invokable Scripts
     patch:
       description: |
@@ -10220,6 +10236,7 @@ paths:
           description: Unexpected error
       summary: Invoke a script
       tags:
+      - Data I/O endpoints
       - Invokable Scripts
   /api/v2/setup:
     get:
@@ -10649,6 +10666,7 @@ paths:
           description: Unexpected error
       summary: List all tasks
       tags:
+      - Data I/O endpoints
       - Tasks
     post:
       operationId: PostTasks
@@ -10676,6 +10694,7 @@ paths:
           description: Unexpected error
       summary: Create a new task
       tags:
+      - Data I/O endpoints
       - Tasks
   /api/v2/tasks/{taskID}:
     delete:
@@ -10726,6 +10745,7 @@ paths:
           description: Unexpected error
       summary: Retrieve a task
       tags:
+      - Data I/O endpoints
       - Tasks
     patch:
       description: Update a task. This will cancel all queued runs.
@@ -11142,6 +11162,7 @@ paths:
           description: Unexpected error
       summary: Manually start a task run, overriding the current schedule
       tags:
+      - Data I/O endpoints
       - Tasks
   /api/v2/tasks/{taskID}/runs/{runID}:
     delete:
@@ -11986,6 +12007,7 @@ paths:
       - BasicAuthentication: []
       summary: Update a password
       tags:
+      - Security and access endpoints
       - Users
   /api/v2/variables:
     get:
@@ -12550,6 +12572,7 @@ paths:
           $ref: '#/components/responses/GeneralServerError'
       summary: Write data
       tags:
+      - Data I/O endpoints
       - Write
   /legacy/authorizations:
     get:
@@ -13124,27 +13147,10 @@ x-tagGroups:
   - Authentication
   - Headers
   - Response codes
-- name: Data I/O endpoints
+- name: Popular endpoints
   tags:
-  - Write
-  - Query
-  - Delete
-  - Invokable Scripts
-  - Tasks
-- name: Resource endpoints
-  tags:
-  - Buckets
-  - Dashboards
-  - Tasks
-  - Resources
-- name: Security and access endpoints
-  tags:
-  - Authorizations
-  - Organizations
-  - Users
-- name: System information endpoints
-  tags:
-  - Ping
-  - Routes
+  - Data I/O endpoints
+  - Security and access endpoints
+  - System information endpoints
 - name: All endpoints
   tags: []

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -6225,6 +6225,7 @@ paths:
       summary: List all top level routes
       tags:
       - Routes
+      - System information endpoints
   /api/v2/authorizations:
     get:
       operationId: GetAuthorizations
@@ -6263,6 +6264,7 @@ paths:
       summary: List all authorizations
       tags:
       - Authorizations
+      - Security and access endpoints
     post:
       operationId: PostAuthorizations
       parameters:
@@ -6333,6 +6335,7 @@ paths:
       summary: Retrieve an authorization
       tags:
       - Authorizations
+      - Security and access endpoints
     patch:
       operationId: PatchAuthorizationsID
       parameters:
@@ -7278,6 +7281,7 @@ paths:
       summary: Retrieve runtime configuration
       tags:
       - Config
+      - System information endpoints
   /api/v2/dashboards:
     get:
       operationId: GetDashboards
@@ -8293,6 +8297,7 @@ paths:
       summary: Retrieve all runtime profiles
       tags:
       - Debug
+      - System information endpoints
       x-codeSamples:
       - label: 'Shell: Get all profiles'
         lang: Shell
@@ -8399,6 +8404,7 @@ paths:
       summary: Retrieve the memory allocations runtime profile
       tags:
       - Debug
+      - System information endpoints
       x-codeSamples:
       - label: 'Shell: go tool pprof'
         lang: Shell
@@ -8480,6 +8486,7 @@ paths:
       summary: Retrieve the block runtime profile
       tags:
       - Debug
+      - System information endpoints
       x-codeSamples:
       - label: 'Shell: go tool pprof'
         lang: Shell
@@ -8518,6 +8525,7 @@ paths:
       summary: Retrieve the command line invocation
       tags:
       - Debug
+      - System information endpoints
   /debug/pprof/goroutine:
     get:
       description: |
@@ -8585,6 +8593,7 @@ paths:
       summary: Retrieve the goroutines runtime profile
       tags:
       - Debug
+      - System information endpoints
       x-codeSamples:
       - label: 'Shell: go tool pprof'
         lang: Shell
@@ -8687,6 +8696,7 @@ paths:
       summary: Retrieve the heap runtime profile
       tags:
       - Debug
+      - System information endpoints
       x-codeSamples:
       - label: 'Shell: go tool pprof'
         lang: Shell
@@ -8774,6 +8784,7 @@ paths:
       summary: Retrieve the mutual exclusion (mutex) runtime profile
       tags:
       - Debug
+      - System information endpoints
       x-codeSamples:
       - label: 'Shell: go tool pprof'
         lang: Shell
@@ -8826,6 +8837,7 @@ paths:
       summary: Retrieve the CPU runtime profile
       tags:
       - Debug
+      - System information endpoints
       x-codeSamples:
       - label: 'Shell: go tool pprof'
         lang: Shell
@@ -8913,6 +8925,7 @@ paths:
       summary: Retrieve the threadcreate runtime profile
       tags:
       - Debug
+      - System information endpoints
       x-codeSamples:
       - label: 'Shell: go tool pprof'
         lang: Shell
@@ -8962,6 +8975,7 @@ paths:
       summary: Retrieve the runtime execution trace
       tags:
       - Debug
+      - System information endpoints
       x-codeSamples:
       - label: 'Shell: go tool trace'
         lang: Shell
@@ -9113,6 +9127,7 @@ paths:
           $ref: '#/components/responses/GeneralServerError'
       summary: Delete data
       tags:
+      - Data I/O endpoints
       - Delete
       x-codeSamples:
       - label: cURL
@@ -9176,6 +9191,7 @@ paths:
       summary: Retrieve the health of the instance
       tags:
       - Health
+      - System information endpoints
   /api/v2/labels:
     get:
       operationId: GetLabels
@@ -9426,6 +9442,7 @@ paths:
       summary: Retrieve workload performance metrics
       tags:
       - Metrics
+      - System information endpoints
   /api/v2/notificationEndpoints:
     get:
       operationId: GetNotificationEndpoints
@@ -10084,6 +10101,7 @@ paths:
       summary: List all organizations
       tags:
       - Organizations
+      - Security and access endpoints
     post:
       operationId: PostOrgs
       parameters:
@@ -10166,6 +10184,7 @@ paths:
       summary: Retrieve an organization
       tags:
       - Organizations
+      - Security and access endpoints
     patch:
       operationId: PatchOrgsID
       parameters:
@@ -10232,6 +10251,7 @@ paths:
       summary: List all members of an organization
       tags:
       - Organizations
+      - Security and access endpoints
     post:
       operationId: PostOrgsIDMembers
       parameters:
@@ -10294,6 +10314,7 @@ paths:
       summary: Remove a member from an organization
       tags:
       - Organizations
+      - Security and access endpoints
   /api/v2/orgs/{orgID}/owners:
     get:
       operationId: GetOrgsIDOwners
@@ -10327,6 +10348,7 @@ paths:
       summary: List all owners of an organization
       tags:
       - Organizations
+      - Security and access endpoints
     post:
       operationId: PostOrgsIDOwners
       parameters:
@@ -10389,6 +10411,7 @@ paths:
       summary: Remove an owner from an organization
       tags:
       - Organizations
+      - Security and access endpoints
   /api/v2/orgs/{orgID}/secrets:
     get:
       operationId: GetOrgsIDSecrets
@@ -10416,6 +10439,7 @@ paths:
       summary: List all secret keys for an organization
       tags:
       - Secrets
+      - Security and access endpoints
     patch:
       operationId: PatchOrgsIDSecrets
       parameters:
@@ -10471,6 +10495,7 @@ paths:
       summary: Delete a secret from an organization
       tags:
       - Secrets
+      - Security and access endpoints
   /api/v2/orgs/{orgID}/secrets/delete:
     post:
       deprecated: true
@@ -10502,6 +10527,7 @@ paths:
       summary: Delete secrets from an organization
       tags:
       - Secrets
+      - Security and access endpoints
   /ping:
     get:
       description: Returns the status and InfluxDB version of the instance.
@@ -10525,6 +10551,7 @@ paths:
       summary: Get the status and version of the instance
       tags:
       - Ping
+      - System information endpoints
     head:
       description: Returns the status and InfluxDB version of the instance.
       operationId: HeadPing
@@ -10687,6 +10714,7 @@ paths:
           $ref: '#/components/responses/GeneralServerError'
       summary: Query data
       tags:
+      - Data I/O endpoints
       - Query
       x-codeSamples:
       - label: cURL
@@ -10844,6 +10872,7 @@ paths:
       summary: Get the readiness of an instance at startup
       tags:
       - Ready
+      - System information endpoints
   /api/v2/remotes:
     get:
       operationId: GetRemoteConnections
@@ -11169,6 +11198,7 @@ paths:
       summary: List all known resources
       tags:
       - Resources
+      - System information endpoints
   /api/v2/restore/bucket/{bucketID}:
     post:
       deprecated: true
@@ -12537,6 +12567,7 @@ paths:
           $ref: '#/components/responses/GeneralServerError'
       summary: List tasks
       tags:
+      - Data I/O endpoints
       - Tasks
     post:
       description: |
@@ -12585,6 +12616,7 @@ paths:
           description: Unexpected error
       summary: Create a task
       tags:
+      - Data I/O endpoints
       - Tasks
       x-codeSamples:
       - label: 'cURL: create a task'
@@ -12654,6 +12686,7 @@ paths:
           description: Unexpected error
       summary: Retrieve a task
       tags:
+      - Data I/O endpoints
       - Tasks
     patch:
       description: Update a task. This will cancel all queued runs.
@@ -13070,6 +13103,7 @@ paths:
           description: Unexpected error
       summary: Manually start a task run, overriding the current schedule
       tags:
+      - Data I/O endpoints
       - Tasks
   /api/v2/tasks/{taskID}/runs/{runID}:
     delete:
@@ -13796,6 +13830,7 @@ paths:
           description: Unexpected error
       summary: List all users
       tags:
+      - Security and access endpoints
       - Users
     post:
       operationId: PostUsers
@@ -13863,6 +13898,7 @@ paths:
           description: Unexpected error
       summary: Retrieve a user
       tags:
+      - Security and access endpoints
       - Users
     patch:
       operationId: PatchUsersID
@@ -13925,6 +13961,7 @@ paths:
       - BasicAuthentication: []
       summary: Update a password
       tags:
+      - Security and access endpoints
       - Users
   /api/v2/variables:
     get:
@@ -14489,6 +14526,7 @@ paths:
           $ref: '#/components/responses/GeneralServerError'
       summary: Write data
       tags:
+      - Data I/O endpoints
       - Write
   /legacy/authorizations:
     get:
@@ -15065,31 +15103,10 @@ x-tagGroups:
   - Authentication
   - Headers
   - Response codes
-- name: Data I/O endpoints
+- name: Popular endpoints
   tags:
-  - Write
-  - Query
-  - Delete
-  - Tasks
-- name: Resource endpoints
-  tags:
-  - Buckets
-  - Dashboards
-  - Tasks
-  - Resources
-- name: Security and access endpoints
-  tags:
-  - Authorizations
-  - Organizations
-  - Users
-- name: System information endpoints
-  tags:
-  - Config
-  - Debug
-  - Health
-  - Metrics
-  - Ping
-  - Ready
-  - Routes
+  - Data I/O endpoints
+  - Security and access endpoints
+  - System information endpoints
 - name: All endpoints
   tags: []

--- a/contracts/svc/invocable-scripts.yml
+++ b/contracts/svc/invocable-scripts.yml
@@ -20,6 +20,7 @@ paths:
     get:
       operationId: GetScripts
       tags:
+        - Data I/O endpoints
         - Invokable Scripts
       summary: List scripts
       parameters:
@@ -71,6 +72,7 @@ paths:
     get:
       operationId: GetScriptsID
       tags:
+        - Data I/O endpoints
         - Invokable Scripts
       summary: Retrieve a script
       description: Uses script ID to retrieve details of an invokable script.
@@ -145,6 +147,7 @@ paths:
     post:
       operationId: PostScriptsIDInvoke
       tags:
+        - Data I/O endpoints
         - Invokable Scripts
       summary: Invoke a script
       description: Invokes a script and substitutes `params` keys referenced in the script with `params` key-values sent in the request body.

--- a/src/cloud/paths/tasks.yml
+++ b/src/cloud/paths/tasks.yml
@@ -1,6 +1,7 @@
 get:
   operationId: GetTasks
   tags:
+    - Data I/O endpoints
     - Tasks
   summary: List all tasks
   parameters:
@@ -88,6 +89,7 @@ get:
 post:
   operationId: PostTasks
   tags:
+    - Data I/O endpoints
     - Tasks
   summary: Create a new task
   parameters:

--- a/src/cloud/tag-groups.yml
+++ b/src/cloud/tag-groups.yml
@@ -5,27 +5,10 @@ x-tagGroups:
       - Authentication
       - Headers
       - Response codes
-  - name: Data I/O endpoints
+  - name: Popular endpoints
     tags:
-      - Write
-      - Query
-      - Delete
-      - Invokable Scripts
-      - Tasks
-  - name: Resource endpoints
-    tags:
-      - Buckets
-      - Dashboards
-      - Tasks
-      - Resources
-  - name: Security and access endpoints
-    tags:
-      - Authorizations
-      - Organizations
-      - Users
-  - name: System information endpoints
-    tags:
-      - Ping
-      - Routes
+      - Data I/O endpoints
+      - Security and access endpoints
+      - System information endpoints
   - name: All endpoints
     tags: []

--- a/src/common/paths/0slash.yml
+++ b/src/common/paths/0slash.yml
@@ -3,6 +3,7 @@ get:
   summary: List all top level routes
   tags:
     - Routes
+    - System information endpoints
   parameters:
     - $ref: "../parameters/TraceSpan.yml"
   responses:

--- a/src/common/paths/authorizations.yml
+++ b/src/common/paths/authorizations.yml
@@ -2,6 +2,7 @@ get:
   operationId: GetAuthorizations
   tags:
     - Authorizations
+    - Security and access endpoints
   summary: List all authorizations
   parameters:
     - $ref: "../../common/parameters/TraceSpan.yml"

--- a/src/common/paths/authorizations_authID.yml
+++ b/src/common/paths/authorizations_authID.yml
@@ -2,6 +2,7 @@ get:
   operationId: GetAuthorizationsID
   tags:
     - Authorizations
+    - Security and access endpoints
   summary: Retrieve an authorization
   parameters:
     - $ref: "../../common/parameters/TraceSpan.yml"

--- a/src/common/paths/delete.yml
+++ b/src/common/paths/delete.yml
@@ -1,6 +1,7 @@
 post:
   operationId: PostDelete
   tags:
+    - Data I/O endpoints
     - Delete
   summary: Delete data
   description: |

--- a/src/common/paths/orgs.yml
+++ b/src/common/paths/orgs.yml
@@ -2,6 +2,7 @@ get:
   operationId: GetOrgs
   tags:
     - Organizations
+    - Security and access endpoints
   summary: List all organizations
   parameters:
     - $ref: "../parameters/TraceSpan.yml"

--- a/src/common/paths/orgs_orgID.yml
+++ b/src/common/paths/orgs_orgID.yml
@@ -2,6 +2,7 @@ get:
   operationId: GetOrgsID
   tags:
     - Organizations
+    - Security and access endpoints
   summary: Retrieve an organization
   parameters:
     - $ref: "../parameters/TraceSpan.yml"

--- a/src/common/paths/orgs_orgID_members.yml
+++ b/src/common/paths/orgs_orgID_members.yml
@@ -2,6 +2,7 @@ get:
   operationId: GetOrgsIDMembers
   tags:
     - Organizations
+    - Security and access endpoints
   summary: List all members of an organization
   parameters:
     - $ref: "../parameters/TraceSpan.yml"

--- a/src/common/paths/orgs_orgID_members_userID.yml
+++ b/src/common/paths/orgs_orgID_members_userID.yml
@@ -2,6 +2,7 @@ delete:
   operationId: DeleteOrgsIDMembersID
   tags:
     - Organizations
+    - Security and access endpoints
   summary: Remove a member from an organization
   parameters:
     - $ref: "../parameters/TraceSpan.yml"

--- a/src/common/paths/orgs_orgID_owners.yml
+++ b/src/common/paths/orgs_orgID_owners.yml
@@ -2,6 +2,7 @@ get:
   operationId: GetOrgsIDOwners
   tags:
     - Organizations
+    - Security and access endpoints
   summary: List all owners of an organization
   parameters:
     - $ref: "../parameters/TraceSpan.yml"

--- a/src/common/paths/orgs_orgID_owners_userID.yml
+++ b/src/common/paths/orgs_orgID_owners_userID.yml
@@ -2,6 +2,7 @@ delete:
   operationId: DeleteOrgsIDOwnersID
   tags:
     - Organizations
+    - Security and access endpoints
   summary: Remove an owner from an organization
   parameters:
     - $ref: "../parameters/TraceSpan.yml"

--- a/src/common/paths/orgs_orgID_secrets.yml
+++ b/src/common/paths/orgs_orgID_secrets.yml
@@ -2,6 +2,7 @@ get:
   operationId: GetOrgsIDSecrets
   tags:
     - Secrets
+    - Security and access endpoints
   summary: List all secret keys for an organization
   parameters:
     - $ref: "../parameters/TraceSpan.yml"

--- a/src/common/paths/orgs_orgID_secrets_delete.yml
+++ b/src/common/paths/orgs_orgID_secrets_delete.yml
@@ -3,6 +3,7 @@ post:
   operationId: PostOrgsIDSecrets
   tags:
     - Secrets
+    - Security and access endpoints
   summary: Delete secrets from an organization
   parameters:
     - $ref: "../parameters/TraceSpan.yml"

--- a/src/common/paths/orgs_orgID_secrets_secretID.yml
+++ b/src/common/paths/orgs_orgID_secrets_secretID.yml
@@ -2,6 +2,7 @@ delete:
   operationId: DeleteOrgsIDSecretsID
   tags:
     - Secrets
+    - Security and access endpoints
   summary: Delete a secret from an organization
   parameters:
     - $ref: '../parameters/TraceSpan.yml'

--- a/src/common/paths/ping.yml
+++ b/src/common/paths/ping.yml
@@ -6,6 +6,7 @@ get:
     - url: ''
   tags:
     - Ping
+    - System information endpoints
   responses:
     '204':
       description: |

--- a/src/common/paths/query.yml
+++ b/src/common/paths/query.yml
@@ -1,6 +1,7 @@
 post:
   operationId: PostQuery
   tags:
+    - Data I/O endpoints
     - Query
   summary: Query data
   description: |

--- a/src/common/paths/resources.yml
+++ b/src/common/paths/resources.yml
@@ -2,6 +2,7 @@ get:
   operationId: GetResources
   tags:
     - Resources
+    - System information endpoints
   summary: List all known resources
   parameters:
     - $ref: "../parameters/TraceSpan.yml"

--- a/src/common/paths/tasks.yml
+++ b/src/common/paths/tasks.yml
@@ -1,6 +1,7 @@
 get:
   operationId: GetTasks
   tags:
+    - Data I/O endpoints
     - Tasks
   summary: List tasks
   description: |
@@ -213,6 +214,7 @@ get:
 post:
   operationId: PostTasks
   tags:
+    - Data I/O endpoints
     - Tasks
   summary: Create a task
   description: |

--- a/src/common/paths/tasks_taskID.yml
+++ b/src/common/paths/tasks_taskID.yml
@@ -1,6 +1,7 @@
 get:
   operationId: GetTasksID
   tags:
+    - Data I/O endpoints
     - Tasks
   summary: Retrieve a task
   parameters:

--- a/src/common/paths/tasks_taskID_runs.yml
+++ b/src/common/paths/tasks_taskID_runs.yml
@@ -52,6 +52,7 @@ get:
 post:
   operationId: PostTasksIDRuns
   tags:
+    - Data I/O endpoints
     - Tasks
   summary: Manually start a task run, overriding the current schedule
   parameters:

--- a/src/common/paths/users.yml
+++ b/src/common/paths/users.yml
@@ -1,6 +1,7 @@
 get:
   operationId: GetUsers
   tags:
+    - Security and access endpoints
     - Users
   summary: List all users
   parameters:

--- a/src/common/paths/users_userID.yml
+++ b/src/common/paths/users_userID.yml
@@ -1,6 +1,7 @@
 get:
   operationId: GetUsersID
   tags:
+    - Security and access endpoints
     - Users
   summary: Retrieve a user
   parameters:

--- a/src/common/paths/users_userID_password.yml
+++ b/src/common/paths/users_userID_password.yml
@@ -1,6 +1,7 @@
 post:
   operationId: PostUsersIDPassword
   tags:
+    - Security and access endpoints
     - Users
   summary: Update a password
   security:

--- a/src/common/paths/write.yml
+++ b/src/common/paths/write.yml
@@ -1,6 +1,7 @@
 post:
   operationId: PostWrite
   tags:
+    - Data I/O endpoints
     - Write
   summary: Write data
   description: |

--- a/src/oss/paths/config.yml
+++ b/src/oss/paths/config.yml
@@ -2,6 +2,7 @@ get:
   operationId: GetConfig
   tags:
     - Config
+    - System information endpoints
   summary: Retrieve runtime configuration
   description: |
     Returns the active runtime configuration of the InfluxDB instance.

--- a/src/oss/paths/debug_pprof_all.yml
+++ b/src/oss/paths/debug_pprof_all.yml
@@ -2,6 +2,7 @@ get:
   operationId: GetDebugPprofAllProfiles
   tags:
     - Debug
+    - System information endpoints
   summary: Retrieve all runtime profiles
   description: |
     Collects samples and returns reports for the following [Go runtime profiles](https://pkg.go.dev/runtime/pprof):

--- a/src/oss/paths/debug_pprof_allocs.yml
+++ b/src/oss/paths/debug_pprof_allocs.yml
@@ -2,6 +2,7 @@ get:
   operationId: GetDebugPprofAllocs
   tags:
     - Debug
+    - System information endpoints
   summary: Retrieve the memory allocations runtime profile
   description: |
     Returns a [Go runtime profile](https://pkg.go.dev/runtime/pprof) report of

--- a/src/oss/paths/debug_pprof_block.yml
+++ b/src/oss/paths/debug_pprof_block.yml
@@ -2,6 +2,7 @@ get:
   operationId: GetDebugPprofBlock
   tags:
     - Debug
+    - System information endpoints
   summary: Retrieve the block runtime profile
   description: |
     Collects samples and returns a [Go runtime profile](https://pkg.go.dev/runtime/pprof)

--- a/src/oss/paths/debug_pprof_cmdline.yml
+++ b/src/oss/paths/debug_pprof_cmdline.yml
@@ -2,6 +2,7 @@ get:
   operationId: GetDebugPprofCmdline
   tags:
     - Debug
+    - System information endpoints
   summary: Retrieve the command line invocation
   description: |
     Returns the command line that invoked InfluxDB.

--- a/src/oss/paths/debug_pprof_goroutine.yml
+++ b/src/oss/paths/debug_pprof_goroutine.yml
@@ -2,6 +2,7 @@ get:
   operationId: GetDebugPprofGoroutine
   tags:
     - Debug
+    - System information endpoints
   summary: Retrieve the goroutines runtime profile
   description: |
     Collects statistics and returns a [Go runtime profile](https://pkg.go.dev/runtime/pprof)

--- a/src/oss/paths/debug_pprof_heap.yml
+++ b/src/oss/paths/debug_pprof_heap.yml
@@ -2,6 +2,7 @@ get:
   operationId: GetDebugPprofHeap
   tags:
     - Debug
+    - System information endpoints
   summary: Retrieve the heap runtime profile
   description: |
     Collects statistics and returns a [Go runtime profile](https://pkg.go.dev/runtime/pprof)

--- a/src/oss/paths/debug_pprof_mutex.yml
+++ b/src/oss/paths/debug_pprof_mutex.yml
@@ -2,6 +2,7 @@ get:
   operationId: GetDebugPprofMutex
   tags:
     - Debug
+    - System information endpoints
   summary: Retrieve the mutual exclusion (mutex) runtime profile
   description: |
     Collects statistics and returns a [Go runtime profile](https://pkg.go.dev/runtime/pprof) report of

--- a/src/oss/paths/debug_pprof_profile.yml
+++ b/src/oss/paths/debug_pprof_profile.yml
@@ -2,6 +2,7 @@ get:
   operationId: GetDebugPprofProfile
   tags:
     - Debug
+    - System information endpoints
   summary: Retrieve the CPU runtime profile
   description: |
     Collects statistics and returns a [Go runtime profile](https://pkg.go.dev/runtime/pprof)

--- a/src/oss/paths/debug_pprof_threadcreate.yml
+++ b/src/oss/paths/debug_pprof_threadcreate.yml
@@ -2,6 +2,7 @@ get:
   operationId: GetDebugPprofThreadCreate
   tags:
     - Debug
+    - System information endpoints
   summary: Retrieve the threadcreate runtime profile
   description: |
     Collects statistics and returns a [Go runtime profile](https://pkg.go.dev/runtime/pprof)

--- a/src/oss/paths/debug_pprof_trace.yml
+++ b/src/oss/paths/debug_pprof_trace.yml
@@ -2,6 +2,7 @@ get:
   operationId: GetDebugPprofTrace
   tags:
     - Debug
+    - System information endpoints
   summary: Retrieve the runtime execution trace
   description: |
     Collects profile data and returns trace execution events for the current program.

--- a/src/oss/paths/health.yml
+++ b/src/oss/paths/health.yml
@@ -2,6 +2,7 @@ get:
   operationId: GetHealth
   tags:
     - Health
+    - System information endpoints
   summary: Retrieve the health of the instance
   description: Returns the health of the instance.
   servers:

--- a/src/oss/paths/metrics.yml
+++ b/src/oss/paths/metrics.yml
@@ -2,6 +2,7 @@ get:
   operationId: GetMetrics
   tags:
     - Metrics
+    - System information endpoints
   summary: Retrieve workload performance metrics
   description: |
     Returns metrics about the workload performance of an InfluxDB instance.

--- a/src/oss/paths/ready.yml
+++ b/src/oss/paths/ready.yml
@@ -2,6 +2,7 @@ get:
   operationId: GetReady
   tags:
     - Ready
+    - System information endpoints
   summary: Get the readiness of an instance at startup
   servers:
     - url: ''

--- a/src/oss/tag-groups.yml
+++ b/src/oss/tag-groups.yml
@@ -5,31 +5,11 @@ x-tagGroups:
       - Authentication
       - Headers
       - Response codes
-  - name: Data I/O endpoints
+  - name: Popular endpoints
     tags:
-      - Write
-      - Query
-      - Delete
-      - Tasks
-  - name: Resource endpoints
-    tags:
-      - Buckets
-      - Dashboards
-      - Tasks
-      - Resources
-  - name: Security and access endpoints
-    tags:
-      - Authorizations
-      - Organizations
-      - Users
-  - name: System information endpoints
-    tags:
-      - Config
-      - Debug
-      - Health
-      - Metrics
-      - Ping
-      - Ready
-      - Routes
+      - Data I/O endpoints
+      - Security and access endpoints
+      - System information endpoints
   - name: All endpoints
     tags: []
+

--- a/src/svc/invocable-scripts/paths/scripts.yml
+++ b/src/svc/invocable-scripts/paths/scripts.yml
@@ -1,6 +1,7 @@
 get:
   operationId: GetScripts
   tags:
+    - Data I/O endpoints
     - Invokable Scripts
   summary: List scripts
   parameters:

--- a/src/svc/invocable-scripts/paths/scripts_scriptID.yml
+++ b/src/svc/invocable-scripts/paths/scripts_scriptID.yml
@@ -1,6 +1,7 @@
 get:
   operationId: GetScriptsID
   tags:
+    - Data I/O endpoints
     - Invokable Scripts
   summary: Retrieve a script
   description: Uses script ID to retrieve details of an invokable script.

--- a/src/svc/invocable-scripts/paths/scripts_scriptID_invoke.yml
+++ b/src/svc/invocable-scripts/paths/scripts_scriptID_invoke.yml
@@ -1,6 +1,7 @@
 post:
   operationId: PostScriptsIDInvoke
   tags:
+    - Data I/O endpoints
     - Invokable Scripts
   summary: Invoke a script
   description: Invokes a script and substitutes `params` keys referenced in the script with `params` key-values sent in the request body.


### PR DESCRIPTION
- Remove some x-tagGroups and apply operation tags instead.
- Helps flatten groupings in the navigation.
- Move toward eliminating x-tagGroups.

Goes with https://github.com/influxdata/docs-v2/pull/4191