### PR TITLE
Docs/411 task logs

### DIFF
--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -2934,26 +2934,20 @@ paths:
           description: |
             Bad request.
             The response body contains detail about the error.
-<<<<<<< HEAD
-=======
 
             #### InfluxDB OSS
 
             - Returns this error if an incorrect value is passed for `org` or `orgID`.
->>>>>>> a6c99ab (docs(error): clarify error summary.)
           content:
             application/json:
               schema:
                 $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
-<<<<<<< HEAD
-=======
               examples:
                 orgProvidedNotFound:
-                  summary: The Org or orgID passed in the request doesn't match the token organization
+                  summary: The org or orgID passed doesn't own the token passed in the header
                   value:
                     code: invalid
                     message: 'failed to decode request body: organization not found'
->>>>>>> a6c99ab (docs(error): clarify error summary.)
         '401':
           $ref: '#/paths/~1tasks/get/responses/401'
         '404':

--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -2913,10 +2913,26 @@ paths:
           description: |
             Bad request.
             The response body contains detail about the error.
+<<<<<<< HEAD
+=======
+
+            #### InfluxDB OSS
+
+            - Returns this error if an incorrect value is passed for `org` or `orgID`.
+>>>>>>> a6c99ab (docs(error): clarify error summary.)
           content:
             application/json:
               schema:
                 $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+<<<<<<< HEAD
+=======
+              examples:
+                orgProvidedNotFound:
+                  summary: The Org or orgID passed in the request doesn't match the token organization
+                  value:
+                    code: invalid
+                    message: 'failed to decode request body: organization not found'
+>>>>>>> a6c99ab (docs(error): clarify error summary.)
         '401':
           $ref: '#/paths/~1tasks/get/responses/401'
         '404':

--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -2769,6 +2769,16 @@ paths:
       description: |
         Creates a [task]({{% INFLUXDB_DOCS_URL %}}/process-data/) and returns the created task.
 
+        Use this endpoint to create a scheduled task that runs a Flux script.
+        In your task, provide one of the following:
+
+          - _`flux`_ property with an inline Flux script
+          - _`scriptID`_ property with an invokable script ID
+
+        #### InfluxDB Cloud
+
+          - Requires either _`flux`_ (Flux query) or _`scriptID`_ (invokable script ID) in the task.
+
         #### Related guides
 
         - [Create a task]({{% INFLUXDB_DOCS_URL %}}/process-data/manage-tasks/create-task/).
@@ -2791,17 +2801,28 @@ paths:
               schema:
                 $ref: '#/components/schemas/Task'
         '400':
-          description: Bad request
+          description: |
+            Bad request
+
+            #### InfluxDB Cloud
+
+              - Returns this error if the task doesn't contain one of _`flux`_ or _`scriptID`_.
+              - Returns this error if the task contains _`flux`_ _and_ _`scriptID`_.
           content:
             application/json:
               schema:
                 $ref: '#/paths/~1tasks~1%7BtaskID%7D/get/responses/400'
               examples:
-                missingFluxError:
-                  summary: Task in request body is missing Flux query
+                fluxAndScriptError:
+                  summary: Task in request body can't contain flux and scriptID properties
                   value:
                     code: invalid
-                    message: 'failed to decode request: missing flux'
+                    message: 'failed to decode request: can not provide both scriptID and flux'
+                missingFluxError:
+                  summary: Task in request body requires a flux or scriptID property
+                  value:
+                    code: invalid
+                    message: 'failed to decode request: flux required'
         '401':
           $ref: '#/paths/~1tasks/get/responses/401'
         '500':

--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -2765,7 +2765,7 @@ paths:
       tags:
         - Data I/O endpoints
         - Tasks
-      summary: Create a new task
+      summary: Create a task
       description: |
         Creates a [task]({{% INFLUXDB_DOCS_URL %}}/process-data/) and returns the created task.
 
@@ -2773,7 +2773,7 @@ paths:
         In your task, provide one of the following:
 
           - _`flux`_ property with an inline Flux script
-          - _`scriptID`_ property with an invokable script ID
+          - _`scriptID`_ property with an [invokable script](#tag/Invokable-Scripts) ID
 
         #### InfluxDB Cloud
 
@@ -2814,12 +2814,12 @@ paths:
                 $ref: '#/paths/~1tasks~1%7BtaskID%7D/get/responses/400'
               examples:
                 fluxAndScriptError:
-                  summary: Task in request body can't contain flux and scriptID properties
+                  summary: The request body can't contain both flux and scriptID
                   value:
                     code: invalid
                     message: 'failed to decode request: can not provide both scriptID and flux'
                 missingFluxError:
-                  summary: Task in request body requires a flux or scriptID property
+                  summary: The request body requires either flux or scriptID
                   value:
                     code: invalid
                     message: 'failed to decode request: flux required'

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -29,7 +29,7 @@
     },
     {
       "name": "Tasks",
-      "description": "Process and analyze your data with tasks in the InfluxDB task engine.\nWith tasks, you can schedule Flux scripts to query, analyze, modify, and act on data.\nIn InfluxDB Cloud, you can create tasks that run [invokable scripts](/#tag/Invokable-Scripts)\nwith parameters.\n\nUse the `/api/v2/tasks` endpoints to create and manage tasks, retry task runs, and retrieve run logs.\n\n#### Related guides\n\n- [Common data processing tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/common-tasks/)\n- [Invoke custom scripts as API endpoints](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/)\n"
+      "description": "Process and analyze your data with tasks in the InfluxDB task engine.\nWith tasks, you can schedule Flux scripts to query, analyze, modify, and act on data.\nIn InfluxDB Cloud, you can create tasks that run [invokable scripts](#tag/Invokable-Scripts)\nwith parameters.\n\nUse the `/api/v2/tasks` endpoints to create and manage tasks, retry task runs, and retrieve run logs.\n\n#### Related guides\n\n- [Common data processing tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/common-tasks/)\n- [Invoke custom scripts as API endpoints](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/)\n"
     },
     {
       "name": "Write",
@@ -10316,8 +10316,8 @@
           "Data I/O endpoints",
           "Tasks"
         ],
-        "summary": "Create a new task",
-        "description": "Creates a [task]({{% INFLUXDB_DOCS_URL %}}/process-data/) and returns the created task.\n\nUse this endpoint to create a scheduled task that runs a Flux script.\nIn your task, provide one of the following:\n\n  - _`flux`_ property with an inline Flux script\n  - _`scriptID`_ property with an invokable script ID\n\n#### InfluxDB Cloud\n\n  - Requires either _`flux`_ (Flux query) or _`scriptID`_ (invokable script ID) in the task.\n\n#### Related guides\n\n- [Create a task]({{% INFLUXDB_DOCS_URL %}}/process-data/manage-tasks/create-task/).\n- [Common tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/common-tasks/)\n- [Task configuration options]({{% INFLUXDB_DOCS_URL %}}/process-data/task-options/)\n",
+        "summary": "Create a task",
+        "description": "Creates a [task]({{% INFLUXDB_DOCS_URL %}}/process-data/) and returns the created task.\n\nUse this endpoint to create a scheduled task that runs a Flux script.\nIn your task, provide one of the following:\n\n  - _`flux`_ property with an inline Flux script\n  - _`scriptID`_ property with an [invokable script](#tag/Invokable-Scripts) ID\n\n#### InfluxDB Cloud\n\n  - Requires either _`flux`_ (Flux query) or _`scriptID`_ (invokable script ID) in the task.\n\n#### Related guides\n\n- [Create a task]({{% INFLUXDB_DOCS_URL %}}/process-data/manage-tasks/create-task/).\n- [Common tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/common-tasks/)\n- [Task configuration options]({{% INFLUXDB_DOCS_URL %}}/process-data/task-options/)\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -10354,14 +10354,14 @@
                 },
                 "examples": {
                   "fluxAndScriptError": {
-                    "summary": "Task in request body can't contain flux and scriptID properties",
+                    "summary": "The request body can't contain both flux and scriptID",
                     "value": {
                       "code": "invalid",
                       "message": "failed to decode request: can not provide both scriptID and flux"
                     }
                   },
                   "missingFluxError": {
-                    "summary": "Task in request body requires a flux or scriptID property",
+                    "summary": "The request body requires either flux or scriptID",
                     "value": {
                       "code": "invalid",
                       "message": "failed to decode request: flux required"

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -29,7 +29,7 @@
     },
     {
       "name": "Tasks",
-      "description": "Process and analyze your data with tasks in the InfluxDB task engine.\nWith tasks, you can schedule Flux scripts to query, analyze, modify, and act on data.\n\nUse the `/api/v2/tasks` endpoints to create and manage tasks, retry task runs, and retrieve run logs.\n\n#### Related guides\n\n- [Common data processing tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/common-tasks/)\n"
+      "description": "Process and analyze your data with tasks in the InfluxDB task engine.\nWith tasks, you can schedule Flux scripts to query, analyze, modify, and act on data.\nWith InfluxDB Cloud, you can manage [invokable scripts](/#tag/Invokable-Scripts)\nfor your organization and schedule tasks that run them with parameters.\n\nUse the `/api/v2/tasks` endpoints to create and manage tasks, retry task runs, and retrieve run logs.\n\n#### Related guides\n\n- [Common data processing tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/common-tasks/)\n"
     },
     {
       "name": "Write",
@@ -6260,37 +6260,37 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Run"
-                }
-              },
-              "examples": {
-                "runSuccess": {
-                  "summary": "A successful task run.",
-                  "value": {
-                    "links": {
-                      "logs": "/api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/logs",
-                      "retry": "/api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/retry",
-                      "self": "/api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000",
-                      "task": "/api/v2/tasks/0996e56b2f378000"
-                    },
-                    "id": "09b070dadaa7d000",
-                    "taskID": "0996e56b2f378000",
-                    "status": "success",
-                    "scheduledFor": "2022-07-18T14:46:06Z",
-                    "startedAt": "2022-07-18T14:46:07.16222Z",
-                    "finishedAt": "2022-07-18T14:46:07.308254Z",
-                    "requestedAt": "2022-07-18T14:46:06Z",
-                    "log": [
-                      {
-                        "runID": "09b070dadaa7d000",
-                        "time": "2022-07-18T14:46:07.101231Z",
-                        "message": "Started task from script: \"option task = {name: \\\"task1\\\", every: 30m} from(bucket: \\\"iot_center\\\") |> range(start: -90d) |> filter(fn: (r) => r._measurement == \\\"environment\\\")               |> aggregateWindow(every: 1h, fn: mean)\""
+                },
+                "examples": {
+                  "runSuccess": {
+                    "summary": "A successful task run.",
+                    "value": {
+                      "links": {
+                        "logs": "/api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/logs",
+                        "retry": "/api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/retry",
+                        "self": "/api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000",
+                        "task": "/api/v2/tasks/0996e56b2f378000"
                       },
-                      {
-                        "runID": "09b070dadaa7d000",
-                        "time": "2022-07-18T14:46:07.242859Z",
-                        "message": "Completed(success)"
-                      }
-                    ]
+                      "id": "09b070dadaa7d000",
+                      "taskID": "0996e56b2f378000",
+                      "status": "success",
+                      "scheduledFor": "2022-07-18T14:46:06Z",
+                      "startedAt": "2022-07-18T14:46:07.16222Z",
+                      "finishedAt": "2022-07-18T14:46:07.308254Z",
+                      "requestedAt": "2022-07-18T14:46:06Z",
+                      "log": [
+                        {
+                          "runID": "09b070dadaa7d000",
+                          "time": "2022-07-18T14:46:07.101231Z",
+                          "message": "Started task from script: \"option task = {name: \\\"task1\\\", every: 30m} from(bucket: \\\"iot_center\\\") |> range(start: -90d) |> filter(fn: (r) => r._measurement == \\\"environment\\\")               |> aggregateWindow(every: 1h, fn: mean)\""
+                        },
+                        {
+                          "runID": "09b070dadaa7d000",
+                          "time": "2022-07-18T14:46:07.242859Z",
+                          "message": "Completed(success)"
+                        }
+                      ]
+                    }
                   }
                 }
               }
@@ -10317,7 +10317,7 @@
           "Tasks"
         ],
         "summary": "Create a new task",
-        "description": "Creates a [task]({{% INFLUXDB_DOCS_URL %}}/process-data/) and returns the created task.\n\n#### Related guides\n\n- [Create a task]({{% INFLUXDB_DOCS_URL %}}/process-data/manage-tasks/create-task/).\n- [Common tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/common-tasks/)\n- [Task configuration options]({{% INFLUXDB_DOCS_URL %}}/process-data/task-options/)\n",
+        "description": "Creates a [task]({{% INFLUXDB_DOCS_URL %}}/process-data/) and returns the created task.\n\nUse this endpoint to create a scheduled task that runs a Flux script.\nIn your task, provide one of the following:\n\n  - _`flux`_ property with an inline Flux script\n  - _`scriptID`_ property with an invokable script ID\n\n#### InfluxDB Cloud\n\n  - Requires either _`flux`_ (Flux query) or _`scriptID`_ (invokable script ID) in the task.\n\n#### Related guides\n\n- [Create a task]({{% INFLUXDB_DOCS_URL %}}/process-data/manage-tasks/create-task/).\n- [Common tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/common-tasks/)\n- [Task configuration options]({{% INFLUXDB_DOCS_URL %}}/process-data/task-options/)\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -10346,18 +10346,25 @@
             }
           },
           "400": {
-            "description": "Bad request",
+            "description": "Bad request\n\n#### InfluxDB Cloud\n\n  - Returns this error if the task doesn't contain one of _`flux`_ or _`scriptID`_.\n  - Returns this error if the task contains _`flux`_ _and_ _`scriptID`_.\n",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/responses/BadRequestError"
                 },
                 "examples": {
-                  "missingFluxError": {
-                    "summary": "Task in request body is missing Flux query",
+                  "fluxAndScriptError": {
+                    "summary": "Task in request body can't contain flux and scriptID properties",
                     "value": {
                       "code": "invalid",
-                      "message": "failed to decode request: missing flux"
+                      "message": "failed to decode request: can not provide both scriptID and flux"
+                    }
+                  },
+                  "missingFluxError": {
+                    "summary": "Task in request body requires a flux or scriptID property",
+                    "value": {
+                      "code": "invalid",
+                      "message": "failed to decode request: flux required"
                     }
                   }
                 }

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -6401,6 +6401,7 @@
           "Tasks"
         ],
         "summary": "Retrieve all logs for a task",
+        "description": "Retrieves a list of all logs for a task.\n\nUse this endpoint to retrieve only the log events for a task,\nwithout additional task metadata.\nEach log event `message` contains detail about the event.\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -6417,7 +6418,7 @@
         ],
         "responses": {
           "200": {
-            "description": "All logs for a task",
+            "description": "Success. The response body contains an `events` list with logs for the task.",
             "content": {
               "application/json": {
                 "schema": {
@@ -6426,15 +6427,20 @@
               }
             }
           },
+          "400": {
+            "$ref": "#/components/responses/BadRequestError"
+          },
+          "401": {
+            "$ref": "#/components/responses/AuthorizationError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ResourceNotFoundError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          },
           "default": {
-            "description": "Unexpected error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
+            "$ref": "#/components/responses/GeneralServerError"
           }
         }
       }

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -18989,27 +18989,20 @@
         }
       },
       "BadRequestError": {
-<<<<<<< HEAD
-        "description": "Bad request.\nThe response body contains detail about the error.\n",
-=======
         "description": "Bad request.\nThe response body contains detail about the error.\n\n#### InfluxDB OSS\n\n- Returns this error if an incorrect value is passed for `org` or `orgID`.\n",
->>>>>>> a6c99ab (docs(error): clarify error summary.)
         "content": {
           "application/json": {
             "schema": {
               "$ref": "#/components/schemas/Error"
-<<<<<<< HEAD
-=======
             },
             "examples": {
               "orgProvidedNotFound": {
-                "summary": "The Org or orgID passed in the request doesn't match the token organization",
+                "summary": "The org or orgID passed doesn't own the token passed in the header",
                 "value": {
                   "code": "invalid",
                   "message": "failed to decode request body: organization not found"
                 }
               }
->>>>>>> a6c99ab (docs(error): clarify error summary.)
             }
           }
         }

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -29,7 +29,7 @@
     },
     {
       "name": "Tasks",
-      "description": "Process and analyze your data with tasks in the InfluxDB task engine.\nWith tasks, you can schedule Flux scripts to query, analyze, modify, and act on data.\nWith InfluxDB Cloud, you can manage [invokable scripts](/#tag/Invokable-Scripts)\nfor your organization and schedule tasks that run them with parameters.\n\nUse the `/api/v2/tasks` endpoints to create and manage tasks, retry task runs, and retrieve run logs.\n\n#### Related guides\n\n- [Common data processing tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/common-tasks/)\n"
+      "description": "Process and analyze your data with tasks in the InfluxDB task engine.\nWith tasks, you can schedule Flux scripts to query, analyze, modify, and act on data.\nIn InfluxDB Cloud, you can create tasks that run [invokable scripts](/#tag/Invokable-Scripts)\nwith parameters.\n\nUse the `/api/v2/tasks` endpoints to create and manage tasks, retry task runs, and retrieve run logs.\n\n#### Related guides\n\n- [Common data processing tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/common-tasks/)\n- [Invoke custom scripts as API endpoints](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/)\n"
     },
     {
       "name": "Write",

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -6228,7 +6228,8 @@
         "tags": [
           "Tasks"
         ],
-        "summary": "Retrieve a single run for a task.",
+        "summary": "Retrieve a run for a task.",
+        "description": "Retrieves a specific run for a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task).\n\nUse this endpoint to retrieve detail and logs for a specific task run.\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -6254,24 +6255,61 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the run record.",
+            "description": "Success. The response body contains the task run.",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Run"
                 }
-              }
-            }
-          },
-          "default": {
-            "description": "Unexpected error.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
+              },
+              "examples": {
+                "runSuccess": {
+                  "summary": "A successful task run.",
+                  "value": {
+                    "links": {
+                      "logs": "/api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/logs",
+                      "retry": "/api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/retry",
+                      "self": "/api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000",
+                      "task": "/api/v2/tasks/0996e56b2f378000"
+                    },
+                    "id": "09b070dadaa7d000",
+                    "taskID": "0996e56b2f378000",
+                    "status": "success",
+                    "scheduledFor": "2022-07-18T14:46:06Z",
+                    "startedAt": "2022-07-18T14:46:07.16222Z",
+                    "finishedAt": "2022-07-18T14:46:07.308254Z",
+                    "requestedAt": "2022-07-18T14:46:06Z",
+                    "log": [
+                      {
+                        "runID": "09b070dadaa7d000",
+                        "time": "2022-07-18T14:46:07.101231Z",
+                        "message": "Started task from script: \"option task = {name: \\\"task1\\\", every: 30m} from(bucket: \\\"iot_center\\\") |> range(start: -90d) |> filter(fn: (r) => r._measurement == \\\"environment\\\")               |> aggregateWindow(every: 1h, fn: mean)\""
+                      },
+                      {
+                        "runID": "09b070dadaa7d000",
+                        "time": "2022-07-18T14:46:07.242859Z",
+                        "message": "Completed(success)"
+                      }
+                    ]
+                  }
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequestError"
+          },
+          "401": {
+            "$ref": "#/components/responses/AuthorizationError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ResourceNotFoundError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralServerError"
           }
         }
       },
@@ -6280,7 +6318,8 @@
         "tags": [
           "Tasks"
         ],
-        "summary": "Cancel a running task.\n\n#### InfluxDB Cloud\n\n  - Doesn't support this operation.\n",
+        "summary": "Cancel a running task",
+        "description": "Cancels a running [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task).\n\nUse this endpoint with InfluxDB OSS to cancel a running task.\n\n#### InfluxDB Cloud\n\n  - Doesn't support this operation.\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -6301,15 +6340,24 @@
               "type": "string"
             },
             "required": true,
-            "description": "The run ID."
+            "description": "The ID of the task run to cancel."
           }
         ],
         "responses": {
           "204": {
-            "description": "Delete has been accepted."
+            "description": "Success. The `DELETE` is accepted and the run will be cancelled.\n\n#### InfluxDB Cloud\n\n  - Doesn't support this operation.\n"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequestError"
+          },
+          "401": {
+            "$ref": "#/components/responses/AuthorizationError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ResourceNotFoundError"
           },
           "405": {
-            "description": "Method not allowed.\n\n#### InfluxDB Cloud\n\n  - Cancelling task runs is not supported in InfluxDB Cloud.\n\n#### InfluxDB OSS\n\n  - Doesn't return this error.\n",
+            "description": "Method not allowed.\n\n#### InfluxDB Cloud\n\n  - Always returns this error; cancelling a task run is not supported.\n\n#### InfluxDB OSS\n\n  - Doesn't return this error.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -6318,15 +6366,11 @@
               }
             }
           },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          },
           "default": {
-            "description": "Unexpected error.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
+            "$ref": "#/components/responses/GeneralServerError"
           }
         }
       }
@@ -6401,7 +6445,7 @@
           "Tasks"
         ],
         "summary": "Retrieve all logs for a task",
-        "description": "Retrieves a list of all logs for a task.\n\nUse this endpoint to retrieve only the log events for a task,\nwithout additional task metadata.\nEach log event `message` contains detail about the event.\n",
+        "description": "Retrieves a list of all logs for a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task).\n\nWhen an InfluxDB task runs, a “run” record is created in the task’s history.\nLogs associated with each run provide relevant log messages, timestamps, and the exit status of the run attempt.\n\nUse this endpoint to retrieve only the log events for a task,\nwithout additional task metadata.\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -6418,11 +6462,52 @@
         ],
         "responses": {
           "200": {
-            "description": "Success. The response body contains an `events` list with logs for the task.",
+            "description": "Success. The response body contains an `events` list with logs for the task.\nEach log event `message` contains detail about the event.\nIf a task run fails, InfluxDB logs an event with the reason for the failure.\n",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Logs"
+                },
+                "examples": {
+                  "taskSuccess": {
+                    "summary": "Events for successful task.",
+                    "value": {
+                      "events": [
+                        {
+                          "runID": "09b070dadaa7d000",
+                          "time": "2022-07-18T14:46:07.101231Z",
+                          "message": "Started task from script: \"option task = {name: \\\"task1\\\", every: 30m} from(bucket: \\\"iot_center\\\") |> range(start: -90d) |> filter(fn: (r) => r._measurement == \\\"environment\\\") |> aggregateWindow(every: 1h, fn: mean)\""
+                        },
+                        {
+                          "runID": "09b070dadaa7d000",
+                          "time": "2022-07-18T14:46:07.242859Z",
+                          "message": "Completed(success)"
+                        }
+                      ]
+                    }
+                  },
+                  "taskFailure": {
+                    "summary": "Events for a failed task.",
+                    "value": {
+                      "events": [
+                        {
+                          "runID": "09a946fc3167d000",
+                          "time": "2022-07-13T07:06:54.198167Z",
+                          "message": "Started task from script: \"option task = {name: \\\"test task\\\", every: 3d, offset: 0s}\""
+                        },
+                        {
+                          "runID": "09a946fc3167d000",
+                          "time": "2022-07-13T07:07:13.104037Z",
+                          "message": "Completed(failed)"
+                        },
+                        {
+                          "runID": "09a946fc3167d000",
+                          "time": "2022-07-13T08:24:37.115323Z",
+                          "message": "error exhausting result iterator: error in query specification while starting program: this Flux script returns no streaming data. Consider adding a \"yield\" or invoking streaming functions directly, without performing an assignment"
+                        }
+                      ]
+                    }
+                  }
                 }
               }
             }

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -18982,11 +18982,27 @@
         }
       },
       "BadRequestError": {
+<<<<<<< HEAD
         "description": "Bad request.\nThe response body contains detail about the error.\n",
+=======
+        "description": "Bad request.\nThe response body contains detail about the error.\n\n#### InfluxDB OSS\n\n- Returns this error if an incorrect value is passed for `org` or `orgID`.\n",
+>>>>>>> a6c99ab (docs(error): clarify error summary.)
         "content": {
           "application/json": {
             "schema": {
               "$ref": "#/components/schemas/Error"
+<<<<<<< HEAD
+=======
+            },
+            "examples": {
+              "orgProvidedNotFound": {
+                "summary": "The Org or orgID passed in the request doesn't match the token organization",
+                "value": {
+                  "code": "invalid",
+                  "message": "failed to decode request body: organization not found"
+                }
+              }
+>>>>>>> a6c99ab (docs(error): clarify error summary.)
             }
           }
         }

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -45,7 +45,7 @@ tags:
     description: |
       Process and analyze your data with tasks in the InfluxDB task engine.
       With tasks, you can schedule Flux scripts to query, analyze, modify, and act on data.
-      In InfluxDB Cloud, you can create tasks that run [invokable scripts](/#tag/Invokable-Scripts)
+      In InfluxDB Cloud, you can create tasks that run [invokable scripts](#tag/Invokable-Scripts)
       with parameters.
 
       Use the `/api/v2/tasks` endpoints to create and manage tasks, retry task runs, and retrieve run logs.
@@ -7020,7 +7020,7 @@ paths:
       tags:
         - Data I/O endpoints
         - Tasks
-      summary: Create a new task
+      summary: Create a task
       description: |
         Creates a [task](https://docs.influxdata.com/influxdb/cloud/process-data/) and returns the created task.
 
@@ -7028,7 +7028,7 @@ paths:
         In your task, provide one of the following:
 
           - _`flux`_ property with an inline Flux script
-          - _`scriptID`_ property with an invokable script ID
+          - _`scriptID`_ property with an [invokable script](#tag/Invokable-Scripts) ID
 
         #### InfluxDB Cloud
 
@@ -7069,12 +7069,12 @@ paths:
                 $ref: '#/components/responses/BadRequestError'
               examples:
                 fluxAndScriptError:
-                  summary: Task in request body can't contain flux and scriptID properties
+                  summary: The request body can't contain both flux and scriptID
                   value:
                     code: invalid
                     message: 'failed to decode request: can not provide both scriptID and flux'
                 missingFluxError:
-                  summary: Task in request body requires a flux or scriptID property
+                  summary: The request body requires either flux or scriptID
                   value:
                     code: invalid
                     message: 'failed to decode request: flux required'

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -4401,7 +4401,11 @@ paths:
       operationId: GetTasksIDRunsID
       tags:
         - Tasks
-      summary: Retrieve a single run for a task.
+      summary: Retrieve a run for a task.
+      description: |
+        Retrieves a specific run for a [task](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#task).
+
+        Use this endpoint to retrieve detail and logs for a specific task run.
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -4418,23 +4422,53 @@ paths:
           description: The run ID.
       responses:
         '200':
-          description: Returns the run record.
+          description: Success. The response body contains the task run.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Run'
+            examples:
+              runSuccess:
+                summary: A successful task run.
+                value:
+                  links:
+                    logs: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/logs
+                    retry: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/retry
+                    self: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000
+                    task: /api/v2/tasks/0996e56b2f378000
+                  id: 09b070dadaa7d000
+                  taskID: 0996e56b2f378000
+                  status: success
+                  scheduledFor: '2022-07-18T14:46:06Z'
+                  startedAt: '2022-07-18T14:46:07.16222Z'
+                  finishedAt: '2022-07-18T14:46:07.308254Z'
+                  requestedAt: '2022-07-18T14:46:06Z'
+                  log:
+                    - runID: 09b070dadaa7d000
+                      time: '2022-07-18T14:46:07.101231Z'
+                      message: 'Started task from script: "option task = {name: \"task1\", every: 30m} from(bucket: \"iot_center\") |> range(start: -90d) |> filter(fn: (r) => r._measurement == \"environment\")               |> aggregateWindow(every: 1h, fn: mean)"'
+                    - runID: 09b070dadaa7d000
+                      time: '2022-07-18T14:46:07.242859Z'
+                      message: Completed(success)
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/AuthorizationError'
+        '404':
+          $ref: '#/components/responses/ResourceNotFoundError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
         default:
-          description: Unexpected error.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/GeneralServerError'
     delete:
       operationId: DeleteTasksIDRunsID
       tags:
         - Tasks
-      summary: |
-        Cancel a running task.
+      summary: Cancel a running task
+      description: |
+        Cancels a running [task](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#task).
+
+        Use this endpoint with InfluxDB OSS to cancel a running task.
 
         #### InfluxDB Cloud
 
@@ -4452,17 +4486,28 @@ paths:
           schema:
             type: string
           required: true
-          description: The run ID.
+          description: The ID of the task run to cancel.
       responses:
         '204':
-          description: Delete has been accepted.
+          description: |
+            Success. The `DELETE` is accepted and the run will be cancelled.
+
+            #### InfluxDB Cloud
+
+              - Doesn't support this operation.
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/AuthorizationError'
+        '404':
+          $ref: '#/components/responses/ResourceNotFoundError'
         '405':
           description: |
             Method not allowed.
 
             #### InfluxDB Cloud
 
-              - Cancelling task runs is not supported in InfluxDB Cloud.
+              - Always returns this error; cancelling a task run is not supported.
 
             #### InfluxDB OSS
 
@@ -4471,12 +4516,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
         default:
-          description: Unexpected error.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/GeneralServerError'
   '/tasks/{taskID}/runs/{runID}/retry':
     post:
       operationId: PostTasksIDRunsIDRetry
@@ -4522,11 +4565,13 @@ paths:
         - Tasks
       summary: Retrieve all logs for a task
       description: |
-        Retrieves a list of all logs for a task.
+        Retrieves a list of all logs for a [task](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#task).
+
+        When an InfluxDB task runs, a “run” record is created in the task’s history.
+        Logs associated with each run provide relevant log messages, timestamps, and the exit status of the run attempt.
 
         Use this endpoint to retrieve only the log events for a task,
         without additional task metadata.
-        Each log event `message` contains detail about the event.
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -4537,11 +4582,38 @@ paths:
           description: The task ID.
       responses:
         '200':
-          description: Success. The response body contains an `events` list with logs for the task.
+          description: |
+            Success. The response body contains an `events` list with logs for the task.
+            Each log event `message` contains detail about the event.
+            If a task run fails, InfluxDB logs an event with the reason for the failure.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Logs'
+              examples:
+                taskSuccess:
+                  summary: Events for successful task.
+                  value:
+                    events:
+                      - runID: 09b070dadaa7d000
+                        time: '2022-07-18T14:46:07.101231Z'
+                        message: 'Started task from script: "option task = {name: \"task1\", every: 30m} from(bucket: \"iot_center\") |> range(start: -90d) |> filter(fn: (r) => r._measurement == \"environment\") |> aggregateWindow(every: 1h, fn: mean)"'
+                      - runID: 09b070dadaa7d000
+                        time: '2022-07-18T14:46:07.242859Z'
+                        message: Completed(success)
+                taskFailure:
+                  summary: Events for a failed task.
+                  value:
+                    events:
+                      - runID: 09a946fc3167d000
+                        time: '2022-07-13T07:06:54.198167Z'
+                        message: 'Started task from script: "option task = {name: \"test task\", every: 3d, offset: 0s}"'
+                      - runID: 09a946fc3167d000
+                        time: '2022-07-13T07:07:13.104037Z'
+                        message: Completed(failed)
+                      - runID: 09a946fc3167d000
+                        time: '2022-07-13T08:24:37.115323Z'
+                        message: 'error exhausting result iterator: error in query specification while starting program: this Flux script returns no streaming data. Consider adding a "yield" or invoking streaming functions directly, without performing an assignment'
         '400':
           $ref: '#/components/responses/BadRequestError'
         '401':

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -13006,26 +13006,20 @@ components:
       description: |
         Bad request.
         The response body contains detail about the error.
-<<<<<<< HEAD
-=======
 
         #### InfluxDB OSS
 
         - Returns this error if an incorrect value is passed for `org` or `orgID`.
->>>>>>> a6c99ab (docs(error): clarify error summary.)
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
-<<<<<<< HEAD
-=======
           examples:
             orgProvidedNotFound:
-              summary: The Org or orgID passed in the request doesn't match the token organization
+              summary: The org or orgID passed doesn't own the token passed in the header
               value:
                 code: invalid
                 message: 'failed to decode request body: organization not found'
->>>>>>> a6c99ab (docs(error): clarify error summary.)
     GeneralServerError:
       description: Non 2XX error response from server.
       content:

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -4521,6 +4521,12 @@ paths:
       tags:
         - Tasks
       summary: Retrieve all logs for a task
+      description: |
+        Retrieves a list of all logs for a task.
+
+        Use this endpoint to retrieve only the log events for a task,
+        without additional task metadata.
+        Each log event `message` contains detail about the event.
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -4531,17 +4537,21 @@ paths:
           description: The task ID.
       responses:
         '200':
-          description: All logs for a task
+          description: Success. The response body contains an `events` list with logs for the task.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Logs'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/AuthorizationError'
+        '404':
+          $ref: '#/components/responses/ResourceNotFoundError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
         default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/GeneralServerError'
   '/tasks/{taskID}/runs/{runID}/logs':
     get:
       operationId: GetTasksIDRunsIDLogs

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -12983,10 +12983,26 @@ components:
       description: |
         Bad request.
         The response body contains detail about the error.
+<<<<<<< HEAD
+=======
+
+        #### InfluxDB OSS
+
+        - Returns this error if an incorrect value is passed for `org` or `orgID`.
+>>>>>>> a6c99ab (docs(error): clarify error summary.)
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
+<<<<<<< HEAD
+=======
+          examples:
+            orgProvidedNotFound:
+              summary: The Org or orgID passed in the request doesn't match the token organization
+              value:
+                code: invalid
+                message: 'failed to decode request body: organization not found'
+>>>>>>> a6c99ab (docs(error): clarify error summary.)
     GeneralServerError:
       description: Non 2XX error response from server.
       content:

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -45,14 +45,15 @@ tags:
     description: |
       Process and analyze your data with tasks in the InfluxDB task engine.
       With tasks, you can schedule Flux scripts to query, analyze, modify, and act on data.
-      With InfluxDB Cloud, you can manage [invokable scripts](/#tag/Invokable-Scripts)
-      for your organization and schedule tasks that run them with parameters.
+      In InfluxDB Cloud, you can create tasks that run [invokable scripts](/#tag/Invokable-Scripts)
+      with parameters.
 
       Use the `/api/v2/tasks` endpoints to create and manage tasks, retry task runs, and retrieve run logs.
 
       #### Related guides
 
       - [Common data processing tasks](https://docs.influxdata.com/influxdb/cloud/process-data/common-tasks/)
+      - [Invoke custom scripts as API endpoints](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/)
   - name: Write
     description: |
       Write time series data to buckets.

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -45,6 +45,8 @@ tags:
     description: |
       Process and analyze your data with tasks in the InfluxDB task engine.
       With tasks, you can schedule Flux scripts to query, analyze, modify, and act on data.
+      With InfluxDB Cloud, you can manage [invokable scripts](/#tag/Invokable-Scripts)
+      for your organization and schedule tasks that run them with parameters.
 
       Use the `/api/v2/tasks` endpoints to create and manage tasks, retry task runs, and retrieve run logs.
 
@@ -4427,29 +4429,29 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Run'
-            examples:
-              runSuccess:
-                summary: A successful task run.
-                value:
-                  links:
-                    logs: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/logs
-                    retry: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/retry
-                    self: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000
-                    task: /api/v2/tasks/0996e56b2f378000
-                  id: 09b070dadaa7d000
-                  taskID: 0996e56b2f378000
-                  status: success
-                  scheduledFor: '2022-07-18T14:46:06Z'
-                  startedAt: '2022-07-18T14:46:07.16222Z'
-                  finishedAt: '2022-07-18T14:46:07.308254Z'
-                  requestedAt: '2022-07-18T14:46:06Z'
-                  log:
-                    - runID: 09b070dadaa7d000
-                      time: '2022-07-18T14:46:07.101231Z'
-                      message: 'Started task from script: "option task = {name: \"task1\", every: 30m} from(bucket: \"iot_center\") |> range(start: -90d) |> filter(fn: (r) => r._measurement == \"environment\")               |> aggregateWindow(every: 1h, fn: mean)"'
-                    - runID: 09b070dadaa7d000
-                      time: '2022-07-18T14:46:07.242859Z'
-                      message: Completed(success)
+              examples:
+                runSuccess:
+                  summary: A successful task run.
+                  value:
+                    links:
+                      logs: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/logs
+                      retry: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/retry
+                      self: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000
+                      task: /api/v2/tasks/0996e56b2f378000
+                    id: 09b070dadaa7d000
+                    taskID: 0996e56b2f378000
+                    status: success
+                    scheduledFor: '2022-07-18T14:46:06Z'
+                    startedAt: '2022-07-18T14:46:07.16222Z'
+                    finishedAt: '2022-07-18T14:46:07.308254Z'
+                    requestedAt: '2022-07-18T14:46:06Z'
+                    log:
+                      - runID: 09b070dadaa7d000
+                        time: '2022-07-18T14:46:07.101231Z'
+                        message: 'Started task from script: "option task = {name: \"task1\", every: 30m} from(bucket: \"iot_center\") |> range(start: -90d) |> filter(fn: (r) => r._measurement == \"environment\")               |> aggregateWindow(every: 1h, fn: mean)"'
+                      - runID: 09b070dadaa7d000
+                        time: '2022-07-18T14:46:07.242859Z'
+                        message: Completed(success)
         '400':
           $ref: '#/components/responses/BadRequestError'
         '401':
@@ -7021,6 +7023,16 @@ paths:
       description: |
         Creates a [task](https://docs.influxdata.com/influxdb/cloud/process-data/) and returns the created task.
 
+        Use this endpoint to create a scheduled task that runs a Flux script.
+        In your task, provide one of the following:
+
+          - _`flux`_ property with an inline Flux script
+          - _`scriptID`_ property with an invokable script ID
+
+        #### InfluxDB Cloud
+
+          - Requires either _`flux`_ (Flux query) or _`scriptID`_ (invokable script ID) in the task.
+
         #### Related guides
 
         - [Create a task](https://docs.influxdata.com/influxdb/cloud/process-data/manage-tasks/create-task/).
@@ -7043,17 +7055,28 @@ paths:
               schema:
                 $ref: '#/components/schemas/Task'
         '400':
-          description: Bad request
+          description: |
+            Bad request
+
+            #### InfluxDB Cloud
+
+              - Returns this error if the task doesn't contain one of _`flux`_ or _`scriptID`_.
+              - Returns this error if the task contains _`flux`_ _and_ _`scriptID`_.
           content:
             application/json:
               schema:
                 $ref: '#/components/responses/BadRequestError'
               examples:
-                missingFluxError:
-                  summary: Task in request body is missing Flux query
+                fluxAndScriptError:
+                  summary: Task in request body can't contain flux and scriptID properties
                   value:
                     code: invalid
-                    message: 'failed to decode request: missing flux'
+                    message: 'failed to decode request: can not provide both scriptID and flux'
+                missingFluxError:
+                  summary: Task in request body requires a flux or scriptID property
+                  value:
+                    code: invalid
+                    message: 'failed to decode request: flux required'
         '401':
           $ref: '#/components/responses/AuthorizationError'
         '500':

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -10872,10 +10872,26 @@ components:
       description: |
         Bad request.
         The response body contains detail about the error.
+<<<<<<< HEAD
+=======
+
+        #### InfluxDB OSS
+
+        - Returns this error if an incorrect value is passed for `org` or `orgID`.
+>>>>>>> a6c99ab (docs(error): clarify error summary.)
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
+<<<<<<< HEAD
+=======
+          examples:
+            orgProvidedNotFound:
+              summary: The Org or orgID passed in the request doesn't match the token organization
+              value:
+                code: invalid
+                message: 'failed to decode request body: organization not found'
+>>>>>>> a6c99ab (docs(error): clarify error summary.)
     GeneralServerError:
       description: Non 2XX error response from server.
       content:

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -10872,26 +10872,20 @@ components:
       description: |
         Bad request.
         The response body contains detail about the error.
-<<<<<<< HEAD
-=======
 
         #### InfluxDB OSS
 
         - Returns this error if an incorrect value is passed for `org` or `orgID`.
->>>>>>> a6c99ab (docs(error): clarify error summary.)
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
-<<<<<<< HEAD
-=======
           examples:
             orgProvidedNotFound:
-              summary: The Org or orgID passed in the request doesn't match the token organization
+              summary: The org or orgID passed doesn't own the token passed in the header
               value:
                 code: invalid
                 message: 'failed to decode request body: organization not found'
->>>>>>> a6c99ab (docs(error): clarify error summary.)
     GeneralServerError:
       description: Non 2XX error response from server.
       content:

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -4272,7 +4272,11 @@ paths:
       operationId: GetTasksIDRunsID
       tags:
         - Tasks
-      summary: Retrieve a single run for a task.
+      summary: Retrieve a run for a task.
+      description: |
+        Retrieves a specific run for a [task](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#task).
+
+        Use this endpoint to retrieve detail and logs for a specific task run.
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -4289,23 +4293,53 @@ paths:
           description: The run ID.
       responses:
         '200':
-          description: Returns the run record.
+          description: Success. The response body contains the task run.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Run'
+            examples:
+              runSuccess:
+                summary: A successful task run.
+                value:
+                  links:
+                    logs: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/logs
+                    retry: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/retry
+                    self: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000
+                    task: /api/v2/tasks/0996e56b2f378000
+                  id: 09b070dadaa7d000
+                  taskID: 0996e56b2f378000
+                  status: success
+                  scheduledFor: '2022-07-18T14:46:06Z'
+                  startedAt: '2022-07-18T14:46:07.16222Z'
+                  finishedAt: '2022-07-18T14:46:07.308254Z'
+                  requestedAt: '2022-07-18T14:46:06Z'
+                  log:
+                    - runID: 09b070dadaa7d000
+                      time: '2022-07-18T14:46:07.101231Z'
+                      message: 'Started task from script: "option task = {name: \"task1\", every: 30m} from(bucket: \"iot_center\") |> range(start: -90d) |> filter(fn: (r) => r._measurement == \"environment\")               |> aggregateWindow(every: 1h, fn: mean)"'
+                    - runID: 09b070dadaa7d000
+                      time: '2022-07-18T14:46:07.242859Z'
+                      message: Completed(success)
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/AuthorizationError'
+        '404':
+          $ref: '#/components/responses/ResourceNotFoundError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
         default:
-          description: Unexpected error.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/GeneralServerError'
     delete:
       operationId: DeleteTasksIDRunsID
       tags:
         - Tasks
-      summary: |
-        Cancel a running task.
+      summary: Cancel a running task
+      description: |
+        Cancels a running [task](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#task).
+
+        Use this endpoint with InfluxDB OSS to cancel a running task.
 
         #### InfluxDB Cloud
 
@@ -4323,17 +4357,28 @@ paths:
           schema:
             type: string
           required: true
-          description: The run ID.
+          description: The ID of the task run to cancel.
       responses:
         '204':
-          description: Delete has been accepted.
+          description: |
+            Success. The `DELETE` is accepted and the run will be cancelled.
+
+            #### InfluxDB Cloud
+
+              - Doesn't support this operation.
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/AuthorizationError'
+        '404':
+          $ref: '#/components/responses/ResourceNotFoundError'
         '405':
           description: |
             Method not allowed.
 
             #### InfluxDB Cloud
 
-              - Cancelling task runs is not supported in InfluxDB Cloud.
+              - Always returns this error; cancelling a task run is not supported.
 
             #### InfluxDB OSS
 
@@ -4342,12 +4387,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
         default:
-          description: Unexpected error.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/GeneralServerError'
   '/tasks/{taskID}/runs/{runID}/retry':
     post:
       operationId: PostTasksIDRunsIDRetry
@@ -4393,11 +4436,13 @@ paths:
         - Tasks
       summary: Retrieve all logs for a task
       description: |
-        Retrieves a list of all logs for a task.
+        Retrieves a list of all logs for a [task](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#task).
+
+        When an InfluxDB task runs, a “run” record is created in the task’s history.
+        Logs associated with each run provide relevant log messages, timestamps, and the exit status of the run attempt.
 
         Use this endpoint to retrieve only the log events for a task,
         without additional task metadata.
-        Each log event `message` contains detail about the event.
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -4408,11 +4453,38 @@ paths:
           description: The task ID.
       responses:
         '200':
-          description: Success. The response body contains an `events` list with logs for the task.
+          description: |
+            Success. The response body contains an `events` list with logs for the task.
+            Each log event `message` contains detail about the event.
+            If a task run fails, InfluxDB logs an event with the reason for the failure.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Logs'
+              examples:
+                taskSuccess:
+                  summary: Events for successful task.
+                  value:
+                    events:
+                      - runID: 09b070dadaa7d000
+                        time: '2022-07-18T14:46:07.101231Z'
+                        message: 'Started task from script: "option task = {name: \"task1\", every: 30m} from(bucket: \"iot_center\") |> range(start: -90d) |> filter(fn: (r) => r._measurement == \"environment\") |> aggregateWindow(every: 1h, fn: mean)"'
+                      - runID: 09b070dadaa7d000
+                        time: '2022-07-18T14:46:07.242859Z'
+                        message: Completed(success)
+                taskFailure:
+                  summary: Events for a failed task.
+                  value:
+                    events:
+                      - runID: 09a946fc3167d000
+                        time: '2022-07-13T07:06:54.198167Z'
+                        message: 'Started task from script: "option task = {name: \"test task\", every: 3d, offset: 0s}"'
+                      - runID: 09a946fc3167d000
+                        time: '2022-07-13T07:07:13.104037Z'
+                        message: Completed(failed)
+                      - runID: 09a946fc3167d000
+                        time: '2022-07-13T08:24:37.115323Z'
+                        message: 'error exhausting result iterator: error in query specification while starting program: this Flux script returns no streaming data. Consider adding a "yield" or invoking streaming functions directly, without performing an assignment'
         '400':
           $ref: '#/components/responses/BadRequestError'
         '401':

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -4298,29 +4298,29 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Run'
-            examples:
-              runSuccess:
-                summary: A successful task run.
-                value:
-                  links:
-                    logs: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/logs
-                    retry: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/retry
-                    self: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000
-                    task: /api/v2/tasks/0996e56b2f378000
-                  id: 09b070dadaa7d000
-                  taskID: 0996e56b2f378000
-                  status: success
-                  scheduledFor: '2022-07-18T14:46:06Z'
-                  startedAt: '2022-07-18T14:46:07.16222Z'
-                  finishedAt: '2022-07-18T14:46:07.308254Z'
-                  requestedAt: '2022-07-18T14:46:06Z'
-                  log:
-                    - runID: 09b070dadaa7d000
-                      time: '2022-07-18T14:46:07.101231Z'
-                      message: 'Started task from script: "option task = {name: \"task1\", every: 30m} from(bucket: \"iot_center\") |> range(start: -90d) |> filter(fn: (r) => r._measurement == \"environment\")               |> aggregateWindow(every: 1h, fn: mean)"'
-                    - runID: 09b070dadaa7d000
-                      time: '2022-07-18T14:46:07.242859Z'
-                      message: Completed(success)
+              examples:
+                runSuccess:
+                  summary: A successful task run.
+                  value:
+                    links:
+                      logs: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/logs
+                      retry: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/retry
+                      self: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000
+                      task: /api/v2/tasks/0996e56b2f378000
+                    id: 09b070dadaa7d000
+                    taskID: 0996e56b2f378000
+                    status: success
+                    scheduledFor: '2022-07-18T14:46:06Z'
+                    startedAt: '2022-07-18T14:46:07.16222Z'
+                    finishedAt: '2022-07-18T14:46:07.308254Z'
+                    requestedAt: '2022-07-18T14:46:06Z'
+                    log:
+                      - runID: 09b070dadaa7d000
+                        time: '2022-07-18T14:46:07.101231Z'
+                        message: 'Started task from script: "option task = {name: \"task1\", every: 30m} from(bucket: \"iot_center\") |> range(start: -90d) |> filter(fn: (r) => r._measurement == \"environment\")               |> aggregateWindow(every: 1h, fn: mean)"'
+                      - runID: 09b070dadaa7d000
+                        time: '2022-07-18T14:46:07.242859Z'
+                        message: Completed(success)
         '400':
           $ref: '#/components/responses/BadRequestError'
         '401':

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -4392,6 +4392,12 @@ paths:
       tags:
         - Tasks
       summary: Retrieve all logs for a task
+      description: |
+        Retrieves a list of all logs for a task.
+
+        Use this endpoint to retrieve only the log events for a task,
+        without additional task metadata.
+        Each log event `message` contains detail about the event.
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -4402,17 +4408,21 @@ paths:
           description: The task ID.
       responses:
         '200':
-          description: All logs for a task
+          description: Success. The response body contains an `events` list with logs for the task.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Logs'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/AuthorizationError'
+        '404':
+          $ref: '#/components/responses/ResourceNotFoundError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
         default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/GeneralServerError'
   '/tasks/{taskID}/runs/{runID}/logs':
     get:
       operationId: GetTasksIDRunsIDLogs

--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -4867,10 +4867,26 @@ paths:
           description: |
             Bad request.
             The response body contains detail about the error.
+<<<<<<< HEAD
+=======
+
+            #### InfluxDB OSS
+
+            - Returns this error if an incorrect value is passed for `org` or `orgID`.
+>>>>>>> a6c99ab (docs(error): clarify error summary.)
           content:
             application/json:
               schema:
                 $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+<<<<<<< HEAD
+=======
+              examples:
+                orgProvidedNotFound:
+                  summary: The Org or orgID passed in the request doesn't match the token organization
+                  value:
+                    code: invalid
+                    message: 'failed to decode request body: organization not found'
+>>>>>>> a6c99ab (docs(error): clarify error summary.)
         '401':
           $ref: '#/paths/~1tasks/get/responses/401'
         '404':

--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -4867,26 +4867,20 @@ paths:
           description: |
             Bad request.
             The response body contains detail about the error.
-<<<<<<< HEAD
-=======
 
             #### InfluxDB OSS
 
             - Returns this error if an incorrect value is passed for `org` or `orgID`.
->>>>>>> a6c99ab (docs(error): clarify error summary.)
           content:
             application/json:
               schema:
                 $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
-<<<<<<< HEAD
-=======
               examples:
                 orgProvidedNotFound:
-                  summary: The Org or orgID passed in the request doesn't match the token organization
+                  summary: The org or orgID passed doesn't own the token passed in the header
                   value:
                     code: invalid
                     message: 'failed to decode request body: organization not found'
->>>>>>> a6c99ab (docs(error): clarify error summary.)
         '401':
           $ref: '#/paths/~1tasks/get/responses/401'
         '404':

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -21762,11 +21762,27 @@
         }
       },
       "BadRequestError": {
+<<<<<<< HEAD
         "description": "Bad request.\nThe response body contains detail about the error.\n",
+=======
+        "description": "Bad request.\nThe response body contains detail about the error.\n\n#### InfluxDB OSS\n\n- Returns this error if an incorrect value is passed for `org` or `orgID`.\n",
+>>>>>>> a6c99ab (docs(error): clarify error summary.)
         "content": {
           "application/json": {
             "schema": {
               "$ref": "#/components/schemas/Error"
+<<<<<<< HEAD
+=======
+            },
+            "examples": {
+              "orgProvidedNotFound": {
+                "summary": "The Org or orgID passed in the request doesn't match the token organization",
+                "value": {
+                  "code": "invalid",
+                  "message": "failed to decode request body: organization not found"
+                }
+              }
+>>>>>>> a6c99ab (docs(error): clarify error summary.)
             }
           }
         }

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -21762,27 +21762,20 @@
         }
       },
       "BadRequestError": {
-<<<<<<< HEAD
-        "description": "Bad request.\nThe response body contains detail about the error.\n",
-=======
         "description": "Bad request.\nThe response body contains detail about the error.\n\n#### InfluxDB OSS\n\n- Returns this error if an incorrect value is passed for `org` or `orgID`.\n",
->>>>>>> a6c99ab (docs(error): clarify error summary.)
         "content": {
           "application/json": {
             "schema": {
               "$ref": "#/components/schemas/Error"
-<<<<<<< HEAD
-=======
             },
             "examples": {
               "orgProvidedNotFound": {
-                "summary": "The Org or orgID passed in the request doesn't match the token organization",
+                "summary": "The org or orgID passed doesn't own the token passed in the header",
                 "value": {
                   "code": "invalid",
                   "message": "failed to decode request body: organization not found"
                 }
               }
->>>>>>> a6c99ab (docs(error): clarify error summary.)
             }
           }
         }

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -6401,6 +6401,7 @@
           "Tasks"
         ],
         "summary": "Retrieve all logs for a task",
+        "description": "Retrieves a list of all logs for a task.\n\nUse this endpoint to retrieve only the log events for a task,\nwithout additional task metadata.\nEach log event `message` contains detail about the event.\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -6417,7 +6418,7 @@
         ],
         "responses": {
           "200": {
-            "description": "All logs for a task",
+            "description": "Success. The response body contains an `events` list with logs for the task.",
             "content": {
               "application/json": {
                 "schema": {
@@ -6426,15 +6427,20 @@
               }
             }
           },
+          "400": {
+            "$ref": "#/components/responses/BadRequestError"
+          },
+          "401": {
+            "$ref": "#/components/responses/AuthorizationError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ResourceNotFoundError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          },
           "default": {
-            "description": "Unexpected error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
+            "$ref": "#/components/responses/GeneralServerError"
           }
         }
       }

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -6260,37 +6260,37 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Run"
-                }
-              },
-              "examples": {
-                "runSuccess": {
-                  "summary": "A successful task run.",
-                  "value": {
-                    "links": {
-                      "logs": "/api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/logs",
-                      "retry": "/api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/retry",
-                      "self": "/api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000",
-                      "task": "/api/v2/tasks/0996e56b2f378000"
-                    },
-                    "id": "09b070dadaa7d000",
-                    "taskID": "0996e56b2f378000",
-                    "status": "success",
-                    "scheduledFor": "2022-07-18T14:46:06Z",
-                    "startedAt": "2022-07-18T14:46:07.16222Z",
-                    "finishedAt": "2022-07-18T14:46:07.308254Z",
-                    "requestedAt": "2022-07-18T14:46:06Z",
-                    "log": [
-                      {
-                        "runID": "09b070dadaa7d000",
-                        "time": "2022-07-18T14:46:07.101231Z",
-                        "message": "Started task from script: \"option task = {name: \\\"task1\\\", every: 30m} from(bucket: \\\"iot_center\\\") |> range(start: -90d) |> filter(fn: (r) => r._measurement == \\\"environment\\\")               |> aggregateWindow(every: 1h, fn: mean)\""
+                },
+                "examples": {
+                  "runSuccess": {
+                    "summary": "A successful task run.",
+                    "value": {
+                      "links": {
+                        "logs": "/api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/logs",
+                        "retry": "/api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/retry",
+                        "self": "/api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000",
+                        "task": "/api/v2/tasks/0996e56b2f378000"
                       },
-                      {
-                        "runID": "09b070dadaa7d000",
-                        "time": "2022-07-18T14:46:07.242859Z",
-                        "message": "Completed(success)"
-                      }
-                    ]
+                      "id": "09b070dadaa7d000",
+                      "taskID": "0996e56b2f378000",
+                      "status": "success",
+                      "scheduledFor": "2022-07-18T14:46:06Z",
+                      "startedAt": "2022-07-18T14:46:07.16222Z",
+                      "finishedAt": "2022-07-18T14:46:07.308254Z",
+                      "requestedAt": "2022-07-18T14:46:06Z",
+                      "log": [
+                        {
+                          "runID": "09b070dadaa7d000",
+                          "time": "2022-07-18T14:46:07.101231Z",
+                          "message": "Started task from script: \"option task = {name: \\\"task1\\\", every: 30m} from(bucket: \\\"iot_center\\\") |> range(start: -90d) |> filter(fn: (r) => r._measurement == \\\"environment\\\")               |> aggregateWindow(every: 1h, fn: mean)\""
+                        },
+                        {
+                          "runID": "09b070dadaa7d000",
+                          "time": "2022-07-18T14:46:07.242859Z",
+                          "message": "Completed(success)"
+                        }
+                      ]
+                    }
                   }
                 }
               }

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -6228,7 +6228,8 @@
         "tags": [
           "Tasks"
         ],
-        "summary": "Retrieve a single run for a task.",
+        "summary": "Retrieve a run for a task.",
+        "description": "Retrieves a specific run for a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task).\n\nUse this endpoint to retrieve detail and logs for a specific task run.\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -6254,24 +6255,61 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the run record.",
+            "description": "Success. The response body contains the task run.",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Run"
                 }
-              }
-            }
-          },
-          "default": {
-            "description": "Unexpected error.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
+              },
+              "examples": {
+                "runSuccess": {
+                  "summary": "A successful task run.",
+                  "value": {
+                    "links": {
+                      "logs": "/api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/logs",
+                      "retry": "/api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/retry",
+                      "self": "/api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000",
+                      "task": "/api/v2/tasks/0996e56b2f378000"
+                    },
+                    "id": "09b070dadaa7d000",
+                    "taskID": "0996e56b2f378000",
+                    "status": "success",
+                    "scheduledFor": "2022-07-18T14:46:06Z",
+                    "startedAt": "2022-07-18T14:46:07.16222Z",
+                    "finishedAt": "2022-07-18T14:46:07.308254Z",
+                    "requestedAt": "2022-07-18T14:46:06Z",
+                    "log": [
+                      {
+                        "runID": "09b070dadaa7d000",
+                        "time": "2022-07-18T14:46:07.101231Z",
+                        "message": "Started task from script: \"option task = {name: \\\"task1\\\", every: 30m} from(bucket: \\\"iot_center\\\") |> range(start: -90d) |> filter(fn: (r) => r._measurement == \\\"environment\\\")               |> aggregateWindow(every: 1h, fn: mean)\""
+                      },
+                      {
+                        "runID": "09b070dadaa7d000",
+                        "time": "2022-07-18T14:46:07.242859Z",
+                        "message": "Completed(success)"
+                      }
+                    ]
+                  }
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequestError"
+          },
+          "401": {
+            "$ref": "#/components/responses/AuthorizationError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ResourceNotFoundError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralServerError"
           }
         }
       },
@@ -6280,7 +6318,8 @@
         "tags": [
           "Tasks"
         ],
-        "summary": "Cancel a running task.\n\n#### InfluxDB Cloud\n\n  - Doesn't support this operation.\n",
+        "summary": "Cancel a running task",
+        "description": "Cancels a running [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task).\n\nUse this endpoint with InfluxDB OSS to cancel a running task.\n\n#### InfluxDB Cloud\n\n  - Doesn't support this operation.\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -6301,15 +6340,24 @@
               "type": "string"
             },
             "required": true,
-            "description": "The run ID."
+            "description": "The ID of the task run to cancel."
           }
         ],
         "responses": {
           "204": {
-            "description": "Delete has been accepted."
+            "description": "Success. The `DELETE` is accepted and the run will be cancelled.\n\n#### InfluxDB Cloud\n\n  - Doesn't support this operation.\n"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequestError"
+          },
+          "401": {
+            "$ref": "#/components/responses/AuthorizationError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ResourceNotFoundError"
           },
           "405": {
-            "description": "Method not allowed.\n\n#### InfluxDB Cloud\n\n  - Cancelling task runs is not supported in InfluxDB Cloud.\n\n#### InfluxDB OSS\n\n  - Doesn't return this error.\n",
+            "description": "Method not allowed.\n\n#### InfluxDB Cloud\n\n  - Always returns this error; cancelling a task run is not supported.\n\n#### InfluxDB OSS\n\n  - Doesn't return this error.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -6318,15 +6366,11 @@
               }
             }
           },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          },
           "default": {
-            "description": "Unexpected error.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
+            "$ref": "#/components/responses/GeneralServerError"
           }
         }
       }
@@ -6401,7 +6445,7 @@
           "Tasks"
         ],
         "summary": "Retrieve all logs for a task",
-        "description": "Retrieves a list of all logs for a task.\n\nUse this endpoint to retrieve only the log events for a task,\nwithout additional task metadata.\nEach log event `message` contains detail about the event.\n",
+        "description": "Retrieves a list of all logs for a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task).\n\nWhen an InfluxDB task runs, a “run” record is created in the task’s history.\nLogs associated with each run provide relevant log messages, timestamps, and the exit status of the run attempt.\n\nUse this endpoint to retrieve only the log events for a task,\nwithout additional task metadata.\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -6418,11 +6462,52 @@
         ],
         "responses": {
           "200": {
-            "description": "Success. The response body contains an `events` list with logs for the task.",
+            "description": "Success. The response body contains an `events` list with logs for the task.\nEach log event `message` contains detail about the event.\nIf a task run fails, InfluxDB logs an event with the reason for the failure.\n",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Logs"
+                },
+                "examples": {
+                  "taskSuccess": {
+                    "summary": "Events for successful task.",
+                    "value": {
+                      "events": [
+                        {
+                          "runID": "09b070dadaa7d000",
+                          "time": "2022-07-18T14:46:07.101231Z",
+                          "message": "Started task from script: \"option task = {name: \\\"task1\\\", every: 30m} from(bucket: \\\"iot_center\\\") |> range(start: -90d) |> filter(fn: (r) => r._measurement == \\\"environment\\\") |> aggregateWindow(every: 1h, fn: mean)\""
+                        },
+                        {
+                          "runID": "09b070dadaa7d000",
+                          "time": "2022-07-18T14:46:07.242859Z",
+                          "message": "Completed(success)"
+                        }
+                      ]
+                    }
+                  },
+                  "taskFailure": {
+                    "summary": "Events for a failed task.",
+                    "value": {
+                      "events": [
+                        {
+                          "runID": "09a946fc3167d000",
+                          "time": "2022-07-13T07:06:54.198167Z",
+                          "message": "Started task from script: \"option task = {name: \\\"test task\\\", every: 3d, offset: 0s}\""
+                        },
+                        {
+                          "runID": "09a946fc3167d000",
+                          "time": "2022-07-13T07:07:13.104037Z",
+                          "message": "Completed(failed)"
+                        },
+                        {
+                          "runID": "09a946fc3167d000",
+                          "time": "2022-07-13T08:24:37.115323Z",
+                          "message": "error exhausting result iterator: error in query specification while starting program: this Flux script returns no streaming data. Consider adding a \"yield\" or invoking streaming functions directly, without performing an assignment"
+                        }
+                      ]
+                    }
+                  }
                 }
               }
             }

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -14976,10 +14976,26 @@ components:
       description: |
         Bad request.
         The response body contains detail about the error.
+<<<<<<< HEAD
+=======
+
+        #### InfluxDB OSS
+
+        - Returns this error if an incorrect value is passed for `org` or `orgID`.
+>>>>>>> a6c99ab (docs(error): clarify error summary.)
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
+<<<<<<< HEAD
+=======
+          examples:
+            orgProvidedNotFound:
+              summary: The Org or orgID passed in the request doesn't match the token organization
+              value:
+                code: invalid
+                message: 'failed to decode request body: organization not found'
+>>>>>>> a6c99ab (docs(error): clarify error summary.)
     GeneralServerError:
       description: Non 2XX error response from server.
       content:

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -4403,7 +4403,11 @@ paths:
       operationId: GetTasksIDRunsID
       tags:
         - Tasks
-      summary: Retrieve a single run for a task.
+      summary: Retrieve a run for a task.
+      description: |
+        Retrieves a specific run for a [task](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#task).
+
+        Use this endpoint to retrieve detail and logs for a specific task run.
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -4420,23 +4424,53 @@ paths:
           description: The run ID.
       responses:
         '200':
-          description: Returns the run record.
+          description: Success. The response body contains the task run.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Run'
+            examples:
+              runSuccess:
+                summary: A successful task run.
+                value:
+                  links:
+                    logs: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/logs
+                    retry: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/retry
+                    self: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000
+                    task: /api/v2/tasks/0996e56b2f378000
+                  id: 09b070dadaa7d000
+                  taskID: 0996e56b2f378000
+                  status: success
+                  scheduledFor: '2022-07-18T14:46:06Z'
+                  startedAt: '2022-07-18T14:46:07.16222Z'
+                  finishedAt: '2022-07-18T14:46:07.308254Z'
+                  requestedAt: '2022-07-18T14:46:06Z'
+                  log:
+                    - runID: 09b070dadaa7d000
+                      time: '2022-07-18T14:46:07.101231Z'
+                      message: 'Started task from script: "option task = {name: \"task1\", every: 30m} from(bucket: \"iot_center\") |> range(start: -90d) |> filter(fn: (r) => r._measurement == \"environment\")               |> aggregateWindow(every: 1h, fn: mean)"'
+                    - runID: 09b070dadaa7d000
+                      time: '2022-07-18T14:46:07.242859Z'
+                      message: Completed(success)
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/AuthorizationError'
+        '404':
+          $ref: '#/components/responses/ResourceNotFoundError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
         default:
-          description: Unexpected error.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/GeneralServerError'
     delete:
       operationId: DeleteTasksIDRunsID
       tags:
         - Tasks
-      summary: |
-        Cancel a running task.
+      summary: Cancel a running task
+      description: |
+        Cancels a running [task](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#task).
+
+        Use this endpoint with InfluxDB OSS to cancel a running task.
 
         #### InfluxDB Cloud
 
@@ -4454,17 +4488,28 @@ paths:
           schema:
             type: string
           required: true
-          description: The run ID.
+          description: The ID of the task run to cancel.
       responses:
         '204':
-          description: Delete has been accepted.
+          description: |
+            Success. The `DELETE` is accepted and the run will be cancelled.
+
+            #### InfluxDB Cloud
+
+              - Doesn't support this operation.
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/AuthorizationError'
+        '404':
+          $ref: '#/components/responses/ResourceNotFoundError'
         '405':
           description: |
             Method not allowed.
 
             #### InfluxDB Cloud
 
-              - Cancelling task runs is not supported in InfluxDB Cloud.
+              - Always returns this error; cancelling a task run is not supported.
 
             #### InfluxDB OSS
 
@@ -4473,12 +4518,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
         default:
-          description: Unexpected error.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/GeneralServerError'
   '/tasks/{taskID}/runs/{runID}/retry':
     post:
       operationId: PostTasksIDRunsIDRetry
@@ -4524,11 +4567,13 @@ paths:
         - Tasks
       summary: Retrieve all logs for a task
       description: |
-        Retrieves a list of all logs for a task.
+        Retrieves a list of all logs for a [task](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#task).
+
+        When an InfluxDB task runs, a “run” record is created in the task’s history.
+        Logs associated with each run provide relevant log messages, timestamps, and the exit status of the run attempt.
 
         Use this endpoint to retrieve only the log events for a task,
         without additional task metadata.
-        Each log event `message` contains detail about the event.
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -4539,11 +4584,38 @@ paths:
           description: The task ID.
       responses:
         '200':
-          description: Success. The response body contains an `events` list with logs for the task.
+          description: |
+            Success. The response body contains an `events` list with logs for the task.
+            Each log event `message` contains detail about the event.
+            If a task run fails, InfluxDB logs an event with the reason for the failure.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Logs'
+              examples:
+                taskSuccess:
+                  summary: Events for successful task.
+                  value:
+                    events:
+                      - runID: 09b070dadaa7d000
+                        time: '2022-07-18T14:46:07.101231Z'
+                        message: 'Started task from script: "option task = {name: \"task1\", every: 30m} from(bucket: \"iot_center\") |> range(start: -90d) |> filter(fn: (r) => r._measurement == \"environment\") |> aggregateWindow(every: 1h, fn: mean)"'
+                      - runID: 09b070dadaa7d000
+                        time: '2022-07-18T14:46:07.242859Z'
+                        message: Completed(success)
+                taskFailure:
+                  summary: Events for a failed task.
+                  value:
+                    events:
+                      - runID: 09a946fc3167d000
+                        time: '2022-07-13T07:06:54.198167Z'
+                        message: 'Started task from script: "option task = {name: \"test task\", every: 3d, offset: 0s}"'
+                      - runID: 09a946fc3167d000
+                        time: '2022-07-13T07:07:13.104037Z'
+                        message: Completed(failed)
+                      - runID: 09a946fc3167d000
+                        time: '2022-07-13T08:24:37.115323Z'
+                        message: 'error exhausting result iterator: error in query specification while starting program: this Flux script returns no streaming data. Consider adding a "yield" or invoking streaming functions directly, without performing an assignment'
         '400':
           $ref: '#/components/responses/BadRequestError'
         '401':

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -4523,6 +4523,12 @@ paths:
       tags:
         - Tasks
       summary: Retrieve all logs for a task
+      description: |
+        Retrieves a list of all logs for a task.
+
+        Use this endpoint to retrieve only the log events for a task,
+        without additional task metadata.
+        Each log event `message` contains detail about the event.
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -4533,17 +4539,21 @@ paths:
           description: The task ID.
       responses:
         '200':
-          description: All logs for a task
+          description: Success. The response body contains an `events` list with logs for the task.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Logs'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/AuthorizationError'
+        '404':
+          $ref: '#/components/responses/ResourceNotFoundError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
         default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/GeneralServerError'
   '/tasks/{taskID}/runs/{runID}/logs':
     get:
       operationId: GetTasksIDRunsIDLogs

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -4429,29 +4429,29 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Run'
-            examples:
-              runSuccess:
-                summary: A successful task run.
-                value:
-                  links:
-                    logs: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/logs
-                    retry: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/retry
-                    self: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000
-                    task: /api/v2/tasks/0996e56b2f378000
-                  id: 09b070dadaa7d000
-                  taskID: 0996e56b2f378000
-                  status: success
-                  scheduledFor: '2022-07-18T14:46:06Z'
-                  startedAt: '2022-07-18T14:46:07.16222Z'
-                  finishedAt: '2022-07-18T14:46:07.308254Z'
-                  requestedAt: '2022-07-18T14:46:06Z'
-                  log:
-                    - runID: 09b070dadaa7d000
-                      time: '2022-07-18T14:46:07.101231Z'
-                      message: 'Started task from script: "option task = {name: \"task1\", every: 30m} from(bucket: \"iot_center\") |> range(start: -90d) |> filter(fn: (r) => r._measurement == \"environment\")               |> aggregateWindow(every: 1h, fn: mean)"'
-                    - runID: 09b070dadaa7d000
-                      time: '2022-07-18T14:46:07.242859Z'
-                      message: Completed(success)
+              examples:
+                runSuccess:
+                  summary: A successful task run.
+                  value:
+                    links:
+                      logs: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/logs
+                      retry: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/retry
+                      self: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000
+                      task: /api/v2/tasks/0996e56b2f378000
+                    id: 09b070dadaa7d000
+                    taskID: 0996e56b2f378000
+                    status: success
+                    scheduledFor: '2022-07-18T14:46:06Z'
+                    startedAt: '2022-07-18T14:46:07.16222Z'
+                    finishedAt: '2022-07-18T14:46:07.308254Z'
+                    requestedAt: '2022-07-18T14:46:06Z'
+                    log:
+                      - runID: 09b070dadaa7d000
+                        time: '2022-07-18T14:46:07.101231Z'
+                        message: 'Started task from script: "option task = {name: \"task1\", every: 30m} from(bucket: \"iot_center\") |> range(start: -90d) |> filter(fn: (r) => r._measurement == \"environment\")               |> aggregateWindow(every: 1h, fn: mean)"'
+                      - runID: 09b070dadaa7d000
+                        time: '2022-07-18T14:46:07.242859Z'
+                        message: Completed(success)
         '400':
           $ref: '#/components/responses/BadRequestError'
         '401':

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -14976,26 +14976,20 @@ components:
       description: |
         Bad request.
         The response body contains detail about the error.
-<<<<<<< HEAD
-=======
 
         #### InfluxDB OSS
 
         - Returns this error if an incorrect value is passed for `org` or `orgID`.
->>>>>>> a6c99ab (docs(error): clarify error summary.)
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
-<<<<<<< HEAD
-=======
           examples:
             orgProvidedNotFound:
-              summary: The Org or orgID passed in the request doesn't match the token organization
+              summary: The org or orgID passed doesn't own the token passed in the header
               value:
                 code: invalid
                 message: 'failed to decode request body: organization not found'
->>>>>>> a6c99ab (docs(error): clarify error summary.)
     GeneralServerError:
       description: Non 2XX error response from server.
       content:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -11654,11 +11654,13 @@ paths:
   /api/v2/tasks/{taskID}/logs:
     get:
       description: |
-        Retrieves a list of all logs for a task.
+        Retrieves a list of all logs for a [task](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#task).
+
+        When an InfluxDB task runs, a “run” record is created in the task’s history.
+        Logs associated with each run provide relevant log messages, timestamps, and the exit status of the run attempt.
 
         Use this endpoint to retrieve only the log events for a task,
         without additional task metadata.
-        Each log event `message` contains detail about the event.
       operationId: GetTasksIDLogs
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
@@ -11672,10 +11674,43 @@ paths:
         "200":
           content:
             application/json:
+              examples:
+                taskFailure:
+                  summary: Events for a failed task.
+                  value:
+                    events:
+                    - message: 'Started task from script: "option task = {name: \"test
+                        task\", every: 3d, offset: 0s}"'
+                      runID: 09a946fc3167d000
+                      time: "2022-07-13T07:06:54.198167Z"
+                    - message: Completed(failed)
+                      runID: 09a946fc3167d000
+                      time: "2022-07-13T07:07:13.104037Z"
+                    - message: 'error exhausting result iterator: error in query specification
+                        while starting program: this Flux script returns no streaming
+                        data. Consider adding a "yield" or invoking streaming functions
+                        directly, without performing an assignment'
+                      runID: 09a946fc3167d000
+                      time: "2022-07-13T08:24:37.115323Z"
+                taskSuccess:
+                  summary: Events for successful task.
+                  value:
+                    events:
+                    - message: 'Started task from script: "option task = {name: \"task1\",
+                        every: 30m} from(bucket: \"iot_center\") |> range(start: -90d)
+                        |> filter(fn: (r) => r._measurement == \"environment\") |>
+                        aggregateWindow(every: 1h, fn: mean)"'
+                      runID: 09b070dadaa7d000
+                      time: "2022-07-18T14:46:07.101231Z"
+                    - message: Completed(success)
+                      runID: 09b070dadaa7d000
+                      time: "2022-07-18T14:46:07.242859Z"
               schema:
                 $ref: '#/components/schemas/Logs'
-          description: Success. The response body contains an `events` list with logs
-            for the task.
+          description: |
+            Success. The response body contains an `events` list with logs for the task.
+            Each log event `message` contains detail about the event.
+            If a task run fails, InfluxDB logs an event with the reason for the failure.
         "400":
           $ref: '#/components/responses/BadRequestError'
         "401":
@@ -11952,6 +11987,14 @@ paths:
       - Tasks
   /api/v2/tasks/{taskID}/runs/{runID}:
     delete:
+      description: |
+        Cancels a running [task](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#task).
+
+        Use this endpoint with InfluxDB OSS to cancel a running task.
+
+        #### InfluxDB Cloud
+
+          - Doesn't support this operation.
       operationId: DeleteTasksIDRunsID
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
@@ -11961,7 +12004,7 @@ paths:
         required: true
         schema:
           type: string
-      - description: The run ID.
+      - description: The ID of the task run to cancel.
         in: path
         name: runID
         required: true
@@ -11969,7 +12012,18 @@ paths:
           type: string
       responses:
         "204":
-          description: Delete has been accepted.
+          description: |
+            Success. The `DELETE` is accepted and the run will be cancelled.
+
+            #### InfluxDB Cloud
+
+              - Doesn't support this operation.
+        "400":
+          $ref: '#/components/responses/BadRequestError'
+        "401":
+          $ref: '#/components/responses/AuthorizationError'
+        "404":
+          $ref: '#/components/responses/ResourceNotFoundError'
         "405":
           content:
             application/json:
@@ -11980,26 +12034,23 @@ paths:
 
             #### InfluxDB Cloud
 
-              - Cancelling task runs is not supported in InfluxDB Cloud.
+              - Always returns this error; cancelling a task run is not supported.
 
             #### InfluxDB OSS
 
               - Doesn't return this error.
+        "500":
+          $ref: '#/components/responses/InternalServerError'
         default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Unexpected error.
-      summary: |
-        Cancel a running task.
-
-        #### InfluxDB Cloud
-
-          - Doesn't support this operation.
+          $ref: '#/components/responses/GeneralServerError'
+      summary: Cancel a running task
       tags:
       - Tasks
     get:
+      description: |
+        Retrieves a specific run for a [task](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#task).
+
+        Use this endpoint to retrieve detail and logs for a specific task run.
       operationId: GetTasksIDRunsID
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
@@ -12021,14 +12072,44 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Run'
-          description: Returns the run record.
+            examples:
+              runSuccess:
+                summary: A successful task run.
+                value:
+                  finishedAt: "2022-07-18T14:46:07.308254Z"
+                  id: 09b070dadaa7d000
+                  links:
+                    logs: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/logs
+                    retry: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/retry
+                    self: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000
+                    task: /api/v2/tasks/0996e56b2f378000
+                  log:
+                  - message: 'Started task from script: "option task = {name: \"task1\",
+                      every: 30m} from(bucket: \"iot_center\") |> range(start: -90d)
+                      |> filter(fn: (r) => r._measurement == \"environment\")               |>
+                      aggregateWindow(every: 1h, fn: mean)"'
+                    runID: 09b070dadaa7d000
+                    time: "2022-07-18T14:46:07.101231Z"
+                  - message: Completed(success)
+                    runID: 09b070dadaa7d000
+                    time: "2022-07-18T14:46:07.242859Z"
+                  requestedAt: "2022-07-18T14:46:06Z"
+                  scheduledFor: "2022-07-18T14:46:06Z"
+                  startedAt: "2022-07-18T14:46:07.16222Z"
+                  status: success
+                  taskID: 0996e56b2f378000
+          description: Success. The response body contains the task run.
+        "400":
+          $ref: '#/components/responses/BadRequestError'
+        "401":
+          $ref: '#/components/responses/AuthorizationError'
+        "404":
+          $ref: '#/components/responses/ResourceNotFoundError'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
         default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Unexpected error.
-      summary: Retrieve a single run for a task.
+          $ref: '#/components/responses/GeneralServerError'
+      summary: Retrieve a run for a task.
       tags:
       - Tasks
   /api/v2/tasks/{taskID}/runs/{runID}/logs:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -11653,6 +11653,12 @@ paths:
       - Tasks
   /api/v2/tasks/{taskID}/logs:
     get:
+      description: |
+        Retrieves a list of all logs for a task.
+
+        Use this endpoint to retrieve only the log events for a task,
+        without additional task metadata.
+        Each log event `message` contains detail about the event.
       operationId: GetTasksIDLogs
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
@@ -11668,13 +11674,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Logs'
-          description: All logs for a task
+          description: Success. The response body contains an `events` list with logs
+            for the task.
+        "400":
+          $ref: '#/components/responses/BadRequestError'
+        "401":
+          $ref: '#/components/responses/AuthorizationError'
+        "404":
+          $ref: '#/components/responses/ResourceNotFoundError'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
         default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Unexpected error
+          $ref: '#/components/responses/GeneralServerError'
       summary: Retrieve all logs for a task
       tags:
       - Tasks

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -13998,14 +13998,15 @@ tags:
 - description: |
     Process and analyze your data with tasks in the InfluxDB task engine.
     With tasks, you can schedule Flux scripts to query, analyze, modify, and act on data.
-    With InfluxDB Cloud, you can manage [invokable scripts](/#tag/Invokable-Scripts)
-    for your organization and schedule tasks that run them with parameters.
+    In InfluxDB Cloud, you can create tasks that run [invokable scripts](/#tag/Invokable-Scripts)
+    with parameters.
 
     Use the `/api/v2/tasks` endpoints to create and manage tasks, retry task runs, and retrieve run logs.
 
     #### Related guides
 
     - [Common data processing tasks](https://docs.influxdata.com/influxdb/cloud/process-data/common-tasks/)
+    - [Invoke custom scripts as API endpoints](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/)
   name: Tasks
 - description: |
     Write time series data to buckets.

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -70,28 +70,22 @@ components:
     BadRequestError:
       content:
         application/json:
-<<<<<<< HEAD
-=======
           examples:
             orgProvidedNotFound:
-              summary: The Org or orgID passed in the request doesn't match the token
-                organization
+              summary: The org or orgID passed doesn't own the token passed in the
+                header
               value:
                 code: invalid
                 message: 'failed to decode request body: organization not found'
->>>>>>> a6c99ab (docs(error): clarify error summary.)
           schema:
             $ref: '#/components/schemas/Error'
       description: |
         Bad request.
         The response body contains detail about the error.
-<<<<<<< HEAD
-=======
 
         #### InfluxDB OSS
 
         - Returns this error if an incorrect value is passed for `org` or `orgID`.
->>>>>>> a6c99ab (docs(error): clarify error summary.)
     GeneralServerError:
       content:
         application/json:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -11350,7 +11350,7 @@ paths:
         In your task, provide one of the following:
 
           - _`flux`_ property with an inline Flux script
-          - _`scriptID`_ property with an invokable script ID
+          - _`scriptID`_ property with an [invokable script](#tag/Invokable-Scripts) ID
 
         #### InfluxDB Cloud
 
@@ -11384,13 +11384,13 @@ paths:
             application/json:
               examples:
                 fluxAndScriptError:
-                  summary: Task in request body can't contain flux and scriptID properties
+                  summary: The request body can't contain both flux and scriptID
                   value:
                     code: invalid
                     message: 'failed to decode request: can not provide both scriptID
                       and flux'
                 missingFluxError:
-                  summary: Task in request body requires a flux or scriptID property
+                  summary: The request body requires either flux or scriptID
                   value:
                     code: invalid
                     message: 'failed to decode request: flux required'
@@ -11413,7 +11413,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Unexpected error
-      summary: Create a new task
+      summary: Create a task
       tags:
       - Data I/O endpoints
       - Tasks
@@ -13998,7 +13998,7 @@ tags:
 - description: |
     Process and analyze your data with tasks in the InfluxDB task engine.
     With tasks, you can schedule Flux scripts to query, analyze, modify, and act on data.
-    In InfluxDB Cloud, you can create tasks that run [invokable scripts](/#tag/Invokable-Scripts)
+    In InfluxDB Cloud, you can create tasks that run [invokable scripts](#tag/Invokable-Scripts)
     with parameters.
 
     Use the `/api/v2/tasks` endpoints to create and manage tasks, retry task runs, and retrieve run logs.

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -70,11 +70,28 @@ components:
     BadRequestError:
       content:
         application/json:
+<<<<<<< HEAD
+=======
+          examples:
+            orgProvidedNotFound:
+              summary: The Org or orgID passed in the request doesn't match the token
+                organization
+              value:
+                code: invalid
+                message: 'failed to decode request body: organization not found'
+>>>>>>> a6c99ab (docs(error): clarify error summary.)
           schema:
             $ref: '#/components/schemas/Error'
       description: |
         Bad request.
         The response body contains detail about the error.
+<<<<<<< HEAD
+=======
+
+        #### InfluxDB OSS
+
+        - Returns this error if an incorrect value is passed for `org` or `orgID`.
+>>>>>>> a6c99ab (docs(error): clarify error summary.)
     GeneralServerError:
       content:
         application/json:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -11352,6 +11352,16 @@ paths:
       description: |
         Creates a [task](https://docs.influxdata.com/influxdb/cloud/process-data/) and returns the created task.
 
+        Use this endpoint to create a scheduled task that runs a Flux script.
+        In your task, provide one of the following:
+
+          - _`flux`_ property with an inline Flux script
+          - _`scriptID`_ property with an invokable script ID
+
+        #### InfluxDB Cloud
+
+          - Requires either _`flux`_ (Flux query) or _`scriptID`_ (invokable script ID) in the task.
+
         #### Related guides
 
         - [Create a task](https://docs.influxdata.com/influxdb/cloud/process-data/manage-tasks/create-task/).
@@ -11379,14 +11389,26 @@ paths:
           content:
             application/json:
               examples:
-                missingFluxError:
-                  summary: Task in request body is missing Flux query
+                fluxAndScriptError:
+                  summary: Task in request body can't contain flux and scriptID properties
                   value:
                     code: invalid
-                    message: 'failed to decode request: missing flux'
+                    message: 'failed to decode request: can not provide both scriptID
+                      and flux'
+                missingFluxError:
+                  summary: Task in request body requires a flux or scriptID property
+                  value:
+                    code: invalid
+                    message: 'failed to decode request: flux required'
               schema:
                 $ref: '#/components/responses/BadRequestError'
-          description: Bad request
+          description: |
+            Bad request
+
+            #### InfluxDB Cloud
+
+              - Returns this error if the task doesn't contain one of _`flux`_ or _`scriptID`_.
+              - Returns this error if the task contains _`flux`_ _and_ _`scriptID`_.
         "401":
           $ref: '#/components/responses/AuthorizationError'
         "500":
@@ -12087,34 +12109,34 @@ paths:
         "200":
           content:
             application/json:
+              examples:
+                runSuccess:
+                  summary: A successful task run.
+                  value:
+                    finishedAt: "2022-07-18T14:46:07.308254Z"
+                    id: 09b070dadaa7d000
+                    links:
+                      logs: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/logs
+                      retry: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/retry
+                      self: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000
+                      task: /api/v2/tasks/0996e56b2f378000
+                    log:
+                    - message: 'Started task from script: "option task = {name: \"task1\",
+                        every: 30m} from(bucket: \"iot_center\") |> range(start: -90d)
+                        |> filter(fn: (r) => r._measurement == \"environment\")               |>
+                        aggregateWindow(every: 1h, fn: mean)"'
+                      runID: 09b070dadaa7d000
+                      time: "2022-07-18T14:46:07.101231Z"
+                    - message: Completed(success)
+                      runID: 09b070dadaa7d000
+                      time: "2022-07-18T14:46:07.242859Z"
+                    requestedAt: "2022-07-18T14:46:06Z"
+                    scheduledFor: "2022-07-18T14:46:06Z"
+                    startedAt: "2022-07-18T14:46:07.16222Z"
+                    status: success
+                    taskID: 0996e56b2f378000
               schema:
                 $ref: '#/components/schemas/Run'
-            examples:
-              runSuccess:
-                summary: A successful task run.
-                value:
-                  finishedAt: "2022-07-18T14:46:07.308254Z"
-                  id: 09b070dadaa7d000
-                  links:
-                    logs: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/logs
-                    retry: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/retry
-                    self: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000
-                    task: /api/v2/tasks/0996e56b2f378000
-                  log:
-                  - message: 'Started task from script: "option task = {name: \"task1\",
-                      every: 30m} from(bucket: \"iot_center\") |> range(start: -90d)
-                      |> filter(fn: (r) => r._measurement == \"environment\")               |>
-                      aggregateWindow(every: 1h, fn: mean)"'
-                    runID: 09b070dadaa7d000
-                    time: "2022-07-18T14:46:07.101231Z"
-                  - message: Completed(success)
-                    runID: 09b070dadaa7d000
-                    time: "2022-07-18T14:46:07.242859Z"
-                  requestedAt: "2022-07-18T14:46:06Z"
-                  scheduledFor: "2022-07-18T14:46:06Z"
-                  startedAt: "2022-07-18T14:46:07.16222Z"
-                  status: success
-                  taskID: 0996e56b2f378000
           description: Success. The response body contains the task run.
         "400":
           $ref: '#/components/responses/BadRequestError'
@@ -13982,6 +14004,8 @@ tags:
 - description: |
     Process and analyze your data with tasks in the InfluxDB task engine.
     With tasks, you can schedule Flux scripts to query, analyze, modify, and act on data.
+    With InfluxDB Cloud, you can manage [invokable scripts](/#tag/Invokable-Scripts)
+    for your organization and schedule tasks that run them with parameters.
 
     Use the `/api/v2/tasks` endpoints to create and manage tasks, retry task runs, and retrieve run logs.
 

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -13383,6 +13383,12 @@ paths:
       - Tasks
   /api/v2/tasks/{taskID}/logs:
     get:
+      description: |
+        Retrieves a list of all logs for a task.
+
+        Use this endpoint to retrieve only the log events for a task,
+        without additional task metadata.
+        Each log event `message` contains detail about the event.
       operationId: GetTasksIDLogs
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
@@ -13398,13 +13404,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Logs'
-          description: All logs for a task
+          description: Success. The response body contains an `events` list with logs
+            for the task.
+        "400":
+          $ref: '#/components/responses/BadRequestError'
+        "401":
+          $ref: '#/components/responses/AuthorizationError'
+        "404":
+          $ref: '#/components/responses/ResourceNotFoundError'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
         default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Unexpected error
+          $ref: '#/components/responses/GeneralServerError'
       summary: Retrieve all logs for a task
       tags:
       - Tasks

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -13817,34 +13817,34 @@ paths:
         "200":
           content:
             application/json:
+              examples:
+                runSuccess:
+                  summary: A successful task run.
+                  value:
+                    finishedAt: "2022-07-18T14:46:07.308254Z"
+                    id: 09b070dadaa7d000
+                    links:
+                      logs: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/logs
+                      retry: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/retry
+                      self: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000
+                      task: /api/v2/tasks/0996e56b2f378000
+                    log:
+                    - message: 'Started task from script: "option task = {name: \"task1\",
+                        every: 30m} from(bucket: \"iot_center\") |> range(start: -90d)
+                        |> filter(fn: (r) => r._measurement == \"environment\")               |>
+                        aggregateWindow(every: 1h, fn: mean)"'
+                      runID: 09b070dadaa7d000
+                      time: "2022-07-18T14:46:07.101231Z"
+                    - message: Completed(success)
+                      runID: 09b070dadaa7d000
+                      time: "2022-07-18T14:46:07.242859Z"
+                    requestedAt: "2022-07-18T14:46:06Z"
+                    scheduledFor: "2022-07-18T14:46:06Z"
+                    startedAt: "2022-07-18T14:46:07.16222Z"
+                    status: success
+                    taskID: 0996e56b2f378000
               schema:
                 $ref: '#/components/schemas/Run'
-            examples:
-              runSuccess:
-                summary: A successful task run.
-                value:
-                  finishedAt: "2022-07-18T14:46:07.308254Z"
-                  id: 09b070dadaa7d000
-                  links:
-                    logs: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/logs
-                    retry: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/retry
-                    self: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000
-                    task: /api/v2/tasks/0996e56b2f378000
-                  log:
-                  - message: 'Started task from script: "option task = {name: \"task1\",
-                      every: 30m} from(bucket: \"iot_center\") |> range(start: -90d)
-                      |> filter(fn: (r) => r._measurement == \"environment\")               |>
-                      aggregateWindow(every: 1h, fn: mean)"'
-                    runID: 09b070dadaa7d000
-                    time: "2022-07-18T14:46:07.101231Z"
-                  - message: Completed(success)
-                    runID: 09b070dadaa7d000
-                    time: "2022-07-18T14:46:07.242859Z"
-                  requestedAt: "2022-07-18T14:46:06Z"
-                  scheduledFor: "2022-07-18T14:46:06Z"
-                  startedAt: "2022-07-18T14:46:07.16222Z"
-                  status: success
-                  taskID: 0996e56b2f378000
           description: Success. The response body contains the task run.
         "400":
           $ref: '#/components/responses/BadRequestError'

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -13384,11 +13384,13 @@ paths:
   /api/v2/tasks/{taskID}/logs:
     get:
       description: |
-        Retrieves a list of all logs for a task.
+        Retrieves a list of all logs for a [task](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#task).
+
+        When an InfluxDB task runs, a “run” record is created in the task’s history.
+        Logs associated with each run provide relevant log messages, timestamps, and the exit status of the run attempt.
 
         Use this endpoint to retrieve only the log events for a task,
         without additional task metadata.
-        Each log event `message` contains detail about the event.
       operationId: GetTasksIDLogs
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
@@ -13402,10 +13404,43 @@ paths:
         "200":
           content:
             application/json:
+              examples:
+                taskFailure:
+                  summary: Events for a failed task.
+                  value:
+                    events:
+                    - message: 'Started task from script: "option task = {name: \"test
+                        task\", every: 3d, offset: 0s}"'
+                      runID: 09a946fc3167d000
+                      time: "2022-07-13T07:06:54.198167Z"
+                    - message: Completed(failed)
+                      runID: 09a946fc3167d000
+                      time: "2022-07-13T07:07:13.104037Z"
+                    - message: 'error exhausting result iterator: error in query specification
+                        while starting program: this Flux script returns no streaming
+                        data. Consider adding a "yield" or invoking streaming functions
+                        directly, without performing an assignment'
+                      runID: 09a946fc3167d000
+                      time: "2022-07-13T08:24:37.115323Z"
+                taskSuccess:
+                  summary: Events for successful task.
+                  value:
+                    events:
+                    - message: 'Started task from script: "option task = {name: \"task1\",
+                        every: 30m} from(bucket: \"iot_center\") |> range(start: -90d)
+                        |> filter(fn: (r) => r._measurement == \"environment\") |>
+                        aggregateWindow(every: 1h, fn: mean)"'
+                      runID: 09b070dadaa7d000
+                      time: "2022-07-18T14:46:07.101231Z"
+                    - message: Completed(success)
+                      runID: 09b070dadaa7d000
+                      time: "2022-07-18T14:46:07.242859Z"
               schema:
                 $ref: '#/components/schemas/Logs'
-          description: Success. The response body contains an `events` list with logs
-            for the task.
+          description: |
+            Success. The response body contains an `events` list with logs for the task.
+            Each log event `message` contains detail about the event.
+            If a task run fails, InfluxDB logs an event with the reason for the failure.
         "400":
           $ref: '#/components/responses/BadRequestError'
         "401":
@@ -13682,6 +13717,14 @@ paths:
       - Tasks
   /api/v2/tasks/{taskID}/runs/{runID}:
     delete:
+      description: |
+        Cancels a running [task](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#task).
+
+        Use this endpoint with InfluxDB OSS to cancel a running task.
+
+        #### InfluxDB Cloud
+
+          - Doesn't support this operation.
       operationId: DeleteTasksIDRunsID
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
@@ -13691,7 +13734,7 @@ paths:
         required: true
         schema:
           type: string
-      - description: The run ID.
+      - description: The ID of the task run to cancel.
         in: path
         name: runID
         required: true
@@ -13699,7 +13742,18 @@ paths:
           type: string
       responses:
         "204":
-          description: Delete has been accepted.
+          description: |
+            Success. The `DELETE` is accepted and the run will be cancelled.
+
+            #### InfluxDB Cloud
+
+              - Doesn't support this operation.
+        "400":
+          $ref: '#/components/responses/BadRequestError'
+        "401":
+          $ref: '#/components/responses/AuthorizationError'
+        "404":
+          $ref: '#/components/responses/ResourceNotFoundError'
         "405":
           content:
             application/json:
@@ -13710,26 +13764,23 @@ paths:
 
             #### InfluxDB Cloud
 
-              - Cancelling task runs is not supported in InfluxDB Cloud.
+              - Always returns this error; cancelling a task run is not supported.
 
             #### InfluxDB OSS
 
               - Doesn't return this error.
+        "500":
+          $ref: '#/components/responses/InternalServerError'
         default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Unexpected error.
-      summary: |
-        Cancel a running task.
-
-        #### InfluxDB Cloud
-
-          - Doesn't support this operation.
+          $ref: '#/components/responses/GeneralServerError'
+      summary: Cancel a running task
       tags:
       - Tasks
     get:
+      description: |
+        Retrieves a specific run for a [task](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#task).
+
+        Use this endpoint to retrieve detail and logs for a specific task run.
       operationId: GetTasksIDRunsID
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
@@ -13751,14 +13802,44 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Run'
-          description: Returns the run record.
+            examples:
+              runSuccess:
+                summary: A successful task run.
+                value:
+                  finishedAt: "2022-07-18T14:46:07.308254Z"
+                  id: 09b070dadaa7d000
+                  links:
+                    logs: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/logs
+                    retry: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/retry
+                    self: /api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000
+                    task: /api/v2/tasks/0996e56b2f378000
+                  log:
+                  - message: 'Started task from script: "option task = {name: \"task1\",
+                      every: 30m} from(bucket: \"iot_center\") |> range(start: -90d)
+                      |> filter(fn: (r) => r._measurement == \"environment\")               |>
+                      aggregateWindow(every: 1h, fn: mean)"'
+                    runID: 09b070dadaa7d000
+                    time: "2022-07-18T14:46:07.101231Z"
+                  - message: Completed(success)
+                    runID: 09b070dadaa7d000
+                    time: "2022-07-18T14:46:07.242859Z"
+                  requestedAt: "2022-07-18T14:46:06Z"
+                  scheduledFor: "2022-07-18T14:46:06Z"
+                  startedAt: "2022-07-18T14:46:07.16222Z"
+                  status: success
+                  taskID: 0996e56b2f378000
+          description: Success. The response body contains the task run.
+        "400":
+          $ref: '#/components/responses/BadRequestError'
+        "401":
+          $ref: '#/components/responses/AuthorizationError'
+        "404":
+          $ref: '#/components/responses/ResourceNotFoundError'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
         default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Unexpected error.
-      summary: Retrieve a single run for a task.
+          $ref: '#/components/responses/GeneralServerError'
+      summary: Retrieve a run for a task.
       tags:
       - Tasks
   /api/v2/tasks/{taskID}/runs/{runID}/logs:

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -70,28 +70,22 @@ components:
     BadRequestError:
       content:
         application/json:
-<<<<<<< HEAD
-=======
           examples:
             orgProvidedNotFound:
-              summary: The Org or orgID passed in the request doesn't match the token
-                organization
+              summary: The org or orgID passed doesn't own the token passed in the
+                header
               value:
                 code: invalid
                 message: 'failed to decode request body: organization not found'
->>>>>>> a6c99ab (docs(error): clarify error summary.)
           schema:
             $ref: '#/components/schemas/Error'
       description: |
         Bad request.
         The response body contains detail about the error.
-<<<<<<< HEAD
-=======
 
         #### InfluxDB OSS
 
         - Returns this error if an incorrect value is passed for `org` or `orgID`.
->>>>>>> a6c99ab (docs(error): clarify error summary.)
     GeneralServerError:
       content:
         application/json:

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -70,11 +70,28 @@ components:
     BadRequestError:
       content:
         application/json:
+<<<<<<< HEAD
+=======
+          examples:
+            orgProvidedNotFound:
+              summary: The Org or orgID passed in the request doesn't match the token
+                organization
+              value:
+                code: invalid
+                message: 'failed to decode request body: organization not found'
+>>>>>>> a6c99ab (docs(error): clarify error summary.)
           schema:
             $ref: '#/components/schemas/Error'
       description: |
         Bad request.
         The response body contains detail about the error.
+<<<<<<< HEAD
+=======
+
+        #### InfluxDB OSS
+
+        - Returns this error if an incorrect value is passed for `org` or `orgID`.
+>>>>>>> a6c99ab (docs(error): clarify error summary.)
     GeneralServerError:
       content:
         application/json:

--- a/src/cloud/paths/tasks.yml
+++ b/src/cloud/paths/tasks.yml
@@ -133,7 +133,7 @@ post:
   tags:
     - Data I/O endpoints
     - Tasks
-  summary: Create a new task
+  summary: Create a task
   description: |
     Creates a [task]({{% INFLUXDB_DOCS_URL %}}/process-data/) and returns the created task.
 
@@ -141,7 +141,7 @@ post:
     In your task, provide one of the following:
 
       - _`flux`_ property with an inline Flux script
-      - _`scriptID`_ property with an invokable script ID
+      - _`scriptID`_ property with an [invokable script](#tag/Invokable-Scripts) ID
 
     #### InfluxDB Cloud
 
@@ -182,14 +182,14 @@ post:
             $ref: "../../common/responses/BadRequestError.yml"
           examples:
             fluxAndScriptError:
-              summary: Task in request body can't contain flux and scriptID properties
+              summary: The request body can't contain both flux and scriptID
               value:
                 {
                   "code": "invalid",
                   "message": "failed to decode request: can not provide both scriptID and flux"
                 }
             missingFluxError:
-              summary: Task in request body requires a flux or scriptID property
+              summary: The request body requires either flux or scriptID
               value:
                 {
                   "code": "invalid",

--- a/src/cloud/paths/tasks.yml
+++ b/src/cloud/paths/tasks.yml
@@ -137,6 +137,16 @@ post:
   description: |
     Creates a [task]({{% INFLUXDB_DOCS_URL %}}/process-data/) and returns the created task.
 
+    Use this endpoint to create a scheduled task that runs a Flux script.
+    In your task, provide one of the following:
+
+      - _`flux`_ property with an inline Flux script
+      - _`scriptID`_ property with an invokable script ID
+
+    #### InfluxDB Cloud
+
+      - Requires either _`flux`_ (Flux query) or _`scriptID`_ (invokable script ID) in the task.
+
     #### Related guides
 
     - [Create a task]({{% INFLUXDB_DOCS_URL %}}/process-data/manage-tasks/create-task/).
@@ -159,17 +169,31 @@ post:
           schema:
             $ref: "../schemas/Task.yml"
     "400":
-      description: Bad request
+      description: |
+        Bad request
+
+        #### InfluxDB Cloud
+
+          - Returns this error if the task doesn't contain one of _`flux`_ or _`scriptID`_.
+          - Returns this error if the task contains _`flux`_ _and_ _`scriptID`_.
       content:
         application/json:
           schema:
             $ref: "../../common/responses/BadRequestError.yml"
           examples:
+            fluxAndScriptError:
+              summary: Task in request body can't contain flux and scriptID properties
+              value:
+                {
+                  "code": "invalid",
+                  "message": "failed to decode request: can not provide both scriptID and flux"
+                }
             missingFluxError:
-              summary: Task in request body is missing Flux query
-              value: {
-                "code":"invalid",
-                "message": "failed to decode request: missing flux"
+              summary: Task in request body requires a flux or scriptID property
+              value:
+                {
+                  "code": "invalid",
+                  "message": "failed to decode request: flux required"
                 }
     "401":
       $ref: "../../common/responses/AuthorizationError.yml"

--- a/src/cloud/tags.yml
+++ b/src/cloud/tags.yml
@@ -37,7 +37,7 @@ tags:
     description: |
       Process and analyze your data with tasks in the InfluxDB task engine.
       With tasks, you can schedule Flux scripts to query, analyze, modify, and act on data.
-      In InfluxDB Cloud, you can create tasks that run [invokable scripts](/#tag/Invokable-Scripts)
+      In InfluxDB Cloud, you can create tasks that run [invokable scripts](#tag/Invokable-Scripts)
       with parameters.
 
       Use the `/api/v2/tasks` endpoints to create and manage tasks, retry task runs, and retrieve run logs.

--- a/src/cloud/tags.yml
+++ b/src/cloud/tags.yml
@@ -37,14 +37,15 @@ tags:
     description: |
       Process and analyze your data with tasks in the InfluxDB task engine.
       With tasks, you can schedule Flux scripts to query, analyze, modify, and act on data.
-      With InfluxDB Cloud, you can manage [invokable scripts](/#tag/Invokable-Scripts)
-      for your organization and schedule tasks that run them with parameters.
+      In InfluxDB Cloud, you can create tasks that run [invokable scripts](/#tag/Invokable-Scripts)
+      with parameters.
 
       Use the `/api/v2/tasks` endpoints to create and manage tasks, retry task runs, and retrieve run logs.
 
       #### Related guides
 
       - [Common data processing tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/common-tasks/)
+      - [Invoke custom scripts as API endpoints](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/)
   - name: Write
     description: |
       Write time series data to buckets.

--- a/src/cloud/tags.yml
+++ b/src/cloud/tags.yml
@@ -37,6 +37,8 @@ tags:
     description: |
       Process and analyze your data with tasks in the InfluxDB task engine.
       With tasks, you can schedule Flux scripts to query, analyze, modify, and act on data.
+      With InfluxDB Cloud, you can manage [invokable scripts](/#tag/Invokable-Scripts)
+      for your organization and schedule tasks that run them with parameters.
 
       Use the `/api/v2/tasks` endpoints to create and manage tasks, retry task runs, and retrieve run logs.
 

--- a/src/common/paths/tasks_taskID_logs.yml
+++ b/src/common/paths/tasks_taskID_logs.yml
@@ -32,7 +32,7 @@ get:
           examples:
             taskSuccess:
               summary: Events for successful task.
-              value: 
+              value:
                 "events": [
                   {
                     "runID": "09b070dadaa7d000",

--- a/src/common/paths/tasks_taskID_logs.yml
+++ b/src/common/paths/tasks_taskID_logs.yml
@@ -3,6 +3,13 @@ get:
   tags:
     - Tasks
   summary: Retrieve all logs for a task
+  description: |
+    Retrieves a list of all logs for a task.
+
+    Use this endpoint to retrieve only the log events for a task,
+    without additional task metadata.
+    Each log event `message` contains detail about the event.
+
   parameters:
     - $ref: "../parameters/TraceSpan.yml"
     - in: path
@@ -13,14 +20,18 @@ get:
       description: The task ID.
   responses:
     "200":
-      description: All logs for a task
+      description: Success. The response body contains an `events` list with logs for the task.
       content:
         application/json:
           schema:
             $ref: "../schemas/Logs.yml"
+    "400":
+      $ref: "../responses/BadRequestError.yml"
+    "401":
+      $ref: "../responses/AuthorizationError.yml"
+    "404":
+      $ref: "../responses/ResourceNotFoundError.yml"
+    "500":
+      $ref: "../responses/InternalServerError.yml"
     default:
-      description: Unexpected error
-      content:
-        application/json:
-          schema:
-            $ref: "../schemas/Error.yml"
+      $ref: "../responses/ServerError.yml"

--- a/src/common/paths/tasks_taskID_logs.yml
+++ b/src/common/paths/tasks_taskID_logs.yml
@@ -4,12 +4,13 @@ get:
     - Tasks
   summary: Retrieve all logs for a task
   description: |
-    Retrieves a list of all logs for a task.
+    Retrieves a list of all logs for a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task).
+
+    When an InfluxDB task runs, a “run” record is created in the task’s history.
+    Logs associated with each run provide relevant log messages, timestamps, and the exit status of the run attempt.
 
     Use this endpoint to retrieve only the log events for a task,
     without additional task metadata.
-    Each log event `message` contains detail about the event.
-
   parameters:
     - $ref: "../parameters/TraceSpan.yml"
     - in: path
@@ -20,11 +21,51 @@ get:
       description: The task ID.
   responses:
     "200":
-      description: Success. The response body contains an `events` list with logs for the task.
+      description: |
+       Success. The response body contains an `events` list with logs for the task.
+       Each log event `message` contains detail about the event.
+       If a task run fails, InfluxDB logs an event with the reason for the failure.
       content:
         application/json:
           schema:
             $ref: "../schemas/Logs.yml"
+          examples:
+            taskSuccess:
+              summary: Events for successful task.
+              value: 
+                "events": [
+                  {
+                    "runID": "09b070dadaa7d000",
+                    "time": "2022-07-18T14:46:07.101231Z",
+                    "message": "Started task from script: \"option task = {name: \\\"task1\\\", every: 30m} from(bucket: \\\"iot_center\\\") |> range(start: -90d) |> filter(fn: (r) => r._measurement == \\\"environment\\\") |> aggregateWindow(every: 1h, fn: mean)\""
+                  },
+                  {
+                    "runID": "09b070dadaa7d000",
+                    "time": "2022-07-18T14:46:07.242859Z",
+                    "message": "Completed(success)"
+                  }
+                ]
+            taskFailure:
+              summary: Events for a failed task.
+              value: {
+                "events": [
+                  {
+                    "runID": "09a946fc3167d000",
+                    "time": "2022-07-13T07:06:54.198167Z",
+                    "message": "Started task from script: \"option task = {name: \\\"test task\\\", every: 3d, offset: 0s}\""
+                  },
+                  {
+                    "runID": "09a946fc3167d000",
+                    "time": "2022-07-13T07:07:13.104037Z",
+                    "message": "Completed(failed)"
+                  },
+                  {
+                    "runID": "09a946fc3167d000",
+                    "time": "2022-07-13T08:24:37.115323Z",
+                    "message": "error exhausting result iterator: error in query specification while starting program: this Flux script returns no streaming data. Consider adding a \"yield\" or invoking streaming functions directly, without performing an assignment"
+                  }
+                ]
+              }
     "400":
       $ref: "../responses/BadRequestError.yml"
     "401":

--- a/src/common/paths/tasks_taskID_runs_runID.yml
+++ b/src/common/paths/tasks_taskID_runs_runID.yml
@@ -2,7 +2,11 @@ get:
   operationId: GetTasksIDRunsID
   tags:
     - Tasks
-  summary: Retrieve a single run for a task.
+  summary: Retrieve a run for a task.
+  description: |
+    Retrieves a specific run for a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task).
+
+    Use this endpoint to retrieve detail and logs for a specific task run.
   parameters:
     - $ref: "../parameters/TraceSpan.yml"
     - in: path
@@ -19,23 +23,61 @@ get:
       description: The run ID.
   responses:
     "200":
-      description: Returns the run record.
+      description: Success. The response body contains the task run.
       content:
         application/json:
           schema:
             $ref: "../schemas/Run.yml"
+        examples:
+          runSuccess:
+            summary: A successful task run.
+            value: 
+              {
+                "links": {
+                  "logs": "/api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/logs",
+                  "retry": "/api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/retry",
+                  "self": "/api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000",
+                  "task": "/api/v2/tasks/0996e56b2f378000"
+                },
+                "id": "09b070dadaa7d000",
+                "taskID": "0996e56b2f378000",
+                "status": "success",
+                "scheduledFor": "2022-07-18T14:46:06Z",
+                "startedAt": "2022-07-18T14:46:07.16222Z",
+                "finishedAt": "2022-07-18T14:46:07.308254Z",
+                "requestedAt": "2022-07-18T14:46:06Z",
+                "log": [
+                  {
+                    "runID": "09b070dadaa7d000",
+                    "time": "2022-07-18T14:46:07.101231Z",
+                    "message": "Started task from script: \"option task = {name: \\\"task1\\\", every: 30m} from(bucket: \\\"iot_center\\\") |> range(start: -90d) |> filter(fn: (r) => r._measurement == \\\"environment\\\")               |> aggregateWindow(every: 1h, fn: mean)\""
+                  },
+                  {
+                    "runID": "09b070dadaa7d000",
+                    "time": "2022-07-18T14:46:07.242859Z",
+                    "message": "Completed(success)"
+                  }
+                ]
+              }
+    "400":
+      $ref: "../responses/BadRequestError.yml"
+    "401":
+      $ref: "../responses/AuthorizationError.yml"
+    "404":
+      $ref: "../responses/ResourceNotFoundError.yml"
+    "500":
+      $ref: "../responses/InternalServerError.yml"
     default:
-      description: Unexpected error.
-      content:
-        application/json:
-          schema:
-            $ref: "../schemas/Error.yml"
+      $ref: "../responses/ServerError.yml"
 delete:
   operationId: DeleteTasksIDRunsID
   tags:
     - Tasks
-  summary: |
-    Cancel a running task.
+  summary: Cancel a running task
+  description: |
+    Cancels a running [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task).
+
+    Use this endpoint with InfluxDB OSS to cancel a running task.
 
     #### InfluxDB Cloud
 
@@ -53,17 +95,23 @@ delete:
       schema:
         type: string
       required: true
-      description: The run ID.
+      description: The ID of the task run to cancel.
   responses:
     "204":
-      description: Delete has been accepted.
+      description: |
+        Success. The `DELETE` is accepted and the run will be cancelled.
+
+        #### InfluxDB Cloud
+
+          - Doesn't support this operation.
+
     "405":
       description: |
         Method not allowed.
 
         #### InfluxDB Cloud
 
-          - Cancelling task runs is not supported in InfluxDB Cloud.
+          - Always returns this error; cancelling a task run is not supported.
 
         #### InfluxDB OSS
 
@@ -72,9 +120,13 @@ delete:
         application/json:
           schema:
             $ref: "../schemas/Error.yml"
+    "400":
+      $ref: "../responses/BadRequestError.yml"
+    "401":
+      $ref: "../responses/AuthorizationError.yml"
+    "404":
+      $ref: "../responses/ResourceNotFoundError.yml"
+    "500":
+      $ref: "../responses/InternalServerError.yml"
     default:
-      description: Unexpected error.
-      content:
-        application/json:
-          schema:
-            $ref: "../schemas/Error.yml"
+      $ref: "../responses/ServerError.yml"

--- a/src/common/paths/tasks_taskID_runs_runID.yml
+++ b/src/common/paths/tasks_taskID_runs_runID.yml
@@ -28,37 +28,37 @@ get:
         application/json:
           schema:
             $ref: "../schemas/Run.yml"
-        examples:
-          runSuccess:
-            summary: A successful task run.
-            value: 
-              {
-                "links": {
-                  "logs": "/api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/logs",
-                  "retry": "/api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/retry",
-                  "self": "/api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000",
-                  "task": "/api/v2/tasks/0996e56b2f378000"
-                },
-                "id": "09b070dadaa7d000",
-                "taskID": "0996e56b2f378000",
-                "status": "success",
-                "scheduledFor": "2022-07-18T14:46:06Z",
-                "startedAt": "2022-07-18T14:46:07.16222Z",
-                "finishedAt": "2022-07-18T14:46:07.308254Z",
-                "requestedAt": "2022-07-18T14:46:06Z",
-                "log": [
-                  {
-                    "runID": "09b070dadaa7d000",
-                    "time": "2022-07-18T14:46:07.101231Z",
-                    "message": "Started task from script: \"option task = {name: \\\"task1\\\", every: 30m} from(bucket: \\\"iot_center\\\") |> range(start: -90d) |> filter(fn: (r) => r._measurement == \\\"environment\\\")               |> aggregateWindow(every: 1h, fn: mean)\""
+          examples:
+            runSuccess:
+              summary: A successful task run.
+              value:
+                {
+                  "links": {
+                    "logs": "/api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/logs",
+                    "retry": "/api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000/retry",
+                    "self": "/api/v2/tasks/0996e56b2f378000/runs/09b070dadaa7d000",
+                    "task": "/api/v2/tasks/0996e56b2f378000"
                   },
-                  {
-                    "runID": "09b070dadaa7d000",
-                    "time": "2022-07-18T14:46:07.242859Z",
-                    "message": "Completed(success)"
-                  }
-                ]
-              }
+                  "id": "09b070dadaa7d000",
+                  "taskID": "0996e56b2f378000",
+                  "status": "success",
+                  "scheduledFor": "2022-07-18T14:46:06Z",
+                  "startedAt": "2022-07-18T14:46:07.16222Z",
+                  "finishedAt": "2022-07-18T14:46:07.308254Z",
+                  "requestedAt": "2022-07-18T14:46:06Z",
+                  "log": [
+                    {
+                      "runID": "09b070dadaa7d000",
+                      "time": "2022-07-18T14:46:07.101231Z",
+                      "message": "Started task from script: \"option task = {name: \\\"task1\\\", every: 30m} from(bucket: \\\"iot_center\\\") |> range(start: -90d) |> filter(fn: (r) => r._measurement == \\\"environment\\\")               |> aggregateWindow(every: 1h, fn: mean)\""
+                    },
+                    {
+                      "runID": "09b070dadaa7d000",
+                      "time": "2022-07-18T14:46:07.242859Z",
+                      "message": "Completed(success)"
+                    }
+                  ]
+                }
     "400":
       $ref: "../responses/BadRequestError.yml"
     "401":

--- a/src/common/responses/BadRequestError.yml
+++ b/src/common/responses/BadRequestError.yml
@@ -12,7 +12,7 @@
         $ref: "../schemas/Error.yml"
       examples:
         orgProvidedNotFound:
-          summary: The org or orgID passed in parameters doesn't own the token passed in the header
+          summary: The org or orgID passed doesn't own the token passed in the header
           value: {
             "code":"invalid",
             "message":"failed to decode request body: organization not found"

--- a/src/common/responses/BadRequestError.yml
+++ b/src/common/responses/BadRequestError.yml
@@ -2,7 +2,18 @@
   description: |
     Bad request.
     The response body contains detail about the error.
+
+    #### InfluxDB OSS
+
+    - Returns this error if an incorrect value is passed for `org` or `orgID`.
   content:
     application/json:
       schema:
         $ref: "../schemas/Error.yml"
+      examples:
+        orgProvidedNotFound:
+          summary: The org or orgID passed in parameters doesn't own the token passed in the header
+          value: {
+            "code":"invalid",
+            "message":"failed to decode request body: organization not found"
+          }


### PR DESCRIPTION
- Retrieve all logs for a task (closes https://github.com/influxdata/openapi/issues/411).
- Cancels a running task (closes https://github.com/influxdata/openapi/issues/420).
- Clarify BadRequestError example summary for org and orgID.