### PR TITLE
feat(ecommerce): Add user response to organization invite

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -714,6 +714,12 @@ paths:
             schema:
               $ref: '#/components/schemas/Invite'
       responses:
+        '200':
+          description: User added to organization
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
         '201':
           description: Invite sent
           content:

--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -719,7 +719,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: '#/components/schemas/OrgUser'
         '201':
           description: Invite sent
           content:

--- a/src/unity/paths/orgs_orgId_invites.yml
+++ b/src/unity/paths/orgs_orgId_invites.yml
@@ -53,7 +53,7 @@ post:
       content:
         application/json:
           schema:
-            $ref: '../schemas/User.yml'
+            $ref: '../schemas/OrgUser.yml'
     '201':
       description: Invite sent
       content:

--- a/src/unity/paths/orgs_orgId_invites.yml
+++ b/src/unity/paths/orgs_orgId_invites.yml
@@ -48,6 +48,12 @@ post:
         schema:
           $ref: '../schemas/Invite.yml'
   responses:
+    '200':
+      description: 'User added to organization'
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/User.yml'
     '201':
       description: Invite sent
       content:


### PR DESCRIPTION
When a user is invited to an organization, but they already belong to the account of that organization, they will instead be automatically added to the organization without sending an invite. In this case, we'll return back their user to be added to the UI.