### PR TITLE
chore: passwords API on cloud not supported

### DIFF
--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -6822,7 +6822,7 @@
           "Users"
         ],
         "summary": "Update a password",
-        "description": "#### InfluxDB Cloud\n\n- Doesn't support changing user passwords through the API.\n",
+        "description": "#### InfluxDB Cloud\n\nInfluxDB Cloud does not support changing user passwords through the API.\nUse the InfluxDB Cloud user interface to update your password.\n",
         "security": [
           {
             "BasicAuthentication": []
@@ -7164,7 +7164,7 @@
           "Users"
         ],
         "summary": "Update a password",
-        "description": "#### InfluxDB Cloud\n\n- Doesn't support changing user passwords through the API.\n",
+        "description": "#### InfluxDB Cloud\n\nInfluxDB Cloud does not support changing user passwords through the API.\nUse the InfluxDB Cloud user interface to update your password.\n",
         "security": [
           {
             "BasicAuthentication": []

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -6822,6 +6822,7 @@
           "Users"
         ],
         "summary": "Update a password",
+        "description": "#### InfluxDB Cloud\n\n- Doesn't support changing user passwords through the API.\n",
         "security": [
           {
             "BasicAuthentication": []
@@ -6846,6 +6847,9 @@
         "responses": {
           "204": {
             "description": "Success. The password was updated."
+          },
+          "400": {
+            "description": "Bad request.\nInfluxDB Cloud does not support changing passwords through the API and always responds with this status.\n"
           },
           "default": {
             "description": "Unsuccessful authentication",
@@ -7160,6 +7164,7 @@
           "Users"
         ],
         "summary": "Update a password",
+        "description": "#### InfluxDB Cloud\n\n- Doesn't support changing user passwords through the API.\n",
         "security": [
           {
             "BasicAuthentication": []
@@ -7193,6 +7198,9 @@
         "responses": {
           "204": {
             "description": "Password successfully updated"
+          },
+          "400": {
+            "description": "Bad request.\nInfluxDB Cloud doesn't support changing passwords through the API and always responds with this status.\n"
           },
           "default": {
             "description": "Unsuccessful authentication",

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -4750,7 +4750,8 @@ paths:
       description: |
         #### InfluxDB Cloud
 
-        - Doesn't support changing user passwords through the API.
+        InfluxDB Cloud does not support changing user passwords through the API.
+        Use the InfluxDB Cloud user interface to update your password.
       security:
         - BasicAuthentication: []
       parameters:
@@ -4963,7 +4964,8 @@ paths:
       description: |
         #### InfluxDB Cloud
 
-        - Doesn't support changing user passwords through the API.
+        InfluxDB Cloud does not support changing user passwords through the API.
+        Use the InfluxDB Cloud user interface to update your password.
       security:
         - BasicAuthentication: []
       parameters:

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -4747,6 +4747,10 @@ paths:
       tags:
         - Users
       summary: Update a password
+      description: |
+        #### InfluxDB Cloud
+
+        - Doesn't support changing user passwords through the API.
       security:
         - BasicAuthentication: []
       parameters:
@@ -4761,6 +4765,10 @@ paths:
       responses:
         '204':
           description: Success. The password was updated.
+        '400':
+          description: |
+            Bad request.
+            InfluxDB Cloud does not support changing passwords through the API and always responds with this status.
         default:
           description: Unsuccessful authentication
           content:
@@ -4952,6 +4960,10 @@ paths:
         - Security and access endpoints
         - Users
       summary: Update a password
+      description: |
+        #### InfluxDB Cloud
+
+        - Doesn't support changing user passwords through the API.
       security:
         - BasicAuthentication: []
       parameters:
@@ -4972,6 +4984,10 @@ paths:
       responses:
         '204':
           description: Password successfully updated
+        '400':
+          description: |
+            Bad request.
+            InfluxDB Cloud doesn't support changing passwords through the API and always responds with this status.
         default:
           description: Unsuccessful authentication
           content:

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -4631,7 +4631,8 @@ paths:
       description: |
         #### InfluxDB Cloud
 
-        - Doesn't support changing user passwords through the API.
+        InfluxDB Cloud does not support changing user passwords through the API.
+        Use the InfluxDB Cloud user interface to update your password.
       security:
         - BasicAuthentication: []
       parameters:
@@ -4844,7 +4845,8 @@ paths:
       description: |
         #### InfluxDB Cloud
 
-        - Doesn't support changing user passwords through the API.
+        InfluxDB Cloud does not support changing user passwords through the API.
+        Use the InfluxDB Cloud user interface to update your password.
       security:
         - BasicAuthentication: []
       parameters:

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -4628,6 +4628,10 @@ paths:
       tags:
         - Users
       summary: Update a password
+      description: |
+        #### InfluxDB Cloud
+
+        - Doesn't support changing user passwords through the API.
       security:
         - BasicAuthentication: []
       parameters:
@@ -4642,6 +4646,10 @@ paths:
       responses:
         '204':
           description: Success. The password was updated.
+        '400':
+          description: |
+            Bad request.
+            InfluxDB Cloud does not support changing passwords through the API and always responds with this status.
         default:
           description: Unsuccessful authentication
           content:
@@ -4833,6 +4841,10 @@ paths:
         - Security and access endpoints
         - Users
       summary: Update a password
+      description: |
+        #### InfluxDB Cloud
+
+        - Doesn't support changing user passwords through the API.
       security:
         - BasicAuthentication: []
       parameters:
@@ -4853,6 +4865,10 @@ paths:
       responses:
         '204':
           description: Password successfully updated
+        '400':
+          description: |
+            Bad request.
+            InfluxDB Cloud doesn't support changing passwords through the API and always responds with this status.
         default:
           description: Unsuccessful authentication
           content:

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -6822,7 +6822,7 @@
           "Users"
         ],
         "summary": "Update a password",
-        "description": "#### InfluxDB Cloud\n\n- Doesn't support changing user passwords through the API.\n",
+        "description": "#### InfluxDB Cloud\n\nInfluxDB Cloud does not support changing user passwords through the API.\nUse the InfluxDB Cloud user interface to update your password.\n",
         "security": [
           {
             "BasicAuthentication": []
@@ -7164,7 +7164,7 @@
           "Users"
         ],
         "summary": "Update a password",
-        "description": "#### InfluxDB Cloud\n\n- Doesn't support changing user passwords through the API.\n",
+        "description": "#### InfluxDB Cloud\n\nInfluxDB Cloud does not support changing user passwords through the API.\nUse the InfluxDB Cloud user interface to update your password.\n",
         "security": [
           {
             "BasicAuthentication": []

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -6822,6 +6822,7 @@
           "Users"
         ],
         "summary": "Update a password",
+        "description": "#### InfluxDB Cloud\n\n- Doesn't support changing user passwords through the API.\n",
         "security": [
           {
             "BasicAuthentication": []
@@ -6846,6 +6847,9 @@
         "responses": {
           "204": {
             "description": "Success. The password was updated."
+          },
+          "400": {
+            "description": "Bad request.\nInfluxDB Cloud does not support changing passwords through the API and always responds with this status.\n"
           },
           "default": {
             "description": "Unsuccessful authentication",
@@ -7160,6 +7164,7 @@
           "Users"
         ],
         "summary": "Update a password",
+        "description": "#### InfluxDB Cloud\n\n- Doesn't support changing user passwords through the API.\n",
         "security": [
           {
             "BasicAuthentication": []
@@ -7193,6 +7198,9 @@
         "responses": {
           "204": {
             "description": "Password successfully updated"
+          },
+          "400": {
+            "description": "Bad request.\nInfluxDB Cloud doesn't support changing passwords through the API and always responds with this status.\n"
           },
           "default": {
             "description": "Unsuccessful authentication",

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -4752,7 +4752,8 @@ paths:
       description: |
         #### InfluxDB Cloud
 
-        - Doesn't support changing user passwords through the API.
+        InfluxDB Cloud does not support changing user passwords through the API.
+        Use the InfluxDB Cloud user interface to update your password.
       security:
         - BasicAuthentication: []
       parameters:
@@ -4965,7 +4966,8 @@ paths:
       description: |
         #### InfluxDB Cloud
 
-        - Doesn't support changing user passwords through the API.
+        InfluxDB Cloud does not support changing user passwords through the API.
+        Use the InfluxDB Cloud user interface to update your password.
       security:
         - BasicAuthentication: []
       parameters:

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -4749,6 +4749,10 @@ paths:
       tags:
         - Users
       summary: Update a password
+      description: |
+        #### InfluxDB Cloud
+
+        - Doesn't support changing user passwords through the API.
       security:
         - BasicAuthentication: []
       parameters:
@@ -4763,6 +4767,10 @@ paths:
       responses:
         '204':
           description: Success. The password was updated.
+        '400':
+          description: |
+            Bad request.
+            InfluxDB Cloud does not support changing passwords through the API and always responds with this status.
         default:
           description: Unsuccessful authentication
           content:
@@ -4954,6 +4962,10 @@ paths:
         - Security and access endpoints
         - Users
       summary: Update a password
+      description: |
+        #### InfluxDB Cloud
+
+        - Doesn't support changing user passwords through the API.
       security:
         - BasicAuthentication: []
       parameters:
@@ -4974,6 +4986,10 @@ paths:
       responses:
         '204':
           description: Password successfully updated
+        '400':
+          description: |
+            Bad request.
+            InfluxDB Cloud doesn't support changing passwords through the API and always responds with this status.
         default:
           description: Unsuccessful authentication
           content:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -8536,7 +8536,8 @@ paths:
       description: |
         #### InfluxDB Cloud
 
-        - Doesn't support changing user passwords through the API.
+        InfluxDB Cloud does not support changing user passwords through the API.
+        Use the InfluxDB Cloud user interface to update your password.
       operationId: PutMePassword
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
@@ -12492,7 +12493,8 @@ paths:
       description: |
         #### InfluxDB Cloud
 
-        - Doesn't support changing user passwords through the API.
+        InfluxDB Cloud does not support changing user passwords through the API.
+        Use the InfluxDB Cloud user interface to update your password.
       operationId: PostUsersIDPassword
       parameters:
       - $ref: '#/components/parameters/TraceSpan'

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -8533,6 +8533,10 @@ paths:
       - Users
   /api/v2/me/password:
     put:
+      description: |
+        #### InfluxDB Cloud
+
+        - Doesn't support changing user passwords through the API.
       operationId: PutMePassword
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
@@ -8546,6 +8550,10 @@ paths:
       responses:
         "204":
           description: Success. The password was updated.
+        "400":
+          description: |
+            Bad request.
+            InfluxDB Cloud does not support changing passwords through the API and always responds with this status.
         default:
           content:
             application/json:
@@ -12481,6 +12489,10 @@ paths:
       - Users
   /api/v2/users/{userID}/password:
     post:
+      description: |
+        #### InfluxDB Cloud
+
+        - Doesn't support changing user passwords through the API.
       operationId: PostUsersIDPassword
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
@@ -12500,6 +12512,10 @@ paths:
       responses:
         "204":
           description: Password successfully updated
+        "400":
+          description: |
+            Bad request.
+            InfluxDB Cloud doesn't support changing passwords through the API and always responds with this status.
         default:
           content:
             application/json:

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -9368,7 +9368,8 @@ paths:
       description: |
         #### InfluxDB Cloud
 
-        - Doesn't support changing user passwords through the API.
+        InfluxDB Cloud does not support changing user passwords through the API.
+        Use the InfluxDB Cloud user interface to update your password.
       operationId: PutMePassword
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
@@ -14446,7 +14447,8 @@ paths:
       description: |
         #### InfluxDB Cloud
 
-        - Doesn't support changing user passwords through the API.
+        InfluxDB Cloud does not support changing user passwords through the API.
+        Use the InfluxDB Cloud user interface to update your password.
       operationId: PostUsersIDPassword
       parameters:
       - $ref: '#/components/parameters/TraceSpan'

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -9365,6 +9365,10 @@ paths:
       - Users
   /api/v2/me/password:
     put:
+      description: |
+        #### InfluxDB Cloud
+
+        - Doesn't support changing user passwords through the API.
       operationId: PutMePassword
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
@@ -9378,6 +9382,10 @@ paths:
       responses:
         "204":
           description: Success. The password was updated.
+        "400":
+          description: |
+            Bad request.
+            InfluxDB Cloud does not support changing passwords through the API and always responds with this status.
         default:
           content:
             application/json:
@@ -14435,6 +14443,10 @@ paths:
       - Users
   /api/v2/users/{userID}/password:
     post:
+      description: |
+        #### InfluxDB Cloud
+
+        - Doesn't support changing user passwords through the API.
       operationId: PostUsersIDPassword
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
@@ -14454,6 +14466,10 @@ paths:
       responses:
         "204":
           description: Password successfully updated
+        "400":
+          description: |
+            Bad request.
+            InfluxDB Cloud doesn't support changing passwords through the API and always responds with this status.
         default:
           content:
             application/json:

--- a/src/common/paths/me_password.yml
+++ b/src/common/paths/me_password.yml
@@ -6,7 +6,8 @@ put:
   description: |
     #### InfluxDB Cloud
 
-    - Doesn't support changing user passwords through the API.
+    InfluxDB Cloud does not support changing user passwords through the API.
+    Use the InfluxDB Cloud user interface to update your password.
   security:
     - BasicAuthentication: []
   parameters:

--- a/src/common/paths/me_password.yml
+++ b/src/common/paths/me_password.yml
@@ -3,23 +3,31 @@ put:
   tags:
     - Users
   summary: Update a password
+  description: |
+    #### InfluxDB Cloud
+
+    - Doesn't support changing user passwords through the API.
   security:
     - BasicAuthentication: []
   parameters:
-    - $ref: "../parameters/TraceSpan.yml"
+    - $ref: '../parameters/TraceSpan.yml'
   requestBody:
     description: The new password.
     required: true
     content:
       application/json:
         schema:
-          $ref: "../schemas/PasswordResetBody.yml"
+          $ref: '../schemas/PasswordResetBody.yml'
   responses:
-    "204":
+    '204':
       description: Success. The password was updated.
+    '400':
+      description: |
+        Bad request.
+        InfluxDB Cloud does not support changing passwords through the API and always responds with this status.
     default:
       description: Unsuccessful authentication
       content:
         application/json:
           schema:
-            $ref: "../schemas/Error.yml"
+            $ref: '../schemas/Error.yml'

--- a/src/common/paths/users_userID_password.yml
+++ b/src/common/paths/users_userID_password.yml
@@ -7,7 +7,8 @@ post:
   description: |
     #### InfluxDB Cloud
 
-    - Doesn't support changing user passwords through the API.
+    InfluxDB Cloud does not support changing user passwords through the API.
+    Use the InfluxDB Cloud user interface to update your password.
   security:
     - BasicAuthentication: []
   parameters:

--- a/src/common/paths/users_userID_password.yml
+++ b/src/common/paths/users_userID_password.yml
@@ -4,10 +4,14 @@ post:
     - Security and access endpoints
     - Users
   summary: Update a password
+  description: |
+    #### InfluxDB Cloud
+
+    - Doesn't support changing user passwords through the API.
   security:
     - BasicAuthentication: []
   parameters:
-    - $ref: "../parameters/TraceSpan.yml"
+    - $ref: '../parameters/TraceSpan.yml'
     - in: path
       name: userID
       schema:
@@ -20,13 +24,17 @@ post:
     content:
       application/json:
         schema:
-          $ref: "../schemas/PasswordResetBody.yml"
+          $ref: '../schemas/PasswordResetBody.yml'
   responses:
-    "204":
+    '204':
       description: Password successfully updated
+    '400':
+      description: |
+        Bad request.
+        InfluxDB Cloud doesn't support changing passwords through the API and always responds with this status.
     default:
       description: Unsuccessful authentication
       content:
         application/json:
           schema:
-            $ref: "../schemas/Error.yml"
+            $ref: '../schemas/Error.yml'


### PR DESCRIPTION
Closes https://github.com/influxdata/idpe/issues/15092

Changing passwords is not supported through the InfluxDB Cloud API, and this PR updates the API docs for that.