### PR TITLE
docs: improve tasks_taskID. Use global error refs.

### DIFF
--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -2763,6 +2763,8 @@ paths:
                   enum:
                     - active
                     - inactive
+                  description: |
+                    `inactive` cancels scheduled runs and prevents manual runs of the task.
                 flux:
                   description: The Flux script to run for this task.
                   type: string
@@ -2782,9 +2784,6 @@ paths:
                   id:
                     readOnly: true
                     type: string
-                  type:
-                    description: 'The type of the task, useful for filtering a task list.'
-                    type: string
                   orgID:
                     description: The ID of the organization that owns the task.
                     type: string
@@ -2795,7 +2794,7 @@ paths:
                     description: The name of the task.
                     type: string
                   ownerID:
-                    description: The ID of the user who owns this Task.
+                    description: The ID of the user who owns the Task.
                     type: string
                   description:
                     description: The description of the task.
@@ -2808,7 +2807,7 @@ paths:
                     description: The ID of the authorization used when the task communicates with the query engine.
                     type: string
                   flux:
-                    description: The Flux script to run for this task.
+                    description: The Flux script to run for the task.
                     type: string
                   every:
                     description: 'An interval ([duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals))) at which the task runs. `every` also determines when the task first runs, depending on the specified time.'

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -28,6 +28,10 @@
       "description": "Retrieve data, analyze queries, and get query suggestions.\n"
     },
     {
+      "name": "Tasks",
+      "description": "Process and analyze your data with tasks in the InfluxDB task engine.\nWith tasks, you can schedule Flux scripts to query, analyze, modify, and act on data.\n\nUse the `/api/v2/tasks` endpoints to create and manage tasks, retry task runs, and retrieve run logs.\n\n#### Related guides\n\n- [Common data processing tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/common-tasks/)\n"
+    },
+    {
       "name": "Write",
       "description": "Write time series data to buckets.\n"
     },
@@ -6053,6 +6057,7 @@
           "Tasks"
         ],
         "summary": "Retrieve a task",
+        "description": "Retrieves a [task]({{% INFLUXDB_DOCS_URL%}}/reference/glossary/#task)\nby task ID.\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -6069,7 +6074,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Task details",
+            "description": "Success. The response body contains the task.",
             "content": {
               "application/json": {
                 "schema": {
@@ -6078,15 +6083,20 @@
               }
             }
           },
+          "400": {
+            "$ref": "#/components/responses/BadRequestError"
+          },
+          "401": {
+            "$ref": "#/components/responses/AuthorizationError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ResourceNotFoundError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          },
           "default": {
-            "description": "Unexpected error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
+            "$ref": "#/components/responses/GeneralServerError"
           }
         }
       },
@@ -6096,9 +6106,9 @@
           "Tasks"
         ],
         "summary": "Update a task",
-        "description": "Update a task. This will cancel all queued runs.",
+        "description": "Updates a task and then cancels all scheduled runs of the task.\n\nUse this endpoint to modify task properties (for example: `cron`, `name`, `flux`, `status`).\nOnce InfluxDB applies the update, it cancels all scheduled runs of the task.\n\nTo update a task, pass an object that contains the updated key-value pairs.\nTo activate or inactivate a task, set the `status` property.\n_`\"status\": \"inactive\"`_ cancels scheduled runs and prevents manual runs of the task.\n",
         "requestBody": {
-          "description": "Task update to apply",
+          "description": "An object that contains updated task properties to apply.",
           "required": true,
           "content": {
             "application/json": {
@@ -6124,7 +6134,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Task updated",
+            "description": "Success. The response body contains the updated task.",
             "content": {
               "application/json": {
                 "schema": {
@@ -6133,15 +6143,20 @@
               }
             }
           },
+          "400": {
+            "$ref": "#/components/responses/BadRequestError"
+          },
+          "401": {
+            "$ref": "#/components/responses/AuthorizationError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ResourceNotFoundError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          },
           "default": {
-            "description": "Unexpected error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
+            "$ref": "#/components/responses/GeneralServerError"
           }
         }
       },
@@ -6151,7 +6166,7 @@
           "Tasks"
         ],
         "summary": "Delete a task",
-        "description": "Deletes a task and all associated records",
+        "description": "Deletes a task and associated records.\n\nUse this endpoint to delete a task and all associated records (task runs, logs, and labels).\nOnce the task is deleted, InfluxDB cancels all scheduled runs of the task.\n\nIf you want to disable a task instead of delete it, [update the task status to `inactive`](#operation/PatchTasksID).\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -6168,17 +6183,22 @@
         ],
         "responses": {
           "204": {
-            "description": "Task deleted"
+            "description": "Success. Task and runs are deleted. Scheduled runs are canceled."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequestError"
+          },
+          "401": {
+            "$ref": "#/components/responses/AuthorizationError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ResourceNotFoundError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
           },
           "default": {
-            "description": "Unexpected error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
+            "$ref": "#/components/responses/GeneralServerError"
           }
         }
       }
@@ -13233,10 +13253,6 @@
             "readOnly": true,
             "type": "string"
           },
-          "type": {
-            "description": "The type of the task, useful for filtering a task list.",
-            "type": "string"
-          },
           "orgID": {
             "description": "The ID of the organization that owns the task.",
             "type": "string"
@@ -13250,7 +13266,7 @@
             "type": "string"
           },
           "ownerID": {
-            "description": "The ID of the user who owns this Task.",
+            "description": "The ID of the user who owns the Task.",
             "type": "string"
           },
           "description": {
@@ -13268,7 +13284,7 @@
             "type": "string"
           },
           "flux": {
-            "description": "The Flux script to run for this task.",
+            "description": "The Flux script to run for the task.",
             "type": "string"
           },
           "every": {
@@ -13359,7 +13375,8 @@
         "enum": [
           "active",
           "inactive"
-        ]
+        ],
+        "description": "`inactive` cancels scheduled runs and prevents manual runs of the task.\n"
       },
       "UserResponse": {
         "properties": {

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -41,6 +41,16 @@ tags:
   - name: Query
     description: |
       Retrieve data, analyze queries, and get query suggestions.
+  - name: Tasks
+    description: |
+      Process and analyze your data with tasks in the InfluxDB task engine.
+      With tasks, you can schedule Flux scripts to query, analyze, modify, and act on data.
+
+      Use the `/api/v2/tasks` endpoints to create and manage tasks, retry task runs, and retrieve run logs.
+
+      #### Related guides
+
+      - [Common data processing tasks](https://docs.influxdata.com/influxdb/cloud/process-data/common-tasks/)
   - name: Write
     description: |
       Write time series data to buckets.
@@ -4264,6 +4274,9 @@ paths:
         - Data I/O endpoints
         - Tasks
       summary: Retrieve a task
+      description: |
+        Retrieves a [task]({{% INFLUXDB_DOCS_URL%}}/reference/glossary/#task)
+        by task ID.
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -4274,25 +4287,37 @@ paths:
           description: The task ID.
       responses:
         '200':
-          description: Task details
+          description: Success. The response body contains the task.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Task'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/AuthorizationError'
+        '404':
+          $ref: '#/components/responses/ResourceNotFoundError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
         default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/GeneralServerError'
     patch:
       operationId: PatchTasksID
       tags:
         - Tasks
       summary: Update a task
-      description: Update a task. This will cancel all queued runs.
+      description: |
+        Updates a task and then cancels all scheduled runs of the task.
+
+        Use this endpoint to modify task properties (for example: `cron`, `name`, `flux`, `status`).
+        Once InfluxDB applies the update, it cancels all scheduled runs of the task.
+
+        To update a task, pass an object that contains the updated key-value pairs.
+        To activate or inactivate a task, set the `status` property.
+        _`"status": "inactive"`_ cancels scheduled runs and prevents manual runs of the task.
       requestBody:
-        description: Task update to apply
+        description: An object that contains updated task properties to apply.
         required: true
         content:
           application/json:
@@ -4308,23 +4333,33 @@ paths:
           description: The task ID.
       responses:
         '200':
-          description: Task updated
+          description: Success. The response body contains the updated task.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Task'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/AuthorizationError'
+        '404':
+          $ref: '#/components/responses/ResourceNotFoundError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
         default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/GeneralServerError'
     delete:
       operationId: DeleteTasksID
       tags:
         - Tasks
       summary: Delete a task
-      description: Deletes a task and all associated records
+      description: |
+        Deletes a task and associated records.
+
+        Use this endpoint to delete a task and all associated records (task runs, logs, and labels).
+        Once the task is deleted, InfluxDB cancels all scheduled runs of the task.
+
+        If you want to disable a task instead of delete it, [update the task status to `inactive`](#operation/PatchTasksID).
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -4335,13 +4370,17 @@ paths:
           description: The ID of the task to delete.
       responses:
         '204':
-          description: Task deleted
+          description: Success. Task and runs are deleted. Scheduled runs are canceled.
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/AuthorizationError'
+        '404':
+          $ref: '#/components/responses/ResourceNotFoundError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
         default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/GeneralServerError'
   '/tasks/{taskID}/runs':
     get:
       operationId: GetTasksIDRuns
@@ -8825,9 +8864,6 @@ components:
         id:
           readOnly: true
           type: string
-        type:
-          description: 'The type of the task, useful for filtering a task list.'
-          type: string
         orgID:
           description: The ID of the organization that owns the task.
           type: string
@@ -8838,7 +8874,7 @@ components:
           description: The name of the task.
           type: string
         ownerID:
-          description: The ID of the user who owns this Task.
+          description: The ID of the user who owns the Task.
           type: string
         description:
           description: The description of the task.
@@ -8851,7 +8887,7 @@ components:
           description: The ID of the authorization used when the task communicates with the query engine.
           type: string
         flux:
-          description: The Flux script to run for this task.
+          description: The Flux script to run for the task.
           type: string
         every:
           description: 'An interval ([duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals))) at which the task runs. `every` also determines when the task first runs, depending on the specified time.'
@@ -8920,6 +8956,8 @@ components:
       enum:
         - active
         - inactive
+      description: |
+        `inactive` cancels scheduled runs and prevents manual runs of the task.
     UserResponse:
       properties:
         id:

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -4145,6 +4145,9 @@ paths:
         - Data I/O endpoints
         - Tasks
       summary: Retrieve a task
+      description: |
+        Retrieves a [task]({{% INFLUXDB_DOCS_URL%}}/reference/glossary/#task)
+        by task ID.
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -4155,25 +4158,37 @@ paths:
           description: The task ID.
       responses:
         '200':
-          description: Task details
+          description: Success. The response body contains the task.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Task'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/AuthorizationError'
+        '404':
+          $ref: '#/components/responses/ResourceNotFoundError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
         default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/GeneralServerError'
     patch:
       operationId: PatchTasksID
       tags:
         - Tasks
       summary: Update a task
-      description: Update a task. This will cancel all queued runs.
+      description: |
+        Updates a task and then cancels all scheduled runs of the task.
+
+        Use this endpoint to modify task properties (for example: `cron`, `name`, `flux`, `status`).
+        Once InfluxDB applies the update, it cancels all scheduled runs of the task.
+
+        To update a task, pass an object that contains the updated key-value pairs.
+        To activate or inactivate a task, set the `status` property.
+        _`"status": "inactive"`_ cancels scheduled runs and prevents manual runs of the task.
       requestBody:
-        description: Task update to apply
+        description: An object that contains updated task properties to apply.
         required: true
         content:
           application/json:
@@ -4189,23 +4204,33 @@ paths:
           description: The task ID.
       responses:
         '200':
-          description: Task updated
+          description: Success. The response body contains the updated task.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Task'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/AuthorizationError'
+        '404':
+          $ref: '#/components/responses/ResourceNotFoundError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
         default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/GeneralServerError'
     delete:
       operationId: DeleteTasksID
       tags:
         - Tasks
       summary: Delete a task
-      description: Deletes a task and all associated records
+      description: |
+        Deletes a task and associated records.
+
+        Use this endpoint to delete a task and all associated records (task runs, logs, and labels).
+        Once the task is deleted, InfluxDB cancels all scheduled runs of the task.
+
+        If you want to disable a task instead of delete it, [update the task status to `inactive`](#operation/PatchTasksID).
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -4216,13 +4241,17 @@ paths:
           description: The ID of the task to delete.
       responses:
         '204':
-          description: Task deleted
+          description: Success. Task and runs are deleted. Scheduled runs are canceled.
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/AuthorizationError'
+        '404':
+          $ref: '#/components/responses/ResourceNotFoundError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
         default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/GeneralServerError'
   '/tasks/{taskID}/runs':
     get:
       operationId: GetTasksIDRuns
@@ -7709,9 +7738,6 @@ components:
         id:
           readOnly: true
           type: string
-        type:
-          description: 'The type of the task, useful for filtering a task list.'
-          type: string
         orgID:
           description: The ID of the organization that owns the task.
           type: string
@@ -7722,7 +7748,7 @@ components:
           description: The name of the task.
           type: string
         ownerID:
-          description: The ID of the user who owns this Task.
+          description: The ID of the user who owns the Task.
           type: string
         description:
           description: The description of the task.
@@ -7735,7 +7761,7 @@ components:
           description: The ID of the authorization used when the task communicates with the query engine.
           type: string
         flux:
-          description: The Flux script to run for this task.
+          description: The Flux script to run for the task.
           type: string
         every:
           description: 'An interval ([duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals))) at which the task runs. `every` also determines when the task first runs, depending on the specified time.'
@@ -7804,6 +7830,8 @@ components:
       enum:
         - active
         - inactive
+      description: |
+        `inactive` cancels scheduled runs and prevents manual runs of the task.
     UserResponse:
       properties:
         id:

--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -4824,6 +4824,8 @@ paths:
                   enum:
                     - active
                     - inactive
+                  description: |
+                    `inactive` cancels scheduled runs and prevents manual runs of the task.
                 flux:
                   description: The Flux script to run for this task.
                   type: string
@@ -4843,9 +4845,6 @@ paths:
                   id:
                     readOnly: true
                     type: string
-                  type:
-                    description: 'The type of the task, useful for filtering a task list.'
-                    type: string
                   orgID:
                     description: The ID of the organization that owns the task.
                     type: string
@@ -4856,7 +4855,7 @@ paths:
                     description: The name of the task.
                     type: string
                   ownerID:
-                    description: The ID of the user who owns this Task.
+                    description: The ID of the user who owns the Task.
                     type: string
                   description:
                     description: The description of the task.
@@ -4869,7 +4868,7 @@ paths:
                     description: The ID of the authorization used when the task communicates with the query engine.
                     type: string
                   flux:
-                    description: The Flux script to run for this task.
+                    description: The Flux script to run for the task.
                     type: string
                   every:
                     description: 'An interval ([duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals))) at which the task runs. `every` also determines when the task first runs, depending on the specified time.'
@@ -4961,6 +4960,10 @@ paths:
                   value:
                     code: invalid
                     message: 'failed to decode request: missing flux'
+        '401':
+          $ref: '#/paths/~1tasks/get/responses/401'
+        '500':
+          $ref: '#/paths/~1tasks/get/responses/500'
         default:
           description: Unexpected error
           content:

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -17,7 +17,7 @@
     },
     {
       "name": "Debug",
-      "description": "Generates profiling and trace reports.\n\nUse routes under `/debug/pprof` to analyze the Go runtime of InfluxDB.\nThese endpoints generate [Go runtime profiles](https://pkg.go.dev/runtime/pprof)\nand **trace** reports.\n**Profiles** are collections of stack traces that show call sequences\nleading to instances of a particular event, such as allocation.\n\nFor more information about **pprof profile** and **trace** reports,\nsee the following resources:\n  - [Google pprof tool](https://github.com/google/pprof)\n  - [Golang diagnostics](https://go.dev/doc/diagnostics)\n"
+      "description": "Generate profiling and trace reports.\n\nUse routes under `/debug/pprof` to analyze the Go runtime of InfluxDB.\nThese endpoints generate [Go runtime profiles](https://pkg.go.dev/runtime/pprof)\nand **trace** reports.\n**Profiles** are collections of stack traces that show call sequences\nleading to instances of a particular event, such as allocation.\n\nFor more information about **pprof profile** and **trace** reports,\nsee the following resources:\n  - [Google pprof tool](https://github.com/google/pprof)\n  - [Golang diagnostics](https://go.dev/doc/diagnostics)\n"
     },
     {
       "name": "Delete",
@@ -26,6 +26,10 @@
     {
       "name": "Query",
       "description": "Retrieve data, analyze queries, and get query suggestions.\n"
+    },
+    {
+      "name": "Tasks",
+      "description": "Process and analyze your data with tasks in the InfluxDB task engine.\nWith tasks, you can schedule Flux scripts to query, analyze, modify, and act on data.\n\nUse the `/api/v2/tasks` endpoints to create and manage tasks, retry task runs, and retrieve run logs.\n\n#### Related guides\n\n- [Common data processing tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/common-tasks/)\n"
     },
     {
       "name": "Write",
@@ -6053,6 +6057,7 @@
           "Tasks"
         ],
         "summary": "Retrieve a task",
+        "description": "Retrieves a [task]({{% INFLUXDB_DOCS_URL%}}/reference/glossary/#task)\nby task ID.\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -6069,7 +6074,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Task details",
+            "description": "Success. The response body contains the task.",
             "content": {
               "application/json": {
                 "schema": {
@@ -6078,15 +6083,20 @@
               }
             }
           },
+          "400": {
+            "$ref": "#/components/responses/BadRequestError"
+          },
+          "401": {
+            "$ref": "#/components/responses/AuthorizationError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ResourceNotFoundError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          },
           "default": {
-            "description": "Unexpected error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
+            "$ref": "#/components/responses/GeneralServerError"
           }
         }
       },
@@ -6096,9 +6106,9 @@
           "Tasks"
         ],
         "summary": "Update a task",
-        "description": "Update a task. This will cancel all queued runs.",
+        "description": "Updates a task and then cancels all scheduled runs of the task.\n\nUse this endpoint to modify task properties (for example: `cron`, `name`, `flux`, `status`).\nOnce InfluxDB applies the update, it cancels all scheduled runs of the task.\n\nTo update a task, pass an object that contains the updated key-value pairs.\nTo activate or inactivate a task, set the `status` property.\n_`\"status\": \"inactive\"`_ cancels scheduled runs and prevents manual runs of the task.\n",
         "requestBody": {
-          "description": "Task update to apply",
+          "description": "An object that contains updated task properties to apply.",
           "required": true,
           "content": {
             "application/json": {
@@ -6124,7 +6134,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Task updated",
+            "description": "Success. The response body contains the updated task.",
             "content": {
               "application/json": {
                 "schema": {
@@ -6133,15 +6143,20 @@
               }
             }
           },
+          "400": {
+            "$ref": "#/components/responses/BadRequestError"
+          },
+          "401": {
+            "$ref": "#/components/responses/AuthorizationError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ResourceNotFoundError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          },
           "default": {
-            "description": "Unexpected error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
+            "$ref": "#/components/responses/GeneralServerError"
           }
         }
       },
@@ -6151,7 +6166,7 @@
           "Tasks"
         ],
         "summary": "Delete a task",
-        "description": "Deletes a task and all associated records",
+        "description": "Deletes a task and associated records.\n\nUse this endpoint to delete a task and all associated records (task runs, logs, and labels).\nOnce the task is deleted, InfluxDB cancels all scheduled runs of the task.\n\nIf you want to disable a task instead of delete it, [update the task status to `inactive`](#operation/PatchTasksID).\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -6168,17 +6183,22 @@
         ],
         "responses": {
           "204": {
-            "description": "Task deleted"
+            "description": "Success. Task and runs are deleted. Scheduled runs are canceled."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequestError"
+          },
+          "401": {
+            "$ref": "#/components/responses/AuthorizationError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ResourceNotFoundError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
           },
           "default": {
-            "description": "Unexpected error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
+            "$ref": "#/components/responses/GeneralServerError"
           }
         }
       }
@@ -12895,6 +12915,12 @@
               }
             }
           },
+          "401": {
+            "$ref": "#/components/responses/AuthorizationError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          },
           "default": {
             "description": "Unexpected error",
             "content": {
@@ -15820,10 +15846,6 @@
             "readOnly": true,
             "type": "string"
           },
-          "type": {
-            "description": "The type of the task, useful for filtering a task list.",
-            "type": "string"
-          },
           "orgID": {
             "description": "The ID of the organization that owns the task.",
             "type": "string"
@@ -15837,7 +15859,7 @@
             "type": "string"
           },
           "ownerID": {
-            "description": "The ID of the user who owns this Task.",
+            "description": "The ID of the user who owns the Task.",
             "type": "string"
           },
           "description": {
@@ -15855,7 +15877,7 @@
             "type": "string"
           },
           "flux": {
-            "description": "The Flux script to run for this task.",
+            "description": "The Flux script to run for the task.",
             "type": "string"
           },
           "every": {
@@ -15946,7 +15968,8 @@
         "enum": [
           "active",
           "inactive"
-        ]
+        ],
+        "description": "`inactive` cancels scheduled runs and prevents manual runs of the task.\n"
       },
       "UserResponse": {
         "properties": {

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -21,7 +21,7 @@ tags:
         - [Assign a token to a specific user](https://docs.influxdata.com/influxdb/v2.3/security/tokens/create-token/).
   - name: Debug
     description: |
-      Generates profiling and trace reports.
+      Generate profiling and trace reports.
 
       Use routes under `/debug/pprof` to analyze the Go runtime of InfluxDB.
       These endpoints generate [Go runtime profiles](https://pkg.go.dev/runtime/pprof)
@@ -39,6 +39,16 @@ tags:
   - name: Query
     description: |
       Retrieve data, analyze queries, and get query suggestions.
+  - name: Tasks
+    description: |
+      Process and analyze your data with tasks in the InfluxDB task engine.
+      With tasks, you can schedule Flux scripts to query, analyze, modify, and act on data.
+
+      Use the `/api/v2/tasks` endpoints to create and manage tasks, retry task runs, and retrieve run logs.
+
+      #### Related guides
+
+      - [Common data processing tasks](https://docs.influxdata.com/influxdb/v2.3/process-data/common-tasks/)
   - name: Write
     description: |
       Write time series data to buckets.
@@ -4266,6 +4276,9 @@ paths:
         - Data I/O endpoints
         - Tasks
       summary: Retrieve a task
+      description: |
+        Retrieves a [task]({{% INFLUXDB_DOCS_URL%}}/reference/glossary/#task)
+        by task ID.
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -4276,25 +4289,37 @@ paths:
           description: The task ID.
       responses:
         '200':
-          description: Task details
+          description: Success. The response body contains the task.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Task'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/AuthorizationError'
+        '404':
+          $ref: '#/components/responses/ResourceNotFoundError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
         default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/GeneralServerError'
     patch:
       operationId: PatchTasksID
       tags:
         - Tasks
       summary: Update a task
-      description: Update a task. This will cancel all queued runs.
+      description: |
+        Updates a task and then cancels all scheduled runs of the task.
+
+        Use this endpoint to modify task properties (for example: `cron`, `name`, `flux`, `status`).
+        Once InfluxDB applies the update, it cancels all scheduled runs of the task.
+
+        To update a task, pass an object that contains the updated key-value pairs.
+        To activate or inactivate a task, set the `status` property.
+        _`"status": "inactive"`_ cancels scheduled runs and prevents manual runs of the task.
       requestBody:
-        description: Task update to apply
+        description: An object that contains updated task properties to apply.
         required: true
         content:
           application/json:
@@ -4310,23 +4335,33 @@ paths:
           description: The task ID.
       responses:
         '200':
-          description: Task updated
+          description: Success. The response body contains the updated task.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Task'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/AuthorizationError'
+        '404':
+          $ref: '#/components/responses/ResourceNotFoundError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
         default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/GeneralServerError'
     delete:
       operationId: DeleteTasksID
       tags:
         - Tasks
       summary: Delete a task
-      description: Deletes a task and all associated records
+      description: |
+        Deletes a task and associated records.
+
+        Use this endpoint to delete a task and all associated records (task runs, logs, and labels).
+        Once the task is deleted, InfluxDB cancels all scheduled runs of the task.
+
+        If you want to disable a task instead of delete it, [update the task status to `inactive`](#operation/PatchTasksID).
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -4337,13 +4372,17 @@ paths:
           description: The ID of the task to delete.
       responses:
         '204':
-          description: Task deleted
+          description: Success. Task and runs are deleted. Scheduled runs are canceled.
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/AuthorizationError'
+        '404':
+          $ref: '#/components/responses/ResourceNotFoundError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
         default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/GeneralServerError'
   '/tasks/{taskID}/runs':
     get:
       operationId: GetTasksIDRuns
@@ -8861,6 +8900,10 @@ paths:
                   value:
                     code: invalid
                     message: 'failed to decode request: missing flux'
+        '401':
+          $ref: '#/components/responses/AuthorizationError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
         default:
           description: Unexpected error
           content:
@@ -10800,9 +10843,6 @@ components:
         id:
           readOnly: true
           type: string
-        type:
-          description: 'The type of the task, useful for filtering a task list.'
-          type: string
         orgID:
           description: The ID of the organization that owns the task.
           type: string
@@ -10813,7 +10853,7 @@ components:
           description: The name of the task.
           type: string
         ownerID:
-          description: The ID of the user who owns this Task.
+          description: The ID of the user who owns the Task.
           type: string
         description:
           description: The description of the task.
@@ -10826,7 +10866,7 @@ components:
           description: The ID of the authorization used when the task communicates with the query engine.
           type: string
         flux:
-          description: The Flux script to run for this task.
+          description: The Flux script to run for the task.
           type: string
         every:
           description: 'An interval ([duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals))) at which the task runs. `every` also determines when the task first runs, depending on the specified time.'
@@ -10895,6 +10935,8 @@ components:
       enum:
         - active
         - inactive
+      description: |
+        `inactive` cancels scheduled runs and prevents manual runs of the task.
     UserResponse:
       properties:
         id:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -4446,7 +4446,7 @@ components:
           format: duration
           type: string
         flux:
-          description: The Flux script to run for this task.
+          description: The Flux script to run for the task.
           type: string
         id:
           readOnly: true
@@ -4508,13 +4508,10 @@ components:
           description: The ID of the organization that owns the task.
           type: string
         ownerID:
-          description: The ID of the user who owns this Task.
+          description: The ID of the user who owns the Task.
           type: string
         status:
           $ref: '#/components/schemas/TaskStatusType'
-        type:
-          description: The type of the task, useful for filtering a task list.
-          type: string
         updatedAt:
           format: date-time
           readOnly: true
@@ -4545,6 +4542,8 @@ components:
       - flux
       type: object
     TaskStatusType:
+      description: |
+        `inactive` cancels scheduled runs and prevents manual runs of the task.
       enum:
       - active
       - inactive
@@ -11201,7 +11200,13 @@ paths:
       - Tasks
   /api/v2/tasks/{taskID}:
     delete:
-      description: Deletes a task and all associated records
+      description: |
+        Deletes a task and associated records.
+
+        Use this endpoint to delete a task and all associated records (task runs, logs, and labels).
+        Once the task is deleted, InfluxDB cancels all scheduled runs of the task.
+
+        If you want to disable a task instead of delete it, [update the task status to `inactive`](#operation/PatchTasksID).
       operationId: DeleteTasksID
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
@@ -11213,17 +11218,24 @@ paths:
           type: string
       responses:
         "204":
-          description: Task deleted
+          description: Success. Task and runs are deleted. Scheduled runs are canceled.
+        "400":
+          $ref: '#/components/responses/BadRequestError'
+        "401":
+          $ref: '#/components/responses/AuthorizationError'
+        "404":
+          $ref: '#/components/responses/ResourceNotFoundError'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
         default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Unexpected error
+          $ref: '#/components/responses/GeneralServerError'
       summary: Delete a task
       tags:
       - Tasks
     get:
+      description: |
+        Retrieves a [task]({{% INFLUXDB_DOCS_URL%}}/reference/glossary/#task)
+        by task ID.
       operationId: GetTasksID
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
@@ -11239,19 +11251,31 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Task'
-          description: Task details
+          description: Success. The response body contains the task.
+        "400":
+          $ref: '#/components/responses/BadRequestError'
+        "401":
+          $ref: '#/components/responses/AuthorizationError'
+        "404":
+          $ref: '#/components/responses/ResourceNotFoundError'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
         default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Unexpected error
+          $ref: '#/components/responses/GeneralServerError'
       summary: Retrieve a task
       tags:
       - Data I/O endpoints
       - Tasks
     patch:
-      description: Update a task. This will cancel all queued runs.
+      description: |
+        Updates a task and then cancels all scheduled runs of the task.
+
+        Use this endpoint to modify task properties (for example: `cron`, `name`, `flux`, `status`).
+        Once InfluxDB applies the update, it cancels all scheduled runs of the task.
+
+        To update a task, pass an object that contains the updated key-value pairs.
+        To activate or inactivate a task, set the `status` property.
+        _`"status": "inactive"`_ cancels scheduled runs and prevents manual runs of the task.
       operationId: PatchTasksID
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
@@ -11266,7 +11290,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/TaskUpdateRequest'
-        description: Task update to apply
+        description: An object that contains updated task properties to apply.
         required: true
       responses:
         "200":
@@ -11274,13 +11298,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Task'
-          description: Task updated
+          description: Success. The response body contains the updated task.
+        "400":
+          $ref: '#/components/responses/BadRequestError'
+        "401":
+          $ref: '#/components/responses/AuthorizationError'
+        "404":
+          $ref: '#/components/responses/ResourceNotFoundError'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
         default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Unexpected error
+          $ref: '#/components/responses/GeneralServerError'
       summary: Update a task
       tags:
       - Tasks
@@ -13575,6 +13603,16 @@ tags:
 - description: |
     Retrieve data, analyze queries, and get query suggestions.
   name: Query
+- description: |
+    Process and analyze your data with tasks in the InfluxDB task engine.
+    With tasks, you can schedule Flux scripts to query, analyze, modify, and act on data.
+
+    Use the `/api/v2/tasks` endpoints to create and manage tasks, retry task runs, and retrieve run logs.
+
+    #### Related guides
+
+    - [Common data processing tasks](https://docs.influxdata.com/influxdb/cloud/process-data/common-tasks/)
+  name: Tasks
 - description: |
     Write time series data to buckets.
   name: Write

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -4602,7 +4602,7 @@ components:
           format: duration
           type: string
         flux:
-          description: The Flux script to run for this task.
+          description: The Flux script to run for the task.
           type: string
         id:
           readOnly: true
@@ -4664,13 +4664,10 @@ components:
           description: The ID of the organization that owns the task.
           type: string
         ownerID:
-          description: The ID of the user who owns this Task.
+          description: The ID of the user who owns the Task.
           type: string
         status:
           $ref: '#/components/schemas/TaskStatusType'
-        type:
-          description: The type of the task, useful for filtering a task list.
-          type: string
         updatedAt:
           format: date-time
           readOnly: true
@@ -4701,6 +4698,8 @@ components:
       - flux
       type: object
     TaskStatusType:
+      description: |
+        `inactive` cancels scheduled runs and prevents manual runs of the task.
       enum:
       - active
       - inactive
@@ -13111,6 +13110,10 @@ paths:
               schema:
                 $ref: '#/components/responses/BadRequestError'
           description: Bad request
+        "401":
+          $ref: '#/components/responses/AuthorizationError'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
         default:
           content:
             application/json:
@@ -13142,7 +13145,13 @@ paths:
           EOF
   /api/v2/tasks/{taskID}:
     delete:
-      description: Deletes a task and all associated records
+      description: |
+        Deletes a task and associated records.
+
+        Use this endpoint to delete a task and all associated records (task runs, logs, and labels).
+        Once the task is deleted, InfluxDB cancels all scheduled runs of the task.
+
+        If you want to disable a task instead of delete it, [update the task status to `inactive`](#operation/PatchTasksID).
       operationId: DeleteTasksID
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
@@ -13154,17 +13163,24 @@ paths:
           type: string
       responses:
         "204":
-          description: Task deleted
+          description: Success. Task and runs are deleted. Scheduled runs are canceled.
+        "400":
+          $ref: '#/components/responses/BadRequestError'
+        "401":
+          $ref: '#/components/responses/AuthorizationError'
+        "404":
+          $ref: '#/components/responses/ResourceNotFoundError'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
         default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Unexpected error
+          $ref: '#/components/responses/GeneralServerError'
       summary: Delete a task
       tags:
       - Tasks
     get:
+      description: |
+        Retrieves a [task]({{% INFLUXDB_DOCS_URL%}}/reference/glossary/#task)
+        by task ID.
       operationId: GetTasksID
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
@@ -13180,19 +13196,31 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Task'
-          description: Task details
+          description: Success. The response body contains the task.
+        "400":
+          $ref: '#/components/responses/BadRequestError'
+        "401":
+          $ref: '#/components/responses/AuthorizationError'
+        "404":
+          $ref: '#/components/responses/ResourceNotFoundError'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
         default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Unexpected error
+          $ref: '#/components/responses/GeneralServerError'
       summary: Retrieve a task
       tags:
       - Data I/O endpoints
       - Tasks
     patch:
-      description: Update a task. This will cancel all queued runs.
+      description: |
+        Updates a task and then cancels all scheduled runs of the task.
+
+        Use this endpoint to modify task properties (for example: `cron`, `name`, `flux`, `status`).
+        Once InfluxDB applies the update, it cancels all scheduled runs of the task.
+
+        To update a task, pass an object that contains the updated key-value pairs.
+        To activate or inactivate a task, set the `status` property.
+        _`"status": "inactive"`_ cancels scheduled runs and prevents manual runs of the task.
       operationId: PatchTasksID
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
@@ -13207,7 +13235,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/TaskUpdateRequest'
-        description: Task update to apply
+        description: An object that contains updated task properties to apply.
         required: true
       responses:
         "200":
@@ -13215,13 +13243,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Task'
-          description: Task updated
+          description: Success. The response body contains the updated task.
+        "400":
+          $ref: '#/components/responses/BadRequestError'
+        "401":
+          $ref: '#/components/responses/AuthorizationError'
+        "404":
+          $ref: '#/components/responses/ResourceNotFoundError'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
         default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Unexpected error
+          $ref: '#/components/responses/GeneralServerError'
       summary: Update a task
       tags:
       - Tasks
@@ -15508,7 +15540,7 @@ tags:
       - [Assign a token to a specific user](https://docs.influxdata.com/influxdb/v2.3/security/tokens/create-token/).
   name: Authorizations
 - description: |
-    Generates profiling and trace reports.
+    Generate profiling and trace reports.
 
     Use routes under `/debug/pprof` to analyze the Go runtime of InfluxDB.
     These endpoints generate [Go runtime profiles](https://pkg.go.dev/runtime/pprof)
@@ -15527,6 +15559,16 @@ tags:
 - description: |
     Retrieve data, analyze queries, and get query suggestions.
   name: Query
+- description: |
+    Process and analyze your data with tasks in the InfluxDB task engine.
+    With tasks, you can schedule Flux scripts to query, analyze, modify, and act on data.
+
+    Use the `/api/v2/tasks` endpoints to create and manage tasks, retry task runs, and retrieve run logs.
+
+    #### Related guides
+
+    - [Common data processing tasks](https://docs.influxdata.com/influxdb/v2.3/process-data/common-tasks/)
+  name: Tasks
 - description: |
     Write time series data to buckets.
   name: Write

--- a/src/cloud/tags.yml
+++ b/src/cloud/tags.yml
@@ -33,6 +33,16 @@ tags:
   - name: Query
     description: |
       Retrieve data, analyze queries, and get query suggestions.
+  - name: Tasks
+    description: |
+      Process and analyze your data with tasks in the InfluxDB task engine.
+      With tasks, you can schedule Flux scripts to query, analyze, modify, and act on data.
+
+      Use the `/api/v2/tasks` endpoints to create and manage tasks, retry task runs, and retrieve run logs.
+
+      #### Related guides
+
+      - [Common data processing tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/common-tasks/)
   - name: Write
     description: |
       Write time series data to buckets.

--- a/src/common/paths/tasks.yml
+++ b/src/common/paths/tasks.yml
@@ -254,6 +254,10 @@ post:
                 "code":"invalid",
                 "message": "failed to decode request: missing flux"
                 }
+    "401":
+      $ref: "../responses/AuthorizationError.yml"
+    "500":
+      $ref: "../responses/InternalServerError.yml"
     default:
       description: Unexpected error
       content:

--- a/src/common/paths/tasks_taskID.yml
+++ b/src/common/paths/tasks_taskID.yml
@@ -4,6 +4,9 @@ get:
     - Data I/O endpoints
     - Tasks
   summary: Retrieve a task
+  description: |
+    Retrieves a [task]({{% INFLUXDB_DOCS_URL%}}/reference/glossary/#task)
+    by task ID.
   parameters:
     - $ref: "../parameters/TraceSpan.yml"
     - in: path
@@ -14,25 +17,37 @@ get:
       description: The task ID.
   responses:
     "200":
-      description: Task details
+      description: Success. The response body contains the task.
       content:
         application/json:
           schema:
             $ref: "../schemas/Task.yml"
+    "400":
+      $ref: "../responses/BadRequestError.yml"
+    "401":
+      $ref: "../responses/AuthorizationError.yml"
+    "404":
+      $ref: "../responses/ResourceNotFoundError.yml"
+    "500":
+      $ref: "../responses/InternalServerError.yml"
     default:
-      description: Unexpected error
-      content:
-        application/json:
-          schema:
-            $ref: "../schemas/Error.yml"
+      $ref: "../responses/ServerError.yml"
 patch:
   operationId: PatchTasksID
   tags:
     - Tasks
   summary: Update a task
-  description: Update a task. This will cancel all queued runs.
+  description: |
+    Updates a task and then cancels all scheduled runs of the task.
+
+    Use this endpoint to modify task properties (for example: `cron`, `name`, `flux`, `status`).
+    Once InfluxDB applies the update, it cancels all scheduled runs of the task.
+
+    To update a task, pass an object that contains the updated key-value pairs.
+    To activate or inactivate a task, set the `status` property.
+    _`"status": "inactive"`_ cancels scheduled runs and prevents manual runs of the task.
   requestBody:
-    description: Task update to apply
+    description: An object that contains updated task properties to apply.
     required: true
     content:
       application/json:
@@ -48,23 +63,33 @@ patch:
       description: The task ID.
   responses:
     "200":
-      description: Task updated
+      description: Success. The response body contains the updated task.
       content:
         application/json:
           schema:
             $ref: "../schemas/Task.yml"
+    "400":
+      $ref: "../responses/BadRequestError.yml"
+    "401":
+      $ref: "../responses/AuthorizationError.yml"
+    "404":
+      $ref: "../responses/ResourceNotFoundError.yml"
+    "500":
+      $ref: "../responses/InternalServerError.yml"
     default:
-      description: Unexpected error
-      content:
-        application/json:
-          schema:
-            $ref: "../schemas/Error.yml"
+      $ref: "../responses/ServerError.yml"
 delete:
   operationId: DeleteTasksID
   tags:
     - Tasks
   summary: Delete a task
-  description: Deletes a task and all associated records
+  description: |
+    Deletes a task and associated records.
+
+    Use this endpoint to delete a task and all associated records (task runs, logs, and labels).
+    Once the task is deleted, InfluxDB cancels all scheduled runs of the task.
+
+    If you want to disable a task instead of delete it, [update the task status to `inactive`](#operation/PatchTasksID).
   parameters:
     - $ref: "../parameters/TraceSpan.yml"
     - in: path
@@ -75,10 +100,14 @@ delete:
       description: The ID of the task to delete.
   responses:
     "204":
-      description: Task deleted
+      description: Success. Task and runs are deleted. Scheduled runs are canceled.
+    "400":
+      $ref: "../responses/BadRequestError.yml"
+    "401":
+      $ref: "../responses/AuthorizationError.yml"
+    "404":
+      $ref: "../responses/ResourceNotFoundError.yml"
+    "500":
+      $ref: "../responses/InternalServerError.yml"
     default:
-      description: Unexpected error
-      content:
-        application/json:
-          schema:
-            $ref: "../schemas/Error.yml"
+      $ref: "../responses/ServerError.yml"

--- a/src/common/schemas/Task.yml
+++ b/src/common/schemas/Task.yml
@@ -3,9 +3,6 @@
     id:
       readOnly: true
       type: string
-    type:
-      description: The type of the task, useful for filtering a task list.
-      type: string
     orgID:
       description: The ID of the organization that owns the task.
       type: string
@@ -16,7 +13,7 @@
       description: The name of the task.
       type: string
     ownerID:
-      description: The ID of the user who owns this Task.
+      description: The ID of the user who owns the Task.
       type: string
     description:
       description: The description of the task.
@@ -29,7 +26,7 @@
       description: The ID of the authorization used when the task communicates with the query engine.
       type: string
     flux:
-      description: The Flux script to run for this task.
+      description: The Flux script to run for the task.
       type: string
     every:
       description: >-

--- a/src/common/schemas/TaskStatusType.yml
+++ b/src/common/schemas/TaskStatusType.yml
@@ -1,2 +1,4 @@
   type: string
   enum: [active, inactive]
+  description: |
+    `inactive` cancels scheduled runs and prevents manual runs of the task.

--- a/src/oss/tags.yml
+++ b/src/oss/tags.yml
@@ -13,7 +13,7 @@ tags:
         - [Assign a token to a specific user]({{% INFLUXDB_DOCS_URL %}}/security/tokens/create-token/).
   - name: Debug
     description: |
-      Generates profiling and trace reports.
+      Generate profiling and trace reports.
 
       Use routes under `/debug/pprof` to analyze the Go runtime of InfluxDB.
       These endpoints generate [Go runtime profiles](https://pkg.go.dev/runtime/pprof)
@@ -31,6 +31,16 @@ tags:
   - name: Query
     description: |
       Retrieve data, analyze queries, and get query suggestions.
+  - name: Tasks
+    description: |
+      Process and analyze your data with tasks in the InfluxDB task engine.
+      With tasks, you can schedule Flux scripts to query, analyze, modify, and act on data.
+
+      Use the `/api/v2/tasks` endpoints to create and manage tasks, retry task runs, and retrieve run logs.
+
+      #### Related guides
+
+      - [Common data processing tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/common-tasks/)
   - name: Write
     description: |
       Write time series data to buckets.


### PR DESCRIPTION
- Remove `type` property from task schema.
- Add, cleanup descriptions.
- Document update, delete, and inactive run cancellations.
- Add Tasks tag description for UI.

 (part of #406, #407)