### PR TITLE
chore: condensed tags when multiple were present to fix codegen

### DIFF
--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -11,7 +11,7 @@ paths:
     get:
       operationId: GetUsers
       tags:
-        - Users
+        - Security and access endpoints
       summary: List all users
       parameters:
         - in: header
@@ -38,7 +38,7 @@ paths:
     post:
       operationId: PostUsers
       tags:
-        - Users
+        - Security and access endpoints
       summary: Create a user
       parameters:
         - $ref: '#/paths/~1users/get/parameters/0'
@@ -63,7 +63,7 @@ paths:
     get:
       operationId: GetUsersID
       tags:
-        - Users
+        - Security and access endpoints
       summary: Retrieve a user
       parameters:
         - $ref: '#/paths/~1users/get/parameters/0'
@@ -86,7 +86,7 @@ paths:
     patch:
       operationId: PatchUsersID
       tags:
-        - Users
+        - Security and access endpoints
       summary: Update a user
       requestBody:
         description: User update to apply
@@ -116,7 +116,7 @@ paths:
     delete:
       operationId: DeleteUsersID
       tags:
-        - Users
+        - Security and access endpoints
       summary: Delete a user
       parameters:
         - $ref: '#/paths/~1users/get/parameters/0'
@@ -205,7 +205,7 @@ paths:
     get:
       operationId: GetAuthorizations
       tags:
-        - Authorizations
+        - Security and access endpoints
       summary: List all authorizations
       parameters:
         - $ref: '#/paths/~1users/get/parameters/0'
@@ -247,7 +247,7 @@ paths:
     post:
       operationId: PostAuthorizations
       tags:
-        - Authorizations
+        - Security and access endpoints
       summary: Create an authorization
       parameters:
         - $ref: '#/paths/~1users/get/parameters/0'
@@ -275,7 +275,7 @@ paths:
     get:
       operationId: GetAuthorizationsID
       tags:
-        - Authorizations
+        - Security and access endpoints
       summary: Retrieve an authorization
       parameters:
         - $ref: '#/paths/~1users/get/parameters/0'
@@ -298,7 +298,7 @@ paths:
     patch:
       operationId: PatchAuthorizationsID
       tags:
-        - Authorizations
+        - Security and access endpoints
       summary: Update authorization status
       description: Update an authorization's status to `active` or `inactive`.
       requestBody:
@@ -329,7 +329,7 @@ paths:
     delete:
       operationId: DeleteAuthorizationsID
       tags:
-        - Authorizations
+        - Security and access endpoints
       summary: Delete an authorization
       parameters:
         - $ref: '#/paths/~1users/get/parameters/0'
@@ -2609,7 +2609,6 @@ paths:
       operationId: GetTasks
       tags:
         - Data I/O endpoints
-        - Tasks
       summary: List all tasks
       description: |
         Retrieves a list of [tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/).
@@ -2764,7 +2763,6 @@ paths:
       operationId: PostTasks
       tags:
         - Data I/O endpoints
-        - Tasks
       summary: Create a task
       description: |
         Creates a [task]({{% INFLUXDB_DOCS_URL %}}/process-data/) and returns the created task.
@@ -2910,7 +2908,6 @@ paths:
       operationId: GetTasksID
       tags:
         - Data I/O endpoints
-        - Tasks
       summary: Retrieve a task
       description: |
         Retrieves a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task)
@@ -2987,7 +2984,7 @@ paths:
     patch:
       operationId: PatchTasksID
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Update a task
       description: |
         Updates a task and then cancels all scheduled runs of the task.
@@ -3033,7 +3030,7 @@ paths:
     delete:
       operationId: DeleteTasksID
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Delete a task
       description: |
         Deletes a task and associated records.

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -191,7 +191,6 @@
           }
         ],
         "tags": [
-          "Ping",
           "System information endpoints"
         ],
         "responses": {
@@ -224,7 +223,7 @@
           }
         ],
         "tags": [
-          "Ping"
+          "System information endpoints"
         ],
         "responses": {
           "204": {
@@ -252,7 +251,6 @@
         "operationId": "GetRoutes",
         "summary": "List all top level routes",
         "tags": [
-          "Routes",
           "System information endpoints"
         ],
         "parameters": [
@@ -1556,8 +1554,7 @@
       "post": {
         "operationId": "PostWrite",
         "tags": [
-          "Data I/O endpoints",
-          "Write"
+          "Data I/O endpoints"
         ],
         "summary": "Write data",
         "description": "Writes data to a bucket.\n\nUse this endpoint to send data in [line protocol]({{% INFLUXDB_DOCS_URL %}}/reference/syntax/line-protocol/) format to InfluxDB.\n\n#### InfluxDB Cloud\n\n- Takes the following steps when you send a write request:\n\n  1. Validates the request and queues the write.\n  2. If the write is queued, responds with an HTTP `204` status code.\n  3. Handles the write asynchronously and reaches eventual consistency.\n\n  An HTTP `2xx` status code acknowledges that the write or delete is queued.\n  To ensure that InfluxDB Cloud handles writes and deletes in the order you request them,\n  wait for a response before you send the next request.\n\n  Because writes are asynchronous, data might not yet be written\n  when you receive the response.\n\n#### InfluxDB OSS\n\n- Validates the request, handles the write synchronously,\n  and then responds with success or failure.\n- If all points were written successfully, returns `204`,\n  otherwise returns the first line that failed.\n\n#### Required permissions\n\n- `write-buckets` or `write-bucket BUCKET_ID`.\n\n  `BUCKET_ID` is the ID of the destination bucket.\n\n#### Rate limits (with InfluxDB Cloud)\n\n`write` rate limits apply.\nFor more information, see [limits and adjustable quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/).\n\n#### Related guides\n\n- [Write data with the InfluxDB API]({{% INFLUXDB_DOCS_URL %}}/write-data/developer-tools/api).\n- [Optimize writes to InfluxDB]({{% INFLUXDB_DOCS_URL %}}/write-data/best-practices/optimize-writes/).\n- [Troubleshoot issues writing data]({{% INFLUXDB_DOCS_URL %}}/write-data/troubleshoot/)\n",
@@ -1769,8 +1766,7 @@
       "post": {
         "operationId": "PostDelete",
         "tags": [
-          "Data I/O endpoints",
-          "Delete"
+          "Data I/O endpoints"
         ],
         "summary": "Delete data",
         "description": "Deletes data from a bucket.\n\nUse this endpoint to delete points from a bucket in a specified time range.\n\n#### InfluxDB Cloud\n\n- Does the following when you send a delete request:\n\n  1. Validates the request and queues the delete.\n  2. Returns _success_ if queued; _error_ otherwise.\n  3. Handles the delete asynchronously.\n\n#### InfluxDB OSS\n\n- Validates the request, handles the delete synchronously,\n  and then responds with success or failure.\n\n#### Required permissions\n\n- `write-buckets` or `write-bucket BUCKET_ID`.\n\n  `BUCKET_ID` is the ID of the destination bucket.\n\n#### Rate limits (with InfluxDB Cloud)\n\n`write` rate limits apply.\nFor more information, see [limits and adjustable quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/).\n\n#### Related guides\n\n- [Delete data]({{% INFLUXDB_DOCS_URL %}}/write-data/delete-data/).\n- Learn how to use [delete predicate syntax]({{% INFLUXDB_DOCS_URL %}}/reference/syntax/delete-predicate/).\n- Learn how InfluxDB handles [deleted tags](https://docs.influxdata.com/flux/v0.x/stdlib/influxdata/influxdb/schema/measurementtagkeys/)\n  and [deleted fields](https://docs.influxdata.com/flux/v0.x/stdlib/influxdata/influxdb/schema/measurementfieldkeys/).\n",
@@ -3137,7 +3133,7 @@
       "post": {
         "operationId": "PostQueryAst",
         "tags": [
-          "Query"
+          "Data I/O endpoints"
         ],
         "summary": "Generate a query Abstract Syntax Tree (AST)",
         "description": "Analyzes a Flux query and returns a complete package source [Abstract Syntax\nTree (AST)](https://https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#abstract-syntax-tree)\nfor the query.\n\nUse this endpoint for deep query analysis such as debugging unexpected query\nresults.\n\nA Flux query AST provides a semantic, tree-like representation with contextual\ninformation about the query. The AST illustrates how the query is distributed\ninto different components for execution.\n\n\n#### Limitations\n\n-  The endpoint doesn't validate values in the query--for example:\n\n    The following query has correct syntax, but contains an incorrect `from()` property key:\n    ```json\n    { \"query\": \"from(foo: \\\"iot_center\\\")\\\n                |> range(start: -90d)\\\n                |> filter(fn: (r) => r._measurement == \\\"environment\\\")\"\n    }\n    ```\n    Passing this to `/api/v2/query/ast` will return a successful response\n    with a generated AST.\n",
@@ -3701,7 +3697,7 @@
       "get": {
         "operationId": "GetQuerySuggestions",
         "tags": [
-          "Query"
+          "Data I/O endpoints"
         ],
         "summary": "Retrieve query suggestions",
         "parameters": [
@@ -3737,7 +3733,7 @@
       "get": {
         "operationId": "GetQuerySuggestionsName",
         "tags": [
-          "Query"
+          "Data I/O endpoints"
         ],
         "summary": "Retrieve query suggestions for a branching suggestion",
         "parameters": [
@@ -3782,7 +3778,7 @@
       "post": {
         "operationId": "PostQueryAnalyze",
         "tags": [
-          "Query"
+          "Data I/O endpoints"
         ],
         "summary": "Analyze a Flux query",
         "description": "Analyzes a [Flux query](https://docs.influxdata.com/flux/v0.x/) for syntax\nerrors and returns the list of errors.\n\nIn the following example `Query` object, `query` is missing a `from()` property key:\n\n    ```json\n    { \"query\": \"from(: \\\"iot_center\\\")\\\n                |> range(start: -90d)\\\n                |> filter(fn: (r) => r._measurement == \\\"environment\\\")\",\n      \"type\": \"flux\"\n    }\n    ```\n\nPassing this to `/api/v2/analyze` returns an `errors` list that contains an error object for the missing key.\n\n#### Limitations\n\n-  The endpoint doesn't validate values in the query--for example:\n\n  - The following query has correct syntax, but contains an incorrect `from()` property key:\n\n    ```json\n    { \"query\": \"from(foo: \\\"iot_center\\\")\\\n                |> range(start: -90d)\\\n                |> filter(fn: (r) => r._measurement == \\\"environment\\\")\",\n      \"type\": \"flux\"\n    }\n    ```\n\n    Passing this to `/api/v2/analyze` returns an empty `errors` list.\n",
@@ -3922,8 +3918,7 @@
       "post": {
         "operationId": "PostQuery",
         "tags": [
-          "Data I/O endpoints",
-          "Query"
+          "Data I/O endpoints"
         ],
         "summary": "Query data",
         "description": "Retrieves data from buckets.\n\nUse this endpoint to send a Flux query request and retrieve data from a bucket.\n\n#### Rate limits (with InfluxDB Cloud)\n\n`read` rate limits apply.\nFor more information, see [limits and adjustable quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/).\n\n#### Related guides\n\n- [Query with the InfluxDB API]({{% INFLUXDB_DOCS_URL %}}/query-data/execute-queries/influx-api/).\n- [Get started with Flux](https://docs.influxdata.com/flux/v0.x/get-started/)\n",
@@ -4804,7 +4799,6 @@
       "get": {
         "operationId": "GetOrgs",
         "tags": [
-          "Organizations",
           "Security and access endpoints"
         ],
         "summary": "List all organizations",
@@ -4872,7 +4866,7 @@
       "post": {
         "operationId": "PostOrgs",
         "tags": [
-          "Organizations"
+          "Security and access endpoints"
         ],
         "summary": "Create an organization",
         "parameters": [
@@ -4919,7 +4913,6 @@
       "get": {
         "operationId": "GetOrgsID",
         "tags": [
-          "Organizations",
           "Security and access endpoints"
         ],
         "summary": "Retrieve an organization",
@@ -4963,7 +4956,7 @@
       "patch": {
         "operationId": "PatchOrgsID",
         "tags": [
-          "Organizations"
+          "Security and access endpoints"
         ],
         "summary": "Update an organization",
         "requestBody": {
@@ -5017,7 +5010,7 @@
       "delete": {
         "operationId": "DeleteOrgsID",
         "tags": [
-          "Organizations"
+          "Security and access endpoints"
         ],
         "summary": "Delete an organization",
         "parameters": [
@@ -5065,7 +5058,6 @@
       "get": {
         "operationId": "GetOrgsIDSecrets",
         "tags": [
-          "Secrets",
           "Security and access endpoints"
         ],
         "summary": "List all secret keys for an organization",
@@ -5109,7 +5101,7 @@
       "patch": {
         "operationId": "PatchOrgsIDSecrets",
         "tags": [
-          "Secrets"
+          "Security and access endpoints"
         ],
         "summary": "Update secrets in an organization",
         "parameters": [
@@ -5158,7 +5150,6 @@
       "get": {
         "operationId": "GetOrgsIDMembers",
         "tags": [
-          "Organizations",
           "Security and access endpoints"
         ],
         "summary": "List all members of an organization",
@@ -5212,7 +5203,7 @@
       "post": {
         "operationId": "PostOrgsIDMembers",
         "tags": [
-          "Organizations"
+          "Security and access endpoints"
         ],
         "summary": "Add a member to an organization",
         "parameters": [
@@ -5268,7 +5259,6 @@
       "delete": {
         "operationId": "DeleteOrgsIDMembersID",
         "tags": [
-          "Organizations",
           "Security and access endpoints"
         ],
         "summary": "Remove a member from an organization",
@@ -5316,7 +5306,6 @@
       "get": {
         "operationId": "GetOrgsIDOwners",
         "tags": [
-          "Organizations",
           "Security and access endpoints"
         ],
         "summary": "List all owners of an organization",
@@ -5370,7 +5359,7 @@
       "post": {
         "operationId": "PostOrgsIDOwners",
         "tags": [
-          "Organizations"
+          "Security and access endpoints"
         ],
         "summary": "Add an owner to an organization",
         "parameters": [
@@ -5426,7 +5415,6 @@
       "delete": {
         "operationId": "DeleteOrgsIDOwnersID",
         "tags": [
-          "Organizations",
           "Security and access endpoints"
         ],
         "summary": "Remove an owner from an organization",
@@ -5475,7 +5463,6 @@
         "deprecated": true,
         "operationId": "PostOrgsIDSecrets",
         "tags": [
-          "Secrets",
           "Security and access endpoints"
         ],
         "summary": "Delete secrets from an organization",
@@ -5525,7 +5512,6 @@
       "delete": {
         "operationId": "DeleteOrgsIDSecretsID",
         "tags": [
-          "Secrets",
           "Security and access endpoints"
         ],
         "summary": "Delete a secret from an organization",
@@ -5567,7 +5553,6 @@
       "get": {
         "operationId": "GetResources",
         "tags": [
-          "Resources",
           "System information endpoints"
         ],
         "summary": "List all known resources",
@@ -6092,7 +6077,7 @@
       "get": {
         "operationId": "GetTasksIDRuns",
         "tags": [
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "List runs for a task",
         "parameters": [
@@ -6172,8 +6157,7 @@
       "post": {
         "operationId": "PostTasksIDRuns",
         "tags": [
-          "Data I/O endpoints",
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "Manually start a task run, overriding the current schedule",
         "parameters": [
@@ -6226,7 +6210,7 @@
       "get": {
         "operationId": "GetTasksIDRunsID",
         "tags": [
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "Retrieve a run for a task.",
         "description": "Retrieves a specific run for a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task).\n\nUse this endpoint to retrieve detail and logs for a specific task run.\n",
@@ -6316,7 +6300,7 @@
       "delete": {
         "operationId": "DeleteTasksIDRunsID",
         "tags": [
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "Cancel a running task",
         "description": "Cancels a running [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task).\n\nUse this endpoint with InfluxDB OSS to cancel a running task.\n\n#### InfluxDB Cloud\n\n  - Doesn't support this operation.\n",
@@ -6379,7 +6363,7 @@
       "post": {
         "operationId": "PostTasksIDRunsIDRetry",
         "tags": [
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "Retry a task run",
         "requestBody": {
@@ -6442,7 +6426,7 @@
       "get": {
         "operationId": "GetTasksIDLogs",
         "tags": [
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "Retrieve all logs for a task",
         "description": "Retrieves a list of all logs for a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task).\n\nWhen an InfluxDB task runs, a “run” record is created in the task’s history.\nLogs associated with each run provide relevant log messages, timestamps, and the exit status of the run attempt.\n\nUse this endpoint to retrieve only the log events for a task,\nwithout additional task metadata.\n",
@@ -6534,7 +6518,7 @@
       "get": {
         "operationId": "GetTasksIDRunsIDLogs",
         "tags": [
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "Retrieve all logs for a run",
         "parameters": [
@@ -6588,7 +6572,7 @@
       "get": {
         "operationId": "GetTasksIDLabels",
         "tags": [
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "List labels for a task",
         "description": "Retrieves a list of all labels for a task.\n\nLabels may be used for grouping and filtering tasks.\n",
@@ -6637,7 +6621,7 @@
       "post": {
         "operationId": "PostTasksIDLabels",
         "tags": [
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "Add a label to a task",
         "description": "Adds a label to a task.\n\nUse this endpoint to add a label that you can use to filter tasks in the InfluxDB UI.\n",
@@ -6699,7 +6683,7 @@
       "delete": {
         "operationId": "DeleteTasksIDLabelsID",
         "tags": [
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "Delete a label from a task",
         "description": "Deletes a label from a task.\n",
@@ -6872,7 +6856,7 @@
       "get": {
         "operationId": "GetTasksIDMembers",
         "tags": [
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "List all task members",
         "parameters": [
@@ -6915,7 +6899,7 @@
       "post": {
         "operationId": "PostTasksIDMembers",
         "tags": [
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "Add a member to a task",
         "parameters": [
@@ -6971,7 +6955,7 @@
       "delete": {
         "operationId": "DeleteTasksIDMembersID",
         "tags": [
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "Remove a member from a task",
         "parameters": [
@@ -7018,7 +7002,7 @@
       "get": {
         "operationId": "GetTasksIDOwners",
         "tags": [
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "List all owners of a task",
         "parameters": [
@@ -7061,7 +7045,7 @@
       "post": {
         "operationId": "PostTasksIDOwners",
         "tags": [
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "Add an owner to a task",
         "parameters": [
@@ -7117,7 +7101,7 @@
       "delete": {
         "operationId": "DeleteTasksIDOwnersID",
         "tags": [
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "Remove an owner from a task",
         "parameters": [
@@ -7164,8 +7148,7 @@
       "post": {
         "operationId": "PostUsersIDPassword",
         "tags": [
-          "Security and access endpoints",
-          "Users"
+          "Security and access endpoints"
         ],
         "summary": "Update a password",
         "description": "#### InfluxDB Cloud\n\nInfluxDB Cloud does not support changing user passwords through the API.\nUse the InfluxDB Cloud user interface to update your password.\n",
@@ -8769,7 +8752,7 @@
       "get": {
         "operationId": "GetUsers",
         "tags": [
-          "Users"
+          "Security and access endpoints"
         ],
         "summary": "List all users",
         "parameters": [
@@ -8797,7 +8780,7 @@
       "post": {
         "operationId": "PostUsers",
         "tags": [
-          "Users"
+          "Security and access endpoints"
         ],
         "summary": "Create a user",
         "parameters": [
@@ -8838,7 +8821,7 @@
       "get": {
         "operationId": "GetUsersID",
         "tags": [
-          "Users"
+          "Security and access endpoints"
         ],
         "summary": "Retrieve a user",
         "parameters": [
@@ -8875,7 +8858,7 @@
       "patch": {
         "operationId": "PatchUsersID",
         "tags": [
-          "Users"
+          "Security and access endpoints"
         ],
         "summary": "Update a user",
         "requestBody": {
@@ -8923,7 +8906,7 @@
       "delete": {
         "operationId": "DeleteUsersID",
         "tags": [
-          "Users"
+          "Security and access endpoints"
         ],
         "summary": "Delete a user",
         "parameters": [
@@ -9059,7 +9042,7 @@
       "get": {
         "operationId": "GetAuthorizations",
         "tags": [
-          "Authorizations"
+          "Security and access endpoints"
         ],
         "summary": "List all authorizations",
         "parameters": [
@@ -9127,7 +9110,7 @@
       "post": {
         "operationId": "PostAuthorizations",
         "tags": [
-          "Authorizations"
+          "Security and access endpoints"
         ],
         "summary": "Create an authorization",
         "parameters": [
@@ -9172,7 +9155,7 @@
       "get": {
         "operationId": "GetAuthorizationsID",
         "tags": [
-          "Authorizations"
+          "Security and access endpoints"
         ],
         "summary": "Retrieve an authorization",
         "parameters": [
@@ -9209,7 +9192,7 @@
       "patch": {
         "operationId": "PatchAuthorizationsID",
         "tags": [
-          "Authorizations"
+          "Security and access endpoints"
         ],
         "summary": "Update authorization status",
         "description": "Update an authorization's status to `active` or `inactive`.",
@@ -9258,7 +9241,7 @@
       "delete": {
         "operationId": "DeleteAuthorizationsID",
         "tags": [
-          "Authorizations"
+          "Security and access endpoints"
         ],
         "summary": "Delete an authorization",
         "parameters": [
@@ -10161,8 +10144,7 @@
       "get": {
         "operationId": "GetTasks",
         "tags": [
-          "Data I/O endpoints",
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "List all tasks",
         "description": "Retrieves a list of [tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/).\n\nTo limit which tasks are returned, pass query parameters in your request.\nIf no query parameters are passed, InfluxDB returns all tasks up to the default `limit`.\n",
@@ -10313,8 +10295,7 @@
       "post": {
         "operationId": "PostTasks",
         "tags": [
-          "Data I/O endpoints",
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "Create a task",
         "description": "Creates a [task]({{% INFLUXDB_DOCS_URL %}}/process-data/) and returns the created task.\n\nUse this endpoint to create a scheduled task that runs a Flux script.\nIn your task, provide one of the following:\n\n  - _`flux`_ property with an inline Flux script\n  - _`scriptID`_ property with an [invokable script](#tag/Invokable-Scripts) ID\n\n#### InfluxDB Cloud\n\n  - Requires either _`flux`_ (Flux query) or _`scriptID`_ (invokable script ID) in the task.\n\n#### Related guides\n\n- [Create a task]({{% INFLUXDB_DOCS_URL %}}/process-data/manage-tasks/create-task/).\n- [Common tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/common-tasks/)\n- [Task configuration options]({{% INFLUXDB_DOCS_URL %}}/process-data/task-options/)\n",
@@ -10406,8 +10387,7 @@
       "get": {
         "operationId": "GetTasksID",
         "tags": [
-          "Data I/O endpoints",
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "Retrieve a task",
         "description": "Retrieves a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task)\nby task ID.\n",
@@ -10456,7 +10436,7 @@
       "patch": {
         "operationId": "PatchTasksID",
         "tags": [
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "Update a task",
         "description": "Updates a task and then cancels all scheduled runs of the task.\n\nUse this endpoint to modify task properties (for example: `cron`, `name`, `flux`, `status`).\nOnce InfluxDB applies the update, it cancels all scheduled runs of the task.\n\nTo update a task, pass an object that contains the updated key-value pairs.\nTo activate or inactivate a task, set the `status` property.\n_`\"status\": \"inactive\"`_ cancels scheduled runs and prevents manual runs of the task.\n",
@@ -10516,7 +10496,7 @@
       "delete": {
         "operationId": "DeleteTasksID",
         "tags": [
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "Delete a task",
         "description": "Deletes a task and associated records.\n\nUse this endpoint to delete a task and all associated records (task runs, logs, and labels).\nOnce the task is deleted, InfluxDB cancels all scheduled runs of the task.\n\nIf you want to disable a task instead of delete it, [update the task status to `inactive`](#operation/PatchTasksID).\n",

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -201,7 +201,6 @@ paths:
       servers:
         - url: ''
       tags:
-        - Ping
         - System information endpoints
       responses:
         '204':
@@ -224,7 +223,7 @@ paths:
       servers:
         - url: ''
       tags:
-        - Ping
+        - System information endpoints
       responses:
         '204':
           description: |
@@ -244,7 +243,6 @@ paths:
       operationId: GetRoutes
       summary: List all top level routes
       tags:
-        - Routes
         - System information endpoints
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -1042,7 +1040,6 @@ paths:
       operationId: PostWrite
       tags:
         - Data I/O endpoints
-        - Write
       summary: Write data
       description: |
         Writes data to a bucket.
@@ -1359,7 +1356,6 @@ paths:
       operationId: PostDelete
       tags:
         - Data I/O endpoints
-        - Delete
       summary: Delete data
       description: |
         Deletes data from a bucket.
@@ -2303,7 +2299,7 @@ paths:
     post:
       operationId: PostQueryAst
       tags:
-        - Query
+        - Data I/O endpoints
       summary: Generate a query Abstract Syntax Tree (AST)
       description: |
         Analyzes a Flux query and returns a complete package source [Abstract Syntax
@@ -2726,7 +2722,7 @@ paths:
     get:
       operationId: GetQuerySuggestions
       tags:
-        - Query
+        - Data I/O endpoints
       summary: Retrieve query suggestions
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -2747,7 +2743,7 @@ paths:
     get:
       operationId: GetQuerySuggestionsName
       tags:
-        - Query
+        - Data I/O endpoints
       summary: Retrieve query suggestions for a branching suggestion
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -2774,7 +2770,7 @@ paths:
     post:
       operationId: PostQueryAnalyze
       tags:
-        - Query
+        - Data I/O endpoints
       summary: Analyze a Flux query
       description: |
         Analyzes a [Flux query](https://docs.influxdata.com/flux/v0.x/) for syntax
@@ -2925,7 +2921,6 @@ paths:
       operationId: PostQuery
       tags:
         - Data I/O endpoints
-        - Query
       summary: Query data
       description: |
         Retrieves data from buckets.
@@ -3527,7 +3522,6 @@ paths:
     get:
       operationId: GetOrgs
       tags:
-        - Organizations
         - Security and access endpoints
       summary: List all organizations
       parameters:
@@ -3566,7 +3560,7 @@ paths:
     post:
       operationId: PostOrgs
       tags:
-        - Organizations
+        - Security and access endpoints
       summary: Create an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3594,7 +3588,6 @@ paths:
     get:
       operationId: GetOrgsID
       tags:
-        - Organizations
         - Security and access endpoints
       summary: Retrieve an organization
       parameters:
@@ -3621,7 +3614,7 @@ paths:
     patch:
       operationId: PatchOrgsID
       tags:
-        - Organizations
+        - Security and access endpoints
       summary: Update an organization
       requestBody:
         description: Organization update to apply
@@ -3654,7 +3647,7 @@ paths:
     delete:
       operationId: DeleteOrgsID
       tags:
-        - Organizations
+        - Security and access endpoints
       summary: Delete an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3683,7 +3676,6 @@ paths:
     get:
       operationId: GetOrgsIDSecrets
       tags:
-        - Secrets
         - Security and access endpoints
       summary: List all secret keys for an organization
       parameters:
@@ -3710,7 +3702,7 @@ paths:
     patch:
       operationId: PatchOrgsIDSecrets
       tags:
-        - Secrets
+        - Security and access endpoints
       summary: Update secrets in an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3740,7 +3732,6 @@ paths:
     get:
       operationId: GetOrgsIDMembers
       tags:
-        - Organizations
         - Security and access endpoints
       summary: List all members of an organization
       parameters:
@@ -3773,7 +3764,7 @@ paths:
     post:
       operationId: PostOrgsIDMembers
       tags:
-        - Organizations
+        - Security and access endpoints
       summary: Add a member to an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3807,7 +3798,6 @@ paths:
     delete:
       operationId: DeleteOrgsIDMembersID
       tags:
-        - Organizations
         - Security and access endpoints
       summary: Remove a member from an organization
       parameters:
@@ -3837,7 +3827,6 @@ paths:
     get:
       operationId: GetOrgsIDOwners
       tags:
-        - Organizations
         - Security and access endpoints
       summary: List all owners of an organization
       parameters:
@@ -3870,7 +3859,7 @@ paths:
     post:
       operationId: PostOrgsIDOwners
       tags:
-        - Organizations
+        - Security and access endpoints
       summary: Add an owner to an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3904,7 +3893,6 @@ paths:
     delete:
       operationId: DeleteOrgsIDOwnersID
       tags:
-        - Organizations
         - Security and access endpoints
       summary: Remove an owner from an organization
       parameters:
@@ -3935,7 +3923,6 @@ paths:
       deprecated: true
       operationId: PostOrgsIDSecrets
       tags:
-        - Secrets
         - Security and access endpoints
       summary: Delete secrets from an organization
       parameters:
@@ -3966,7 +3953,6 @@ paths:
     delete:
       operationId: DeleteOrgsIDSecretsID
       tags:
-        - Secrets
         - Security and access endpoints
       summary: Delete a secret from an organization
       parameters:
@@ -3993,7 +3979,6 @@ paths:
     get:
       operationId: GetResources
       tags:
-        - Resources
         - System information endpoints
       summary: List all known resources
       parameters:
@@ -4320,7 +4305,7 @@ paths:
     get:
       operationId: GetTasksIDRuns
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: List runs for a task
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -4372,7 +4357,6 @@ paths:
       operationId: PostTasksIDRuns
       tags:
         - Data I/O endpoints
-        - Tasks
       summary: 'Manually start a task run, overriding the current schedule'
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -4403,7 +4387,7 @@ paths:
     get:
       operationId: GetTasksIDRunsID
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Retrieve a run for a task.
       description: |
         Retrieves a specific run for a [task](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#task).
@@ -4466,7 +4450,7 @@ paths:
     delete:
       operationId: DeleteTasksIDRunsID
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Cancel a running task
       description: |
         Cancels a running [task](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#task).
@@ -4527,7 +4511,7 @@ paths:
     post:
       operationId: PostTasksIDRunsIDRetry
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Retry a task run
       requestBody:
         content:
@@ -4565,7 +4549,7 @@ paths:
     get:
       operationId: GetTasksIDLogs
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Retrieve all logs for a task
       description: |
         Retrieves a list of all logs for a [task](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#task).
@@ -4631,7 +4615,7 @@ paths:
     get:
       operationId: GetTasksIDRunsIDLogs
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Retrieve all logs for a run
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -4664,7 +4648,7 @@ paths:
     get:
       operationId: GetTasksIDLabels
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: List labels for a task
       description: |
         Retrieves a list of all labels for a task.
@@ -4698,7 +4682,7 @@ paths:
     post:
       operationId: PostTasksIDLabels
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Add a label to a task
       description: |
         Adds a label to a task.
@@ -4740,7 +4724,7 @@ paths:
     delete:
       operationId: DeleteTasksIDLabelsID
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Delete a label from a task
       description: |
         Deletes a label from a task.
@@ -4852,7 +4836,7 @@ paths:
     get:
       operationId: GetTasksIDMembers
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: List all task members
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -4878,7 +4862,7 @@ paths:
     post:
       operationId: PostTasksIDMembers
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Add a member to a task
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -4912,7 +4896,7 @@ paths:
     delete:
       operationId: DeleteTasksIDMembersID
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Remove a member from a task
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -4941,7 +4925,7 @@ paths:
     get:
       operationId: GetTasksIDOwners
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: List all owners of a task
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -4967,7 +4951,7 @@ paths:
     post:
       operationId: PostTasksIDOwners
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Add an owner to a task
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -5001,7 +4985,7 @@ paths:
     delete:
       operationId: DeleteTasksIDOwnersID
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Remove an owner from a task
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -5031,7 +5015,6 @@ paths:
       operationId: PostUsersIDPassword
       tags:
         - Security and access endpoints
-        - Users
       summary: Update a password
       description: |
         #### InfluxDB Cloud
@@ -6008,7 +5991,7 @@ paths:
     get:
       operationId: GetUsers
       tags:
-        - Users
+        - Security and access endpoints
       summary: List all users
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -6025,7 +6008,7 @@ paths:
     post:
       operationId: PostUsers
       tags:
-        - Users
+        - Security and access endpoints
       summary: Create a user
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -6050,7 +6033,7 @@ paths:
     get:
       operationId: GetUsersID
       tags:
-        - Users
+        - Security and access endpoints
       summary: Retrieve a user
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -6073,7 +6056,7 @@ paths:
     patch:
       operationId: PatchUsersID
       tags:
-        - Users
+        - Security and access endpoints
       summary: Update a user
       requestBody:
         description: User update to apply
@@ -6103,7 +6086,7 @@ paths:
     delete:
       operationId: DeleteUsersID
       tags:
-        - Users
+        - Security and access endpoints
       summary: Delete a user
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -6188,7 +6171,7 @@ paths:
     get:
       operationId: GetAuthorizations
       tags:
-        - Authorizations
+        - Security and access endpoints
       summary: List all authorizations
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -6230,7 +6213,7 @@ paths:
     post:
       operationId: PostAuthorizations
       tags:
-        - Authorizations
+        - Security and access endpoints
       summary: Create an authorization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -6258,7 +6241,7 @@ paths:
     get:
       operationId: GetAuthorizationsID
       tags:
-        - Authorizations
+        - Security and access endpoints
       summary: Retrieve an authorization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -6281,7 +6264,7 @@ paths:
     patch:
       operationId: PatchAuthorizationsID
       tags:
-        - Authorizations
+        - Security and access endpoints
       summary: Update authorization status
       description: Update an authorization's status to `active` or `inactive`.
       requestBody:
@@ -6312,7 +6295,7 @@ paths:
     delete:
       operationId: DeleteAuthorizationsID
       tags:
-        - Authorizations
+        - Security and access endpoints
       summary: Delete an authorization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -6889,7 +6872,6 @@ paths:
       operationId: GetTasks
       tags:
         - Data I/O endpoints
-        - Tasks
       summary: List all tasks
       description: |
         Retrieves a list of [tasks](https://docs.influxdata.com/influxdb/cloud/process-data/).
@@ -7019,7 +7001,6 @@ paths:
       operationId: PostTasks
       tags:
         - Data I/O endpoints
-        - Tasks
       summary: Create a task
       description: |
         Creates a [task](https://docs.influxdata.com/influxdb/cloud/process-data/) and returns the created task.
@@ -7133,7 +7114,6 @@ paths:
       operationId: GetTasksID
       tags:
         - Data I/O endpoints
-        - Tasks
       summary: Retrieve a task
       description: |
         Retrieves a [task](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#task)
@@ -7166,7 +7146,7 @@ paths:
     patch:
       operationId: PatchTasksID
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Update a task
       description: |
         Updates a task and then cancels all scheduled runs of the task.
@@ -7212,7 +7192,7 @@ paths:
     delete:
       operationId: DeleteTasksID
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Delete a task
       description: |
         Deletes a task and associated records.

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -69,7 +69,6 @@ paths:
       servers:
         - url: ''
       tags:
-        - Ping
         - System information endpoints
       responses:
         '204':
@@ -92,7 +91,7 @@ paths:
       servers:
         - url: ''
       tags:
-        - Ping
+        - System information endpoints
       responses:
         '204':
           description: |
@@ -112,7 +111,6 @@ paths:
       operationId: GetRoutes
       summary: List all top level routes
       tags:
-        - Routes
         - System information endpoints
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -910,7 +908,6 @@ paths:
       operationId: PostWrite
       tags:
         - Data I/O endpoints
-        - Write
       summary: Write data
       description: |
         Writes data to a bucket.
@@ -1227,7 +1224,6 @@ paths:
       operationId: PostDelete
       tags:
         - Data I/O endpoints
-        - Delete
       summary: Delete data
       description: |
         Deletes data from a bucket.
@@ -2171,7 +2167,7 @@ paths:
     post:
       operationId: PostQueryAst
       tags:
-        - Query
+        - Data I/O endpoints
       summary: Generate a query Abstract Syntax Tree (AST)
       description: |
         Analyzes a Flux query and returns a complete package source [Abstract Syntax
@@ -2594,7 +2590,7 @@ paths:
     get:
       operationId: GetQuerySuggestions
       tags:
-        - Query
+        - Data I/O endpoints
       summary: Retrieve query suggestions
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -2615,7 +2611,7 @@ paths:
     get:
       operationId: GetQuerySuggestionsName
       tags:
-        - Query
+        - Data I/O endpoints
       summary: Retrieve query suggestions for a branching suggestion
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -2642,7 +2638,7 @@ paths:
     post:
       operationId: PostQueryAnalyze
       tags:
-        - Query
+        - Data I/O endpoints
       summary: Analyze a Flux query
       description: |
         Analyzes a [Flux query](https://docs.influxdata.com/flux/v0.x/) for syntax
@@ -2793,7 +2789,6 @@ paths:
       operationId: PostQuery
       tags:
         - Data I/O endpoints
-        - Query
       summary: Query data
       description: |
         Retrieves data from buckets.
@@ -3395,7 +3390,6 @@ paths:
     get:
       operationId: GetOrgs
       tags:
-        - Organizations
         - Security and access endpoints
       summary: List all organizations
       parameters:
@@ -3434,7 +3428,7 @@ paths:
     post:
       operationId: PostOrgs
       tags:
-        - Organizations
+        - Security and access endpoints
       summary: Create an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3462,7 +3456,6 @@ paths:
     get:
       operationId: GetOrgsID
       tags:
-        - Organizations
         - Security and access endpoints
       summary: Retrieve an organization
       parameters:
@@ -3489,7 +3482,7 @@ paths:
     patch:
       operationId: PatchOrgsID
       tags:
-        - Organizations
+        - Security and access endpoints
       summary: Update an organization
       requestBody:
         description: Organization update to apply
@@ -3522,7 +3515,7 @@ paths:
     delete:
       operationId: DeleteOrgsID
       tags:
-        - Organizations
+        - Security and access endpoints
       summary: Delete an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3551,7 +3544,6 @@ paths:
     get:
       operationId: GetOrgsIDSecrets
       tags:
-        - Secrets
         - Security and access endpoints
       summary: List all secret keys for an organization
       parameters:
@@ -3578,7 +3570,7 @@ paths:
     patch:
       operationId: PatchOrgsIDSecrets
       tags:
-        - Secrets
+        - Security and access endpoints
       summary: Update secrets in an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3608,7 +3600,6 @@ paths:
     get:
       operationId: GetOrgsIDMembers
       tags:
-        - Organizations
         - Security and access endpoints
       summary: List all members of an organization
       parameters:
@@ -3641,7 +3632,7 @@ paths:
     post:
       operationId: PostOrgsIDMembers
       tags:
-        - Organizations
+        - Security and access endpoints
       summary: Add a member to an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3675,7 +3666,6 @@ paths:
     delete:
       operationId: DeleteOrgsIDMembersID
       tags:
-        - Organizations
         - Security and access endpoints
       summary: Remove a member from an organization
       parameters:
@@ -3705,7 +3695,6 @@ paths:
     get:
       operationId: GetOrgsIDOwners
       tags:
-        - Organizations
         - Security and access endpoints
       summary: List all owners of an organization
       parameters:
@@ -3738,7 +3727,7 @@ paths:
     post:
       operationId: PostOrgsIDOwners
       tags:
-        - Organizations
+        - Security and access endpoints
       summary: Add an owner to an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3772,7 +3761,6 @@ paths:
     delete:
       operationId: DeleteOrgsIDOwnersID
       tags:
-        - Organizations
         - Security and access endpoints
       summary: Remove an owner from an organization
       parameters:
@@ -3803,7 +3791,6 @@ paths:
       deprecated: true
       operationId: PostOrgsIDSecrets
       tags:
-        - Secrets
         - Security and access endpoints
       summary: Delete secrets from an organization
       parameters:
@@ -3834,7 +3821,6 @@ paths:
     delete:
       operationId: DeleteOrgsIDSecretsID
       tags:
-        - Secrets
         - Security and access endpoints
       summary: Delete a secret from an organization
       parameters:
@@ -3861,7 +3847,6 @@ paths:
     get:
       operationId: GetResources
       tags:
-        - Resources
         - System information endpoints
       summary: List all known resources
       parameters:
@@ -4188,7 +4173,7 @@ paths:
     get:
       operationId: GetTasksIDRuns
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: List runs for a task
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -4240,7 +4225,6 @@ paths:
       operationId: PostTasksIDRuns
       tags:
         - Data I/O endpoints
-        - Tasks
       summary: 'Manually start a task run, overriding the current schedule'
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -4271,7 +4255,7 @@ paths:
     get:
       operationId: GetTasksIDRunsID
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Retrieve a run for a task.
       description: |
         Retrieves a specific run for a [task](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#task).
@@ -4334,7 +4318,7 @@ paths:
     delete:
       operationId: DeleteTasksIDRunsID
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Cancel a running task
       description: |
         Cancels a running [task](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#task).
@@ -4395,7 +4379,7 @@ paths:
     post:
       operationId: PostTasksIDRunsIDRetry
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Retry a task run
       requestBody:
         content:
@@ -4433,7 +4417,7 @@ paths:
     get:
       operationId: GetTasksIDLogs
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Retrieve all logs for a task
       description: |
         Retrieves a list of all logs for a [task](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#task).
@@ -4499,7 +4483,7 @@ paths:
     get:
       operationId: GetTasksIDRunsIDLogs
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Retrieve all logs for a run
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -4532,7 +4516,7 @@ paths:
     get:
       operationId: GetTasksIDLabels
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: List labels for a task
       description: |
         Retrieves a list of all labels for a task.
@@ -4566,7 +4550,7 @@ paths:
     post:
       operationId: PostTasksIDLabels
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Add a label to a task
       description: |
         Adds a label to a task.
@@ -4608,7 +4592,7 @@ paths:
     delete:
       operationId: DeleteTasksIDLabelsID
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Delete a label from a task
       description: |
         Deletes a label from a task.
@@ -4720,7 +4704,7 @@ paths:
     get:
       operationId: GetTasksIDMembers
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: List all task members
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -4746,7 +4730,7 @@ paths:
     post:
       operationId: PostTasksIDMembers
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Add a member to a task
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -4780,7 +4764,7 @@ paths:
     delete:
       operationId: DeleteTasksIDMembersID
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Remove a member from a task
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -4809,7 +4793,7 @@ paths:
     get:
       operationId: GetTasksIDOwners
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: List all owners of a task
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -4835,7 +4819,7 @@ paths:
     post:
       operationId: PostTasksIDOwners
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Add an owner to a task
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -4869,7 +4853,7 @@ paths:
     delete:
       operationId: DeleteTasksIDOwnersID
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Remove an owner from a task
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -4899,7 +4883,6 @@ paths:
       operationId: PostUsersIDPassword
       tags:
         - Security and access endpoints
-        - Users
       summary: Update a password
       description: |
         #### InfluxDB Cloud

--- a/contracts/invocable-scripts.yml
+++ b/contracts/invocable-scripts.yml
@@ -21,7 +21,6 @@ paths:
       operationId: GetScripts
       tags:
         - Data I/O endpoints
-        - Invokable Scripts
       summary: List scripts
       description: |
         Retrieves a list of [scripts](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/).
@@ -121,7 +120,7 @@ paths:
     post:
       operationId: PostScripts
       tags:
-        - Invokable Scripts
+        - Data I/O endpoints
       summary: Create a script
       description: |
         Creates an [invokable script](https://docs.influxdata.com/resources/videos/api-invokable-scripts/)
@@ -220,7 +219,6 @@ paths:
       operationId: GetScriptsID
       tags:
         - Data I/O endpoints
-        - Invokable Scripts
       summary: Retrieve a script
       description: Uses script ID to retrieve details of an invokable script.
       parameters:
@@ -243,7 +241,7 @@ paths:
     patch:
       operationId: PatchScriptsID
       tags:
-        - Invokable Scripts
+        - Data I/O endpoints
       summary: Update a script
       description: |
         Updates properties (`name`, `description`, and `script`) of an invokable script.
@@ -274,7 +272,7 @@ paths:
     delete:
       operationId: DeleteScriptsID
       tags:
-        - Invokable Scripts
+        - Data I/O endpoints
       summary: Delete a script
       description: Deletes a script and all associated records.
       parameters:
@@ -295,7 +293,6 @@ paths:
       operationId: PostScriptsIDInvoke
       tags:
         - Data I/O endpoints
-        - Invokable Scripts
       summary: Invoke a script
       description: Invokes a script and substitutes `params` keys referenced in the script with `params` key-values sent in the request body.
       parameters:

--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -747,7 +747,6 @@ paths:
     get:
       operationId: GetHealth
       tags:
-        - Health
         - System information endpoints
       summary: Retrieve the health of the instance
       description: Returns the health of the instance.
@@ -798,7 +797,6 @@ paths:
     get:
       operationId: GetMetrics
       tags:
-        - Metrics
         - System information endpoints
       summary: Retrieve workload performance metrics
       description: |
@@ -853,7 +851,6 @@ paths:
     get:
       operationId: GetReady
       tags:
-        - Ready
         - System information endpoints
       summary: Get the readiness of an instance at startup
       servers:
@@ -897,7 +894,6 @@ paths:
       operationId: GetUsers
       tags:
         - Security and access endpoints
-        - Users
       summary: List all users
       parameters:
         - $ref: '#/paths/~1ready/get/parameters/0'
@@ -943,7 +939,7 @@ paths:
     post:
       operationId: PostUsers
       tags:
-        - Users
+        - Security and access endpoints
       summary: Create a user
       parameters:
         - $ref: '#/paths/~1ready/get/parameters/0'
@@ -969,7 +965,6 @@ paths:
       operationId: GetUsersID
       tags:
         - Security and access endpoints
-        - Users
       summary: Retrieve a user
       parameters:
         - $ref: '#/paths/~1ready/get/parameters/0'
@@ -992,7 +987,7 @@ paths:
     patch:
       operationId: PatchUsersID
       tags:
-        - Users
+        - Security and access endpoints
       summary: Update a user
       requestBody:
         description: User update to apply
@@ -1022,7 +1017,7 @@ paths:
     delete:
       operationId: DeleteUsersID
       tags:
-        - Users
+        - Security and access endpoints
       summary: Delete a user
       parameters:
         - $ref: '#/paths/~1ready/get/parameters/0'
@@ -1087,7 +1082,6 @@ paths:
     get:
       operationId: GetAuthorizations
       tags:
-        - Authorizations
         - Security and access endpoints
       summary: List all authorizations
       parameters:
@@ -1125,7 +1119,7 @@ paths:
     post:
       operationId: PostAuthorizations
       tags:
-        - Authorizations
+        - Security and access endpoints
       summary: Create an authorization
       parameters:
         - $ref: '#/paths/~1ready/get/parameters/0'
@@ -1153,7 +1147,6 @@ paths:
     get:
       operationId: GetAuthorizationsID
       tags:
-        - Authorizations
         - Security and access endpoints
       summary: Retrieve an authorization
       parameters:
@@ -1177,7 +1170,7 @@ paths:
     patch:
       operationId: PatchAuthorizationsID
       tags:
-        - Authorizations
+        - Security and access endpoints
       summary: Update an authorization to be active or inactive
       requestBody:
         description: Authorization to update
@@ -1207,7 +1200,7 @@ paths:
     delete:
       operationId: DeleteAuthorizationsID
       tags:
-        - Authorizations
+        - Security and access endpoints
       summary: Delete an authorization
       parameters:
         - $ref: '#/paths/~1ready/get/parameters/0'
@@ -1411,7 +1404,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
     get:
       operationId: GetSources
       tags:
@@ -1436,7 +1429,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   '/sources/{sourceID}':
     delete:
       operationId: DeleteSourcesID
@@ -1459,13 +1452,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
         default:
           description: Unexpected error
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
     patch:
       operationId: PatchSourcesID
       tags:
@@ -1498,13 +1491,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
         default:
           description: Unexpected error
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
     get:
       operationId: GetSourcesID
       tags:
@@ -1530,13 +1523,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
         default:
           description: Unexpected error
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   '/sources/{sourceID}/health':
     get:
       operationId: GetSourcesIDHealth
@@ -1569,7 +1562,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   '/sources/{sourceID}/buckets':
     get:
       operationId: GetSourcesIDBuckets
@@ -1610,13 +1603,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
         default:
           description: Unexpected error
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   /scrapers:
     get:
       operationId: GetScrapers
@@ -1680,7 +1673,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   '/scrapers/{scraperTargetID}':
     get:
       operationId: GetScrapersID
@@ -1707,7 +1700,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
     delete:
       operationId: DeleteScrapersID
       tags:
@@ -1729,7 +1722,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
     patch:
       operationId: PatchScrapersID
       summary: Update a scraper target
@@ -1762,7 +1755,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   '/scrapers/{scraperTargetID}/labels':
     get:
       operationId: GetScrapersIDLabels
@@ -1794,7 +1787,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
     post:
       operationId: PostScrapersIDLabels
       tags:
@@ -1854,7 +1847,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   '/scrapers/{scraperTargetID}/labels/{labelID}':
     delete:
       operationId: DeleteScrapersIDLabelsID
@@ -1883,13 +1876,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
         default:
           description: Unexpected error
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   '/scrapers/{scraperTargetID}/members':
     get:
       operationId: GetScrapersIDMembers
@@ -1927,7 +1920,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
     post:
       operationId: PostScrapersIDMembers
       tags:
@@ -1968,7 +1961,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   '/scrapers/{scraperTargetID}/members/{userID}':
     delete:
       operationId: DeleteScrapersIDMembersID
@@ -1997,7 +1990,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   '/scrapers/{scraperTargetID}/owners':
     get:
       operationId: GetScrapersIDOwners
@@ -2035,7 +2028,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
     post:
       operationId: PostScrapersIDOwners
       tags:
@@ -2083,7 +2076,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   '/scrapers/{scraperTargetID}/owners/{userID}':
     delete:
       operationId: DeleteScrapersIDOwnersID
@@ -2112,7 +2105,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   /backup/kv:
     get:
       operationId: GetBackupKV
@@ -2227,7 +2220,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
         default:
           description: Unexpected error
           $ref: '#/paths/~1config/get/responses/401'
@@ -2440,7 +2433,6 @@ paths:
     get:
       operationId: GetConfig
       tags:
-        - Config
         - System information endpoints
       summary: Retrieve runtime configuration
       description: |
@@ -2468,7 +2460,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
         default:
           $ref: '#/paths/~1config/get/responses/401'
   /remotes:
@@ -4479,7 +4471,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
     get:
       operationId: GetDashboards
       tags:
@@ -4554,13 +4546,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   /tasks:
     get:
       operationId: GetTasks
       tags:
         - Data I/O endpoints
-        - Tasks
       summary: List tasks
       description: |
         Retrieves a list of [tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/).
@@ -4718,7 +4709,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
               examples:
                 tokenNotAuthorized:
                   summary: Token is not authorized to access a resource
@@ -4732,14 +4723,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
         default:
           $ref: '#/paths/~1config/get/responses/401'
     post:
       operationId: PostTasks
       tags:
         - Data I/O endpoints
-        - Tasks
       summary: Create a task
       description: |
         Creates a [task]({{% INFLUXDB_DOCS_URL %}}/process-data/) and returns the created task.
@@ -4767,22 +4757,6 @@ paths:
                 $ref: '#/components/schemas/Task'
         '400':
           description: Bad request
-          content:
-            application/json:
-              schema:
-                $ref: '#/paths/~1tasks~1%7BtaskID%7D/get/responses/400'
-              examples:
-                missingFluxError:
-                  summary: Task in request body is missing Flux query
-                  value:
-                    code: invalid
-                    message: 'failed to decode request: missing flux'
-        '401':
-          $ref: '#/paths/~1tasks/get/responses/401'
-        '500':
-          $ref: '#/paths/~1tasks/get/responses/500'
-        default:
-          description: Unexpected error
           content:
             application/json:
               schema:
@@ -4819,6 +4793,22 @@ paths:
                     type: string
                 required:
                   - code
+              examples:
+                missingFluxError:
+                  summary: Task in request body is missing Flux query
+                  value:
+                    code: invalid
+                    message: 'failed to decode request: missing flux'
+        '401':
+          $ref: '#/paths/~1tasks/get/responses/401'
+        '500':
+          $ref: '#/paths/~1tasks/get/responses/500'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
       x-codeSamples:
         - lang: Shell
           label: 'cURL: create a task'
@@ -4843,7 +4833,6 @@ paths:
       operationId: GetTasksID
       tags:
         - Data I/O endpoints
-        - Tasks
       summary: Retrieve a task
       description: |
         Retrieves a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task)
@@ -4874,7 +4863,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
               examples:
                 orgProvidedNotFound:
                   summary: The org or orgID passed doesn't own the token passed in the header
@@ -4896,7 +4885,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
               examples:
                 org-not-found:
                   summary: Organization name not found
@@ -4920,7 +4909,7 @@ paths:
     patch:
       operationId: PatchTasksID
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Update a task
       description: |
         Updates a task and then cancels all scheduled runs of the task.
@@ -4966,7 +4955,7 @@ paths:
     delete:
       operationId: DeleteTasksID
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Delete a task
       description: |
         Deletes a task and associated records.

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -191,7 +191,6 @@
           }
         ],
         "tags": [
-          "Ping",
           "System information endpoints"
         ],
         "responses": {
@@ -224,7 +223,7 @@
           }
         ],
         "tags": [
-          "Ping"
+          "System information endpoints"
         ],
         "responses": {
           "204": {
@@ -252,7 +251,6 @@
         "operationId": "GetRoutes",
         "summary": "List all top level routes",
         "tags": [
-          "Routes",
           "System information endpoints"
         ],
         "parameters": [
@@ -1556,8 +1554,7 @@
       "post": {
         "operationId": "PostWrite",
         "tags": [
-          "Data I/O endpoints",
-          "Write"
+          "Data I/O endpoints"
         ],
         "summary": "Write data",
         "description": "Writes data to a bucket.\n\nUse this endpoint to send data in [line protocol]({{% INFLUXDB_DOCS_URL %}}/reference/syntax/line-protocol/) format to InfluxDB.\n\n#### InfluxDB Cloud\n\n- Takes the following steps when you send a write request:\n\n  1. Validates the request and queues the write.\n  2. If the write is queued, responds with an HTTP `204` status code.\n  3. Handles the write asynchronously and reaches eventual consistency.\n\n  An HTTP `2xx` status code acknowledges that the write or delete is queued.\n  To ensure that InfluxDB Cloud handles writes and deletes in the order you request them,\n  wait for a response before you send the next request.\n\n  Because writes are asynchronous, data might not yet be written\n  when you receive the response.\n\n#### InfluxDB OSS\n\n- Validates the request, handles the write synchronously,\n  and then responds with success or failure.\n- If all points were written successfully, returns `204`,\n  otherwise returns the first line that failed.\n\n#### Required permissions\n\n- `write-buckets` or `write-bucket BUCKET_ID`.\n\n  `BUCKET_ID` is the ID of the destination bucket.\n\n#### Rate limits (with InfluxDB Cloud)\n\n`write` rate limits apply.\nFor more information, see [limits and adjustable quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/).\n\n#### Related guides\n\n- [Write data with the InfluxDB API]({{% INFLUXDB_DOCS_URL %}}/write-data/developer-tools/api).\n- [Optimize writes to InfluxDB]({{% INFLUXDB_DOCS_URL %}}/write-data/best-practices/optimize-writes/).\n- [Troubleshoot issues writing data]({{% INFLUXDB_DOCS_URL %}}/write-data/troubleshoot/)\n",
@@ -1769,8 +1766,7 @@
       "post": {
         "operationId": "PostDelete",
         "tags": [
-          "Data I/O endpoints",
-          "Delete"
+          "Data I/O endpoints"
         ],
         "summary": "Delete data",
         "description": "Deletes data from a bucket.\n\nUse this endpoint to delete points from a bucket in a specified time range.\n\n#### InfluxDB Cloud\n\n- Does the following when you send a delete request:\n\n  1. Validates the request and queues the delete.\n  2. Returns _success_ if queued; _error_ otherwise.\n  3. Handles the delete asynchronously.\n\n#### InfluxDB OSS\n\n- Validates the request, handles the delete synchronously,\n  and then responds with success or failure.\n\n#### Required permissions\n\n- `write-buckets` or `write-bucket BUCKET_ID`.\n\n  `BUCKET_ID` is the ID of the destination bucket.\n\n#### Rate limits (with InfluxDB Cloud)\n\n`write` rate limits apply.\nFor more information, see [limits and adjustable quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/).\n\n#### Related guides\n\n- [Delete data]({{% INFLUXDB_DOCS_URL %}}/write-data/delete-data/).\n- Learn how to use [delete predicate syntax]({{% INFLUXDB_DOCS_URL %}}/reference/syntax/delete-predicate/).\n- Learn how InfluxDB handles [deleted tags](https://docs.influxdata.com/flux/v0.x/stdlib/influxdata/influxdb/schema/measurementtagkeys/)\n  and [deleted fields](https://docs.influxdata.com/flux/v0.x/stdlib/influxdata/influxdb/schema/measurementfieldkeys/).\n",
@@ -3137,7 +3133,7 @@
       "post": {
         "operationId": "PostQueryAst",
         "tags": [
-          "Query"
+          "Data I/O endpoints"
         ],
         "summary": "Generate a query Abstract Syntax Tree (AST)",
         "description": "Analyzes a Flux query and returns a complete package source [Abstract Syntax\nTree (AST)](https://https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#abstract-syntax-tree)\nfor the query.\n\nUse this endpoint for deep query analysis such as debugging unexpected query\nresults.\n\nA Flux query AST provides a semantic, tree-like representation with contextual\ninformation about the query. The AST illustrates how the query is distributed\ninto different components for execution.\n\n\n#### Limitations\n\n-  The endpoint doesn't validate values in the query--for example:\n\n    The following query has correct syntax, but contains an incorrect `from()` property key:\n    ```json\n    { \"query\": \"from(foo: \\\"iot_center\\\")\\\n                |> range(start: -90d)\\\n                |> filter(fn: (r) => r._measurement == \\\"environment\\\")\"\n    }\n    ```\n    Passing this to `/api/v2/query/ast` will return a successful response\n    with a generated AST.\n",
@@ -3701,7 +3697,7 @@
       "get": {
         "operationId": "GetQuerySuggestions",
         "tags": [
-          "Query"
+          "Data I/O endpoints"
         ],
         "summary": "Retrieve query suggestions",
         "parameters": [
@@ -3737,7 +3733,7 @@
       "get": {
         "operationId": "GetQuerySuggestionsName",
         "tags": [
-          "Query"
+          "Data I/O endpoints"
         ],
         "summary": "Retrieve query suggestions for a branching suggestion",
         "parameters": [
@@ -3782,7 +3778,7 @@
       "post": {
         "operationId": "PostQueryAnalyze",
         "tags": [
-          "Query"
+          "Data I/O endpoints"
         ],
         "summary": "Analyze a Flux query",
         "description": "Analyzes a [Flux query](https://docs.influxdata.com/flux/v0.x/) for syntax\nerrors and returns the list of errors.\n\nIn the following example `Query` object, `query` is missing a `from()` property key:\n\n    ```json\n    { \"query\": \"from(: \\\"iot_center\\\")\\\n                |> range(start: -90d)\\\n                |> filter(fn: (r) => r._measurement == \\\"environment\\\")\",\n      \"type\": \"flux\"\n    }\n    ```\n\nPassing this to `/api/v2/analyze` returns an `errors` list that contains an error object for the missing key.\n\n#### Limitations\n\n-  The endpoint doesn't validate values in the query--for example:\n\n  - The following query has correct syntax, but contains an incorrect `from()` property key:\n\n    ```json\n    { \"query\": \"from(foo: \\\"iot_center\\\")\\\n                |> range(start: -90d)\\\n                |> filter(fn: (r) => r._measurement == \\\"environment\\\")\",\n      \"type\": \"flux\"\n    }\n    ```\n\n    Passing this to `/api/v2/analyze` returns an empty `errors` list.\n",
@@ -3922,8 +3918,7 @@
       "post": {
         "operationId": "PostQuery",
         "tags": [
-          "Data I/O endpoints",
-          "Query"
+          "Data I/O endpoints"
         ],
         "summary": "Query data",
         "description": "Retrieves data from buckets.\n\nUse this endpoint to send a Flux query request and retrieve data from a bucket.\n\n#### Rate limits (with InfluxDB Cloud)\n\n`read` rate limits apply.\nFor more information, see [limits and adjustable quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/).\n\n#### Related guides\n\n- [Query with the InfluxDB API]({{% INFLUXDB_DOCS_URL %}}/query-data/execute-queries/influx-api/).\n- [Get started with Flux](https://docs.influxdata.com/flux/v0.x/get-started/)\n",
@@ -4804,7 +4799,6 @@
       "get": {
         "operationId": "GetOrgs",
         "tags": [
-          "Organizations",
           "Security and access endpoints"
         ],
         "summary": "List all organizations",
@@ -4872,7 +4866,7 @@
       "post": {
         "operationId": "PostOrgs",
         "tags": [
-          "Organizations"
+          "Security and access endpoints"
         ],
         "summary": "Create an organization",
         "parameters": [
@@ -4919,7 +4913,6 @@
       "get": {
         "operationId": "GetOrgsID",
         "tags": [
-          "Organizations",
           "Security and access endpoints"
         ],
         "summary": "Retrieve an organization",
@@ -4963,7 +4956,7 @@
       "patch": {
         "operationId": "PatchOrgsID",
         "tags": [
-          "Organizations"
+          "Security and access endpoints"
         ],
         "summary": "Update an organization",
         "requestBody": {
@@ -5017,7 +5010,7 @@
       "delete": {
         "operationId": "DeleteOrgsID",
         "tags": [
-          "Organizations"
+          "Security and access endpoints"
         ],
         "summary": "Delete an organization",
         "parameters": [
@@ -5065,7 +5058,6 @@
       "get": {
         "operationId": "GetOrgsIDSecrets",
         "tags": [
-          "Secrets",
           "Security and access endpoints"
         ],
         "summary": "List all secret keys for an organization",
@@ -5109,7 +5101,7 @@
       "patch": {
         "operationId": "PatchOrgsIDSecrets",
         "tags": [
-          "Secrets"
+          "Security and access endpoints"
         ],
         "summary": "Update secrets in an organization",
         "parameters": [
@@ -5158,7 +5150,6 @@
       "get": {
         "operationId": "GetOrgsIDMembers",
         "tags": [
-          "Organizations",
           "Security and access endpoints"
         ],
         "summary": "List all members of an organization",
@@ -5212,7 +5203,7 @@
       "post": {
         "operationId": "PostOrgsIDMembers",
         "tags": [
-          "Organizations"
+          "Security and access endpoints"
         ],
         "summary": "Add a member to an organization",
         "parameters": [
@@ -5268,7 +5259,6 @@
       "delete": {
         "operationId": "DeleteOrgsIDMembersID",
         "tags": [
-          "Organizations",
           "Security and access endpoints"
         ],
         "summary": "Remove a member from an organization",
@@ -5316,7 +5306,6 @@
       "get": {
         "operationId": "GetOrgsIDOwners",
         "tags": [
-          "Organizations",
           "Security and access endpoints"
         ],
         "summary": "List all owners of an organization",
@@ -5370,7 +5359,7 @@
       "post": {
         "operationId": "PostOrgsIDOwners",
         "tags": [
-          "Organizations"
+          "Security and access endpoints"
         ],
         "summary": "Add an owner to an organization",
         "parameters": [
@@ -5426,7 +5415,6 @@
       "delete": {
         "operationId": "DeleteOrgsIDOwnersID",
         "tags": [
-          "Organizations",
           "Security and access endpoints"
         ],
         "summary": "Remove an owner from an organization",
@@ -5475,7 +5463,6 @@
         "deprecated": true,
         "operationId": "PostOrgsIDSecrets",
         "tags": [
-          "Secrets",
           "Security and access endpoints"
         ],
         "summary": "Delete secrets from an organization",
@@ -5525,7 +5512,6 @@
       "delete": {
         "operationId": "DeleteOrgsIDSecretsID",
         "tags": [
-          "Secrets",
           "Security and access endpoints"
         ],
         "summary": "Delete a secret from an organization",
@@ -5567,7 +5553,6 @@
       "get": {
         "operationId": "GetResources",
         "tags": [
-          "Resources",
           "System information endpoints"
         ],
         "summary": "List all known resources",
@@ -6092,7 +6077,7 @@
       "get": {
         "operationId": "GetTasksIDRuns",
         "tags": [
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "List runs for a task",
         "parameters": [
@@ -6172,8 +6157,7 @@
       "post": {
         "operationId": "PostTasksIDRuns",
         "tags": [
-          "Data I/O endpoints",
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "Manually start a task run, overriding the current schedule",
         "parameters": [
@@ -6226,7 +6210,7 @@
       "get": {
         "operationId": "GetTasksIDRunsID",
         "tags": [
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "Retrieve a run for a task.",
         "description": "Retrieves a specific run for a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task).\n\nUse this endpoint to retrieve detail and logs for a specific task run.\n",
@@ -6316,7 +6300,7 @@
       "delete": {
         "operationId": "DeleteTasksIDRunsID",
         "tags": [
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "Cancel a running task",
         "description": "Cancels a running [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task).\n\nUse this endpoint with InfluxDB OSS to cancel a running task.\n\n#### InfluxDB Cloud\n\n  - Doesn't support this operation.\n",
@@ -6379,7 +6363,7 @@
       "post": {
         "operationId": "PostTasksIDRunsIDRetry",
         "tags": [
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "Retry a task run",
         "requestBody": {
@@ -6442,7 +6426,7 @@
       "get": {
         "operationId": "GetTasksIDLogs",
         "tags": [
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "Retrieve all logs for a task",
         "description": "Retrieves a list of all logs for a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task).\n\nWhen an InfluxDB task runs, a “run” record is created in the task’s history.\nLogs associated with each run provide relevant log messages, timestamps, and the exit status of the run attempt.\n\nUse this endpoint to retrieve only the log events for a task,\nwithout additional task metadata.\n",
@@ -6534,7 +6518,7 @@
       "get": {
         "operationId": "GetTasksIDRunsIDLogs",
         "tags": [
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "Retrieve all logs for a run",
         "parameters": [
@@ -6588,7 +6572,7 @@
       "get": {
         "operationId": "GetTasksIDLabels",
         "tags": [
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "List labels for a task",
         "description": "Retrieves a list of all labels for a task.\n\nLabels may be used for grouping and filtering tasks.\n",
@@ -6637,7 +6621,7 @@
       "post": {
         "operationId": "PostTasksIDLabels",
         "tags": [
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "Add a label to a task",
         "description": "Adds a label to a task.\n\nUse this endpoint to add a label that you can use to filter tasks in the InfluxDB UI.\n",
@@ -6699,7 +6683,7 @@
       "delete": {
         "operationId": "DeleteTasksIDLabelsID",
         "tags": [
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "Delete a label from a task",
         "description": "Deletes a label from a task.\n",
@@ -6872,7 +6856,7 @@
       "get": {
         "operationId": "GetTasksIDMembers",
         "tags": [
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "List all task members",
         "parameters": [
@@ -6915,7 +6899,7 @@
       "post": {
         "operationId": "PostTasksIDMembers",
         "tags": [
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "Add a member to a task",
         "parameters": [
@@ -6971,7 +6955,7 @@
       "delete": {
         "operationId": "DeleteTasksIDMembersID",
         "tags": [
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "Remove a member from a task",
         "parameters": [
@@ -7018,7 +7002,7 @@
       "get": {
         "operationId": "GetTasksIDOwners",
         "tags": [
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "List all owners of a task",
         "parameters": [
@@ -7061,7 +7045,7 @@
       "post": {
         "operationId": "PostTasksIDOwners",
         "tags": [
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "Add an owner to a task",
         "parameters": [
@@ -7117,7 +7101,7 @@
       "delete": {
         "operationId": "DeleteTasksIDOwnersID",
         "tags": [
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "Remove an owner from a task",
         "parameters": [
@@ -7164,8 +7148,7 @@
       "post": {
         "operationId": "PostUsersIDPassword",
         "tags": [
-          "Security and access endpoints",
-          "Users"
+          "Security and access endpoints"
         ],
         "summary": "Update a password",
         "description": "#### InfluxDB Cloud\n\nInfluxDB Cloud does not support changing user passwords through the API.\nUse the InfluxDB Cloud user interface to update your password.\n",
@@ -9515,7 +9498,6 @@
       "get": {
         "operationId": "GetHealth",
         "tags": [
-          "Health",
           "System information endpoints"
         ],
         "summary": "Retrieve the health of the instance",
@@ -9562,7 +9544,6 @@
       "get": {
         "operationId": "GetMetrics",
         "tags": [
-          "Metrics",
           "System information endpoints"
         ],
         "summary": "Retrieve workload performance metrics",
@@ -9610,7 +9591,6 @@
       "get": {
         "operationId": "GetReady",
         "tags": [
-          "Ready",
           "System information endpoints"
         ],
         "summary": "Get the readiness of an instance at startup",
@@ -9646,8 +9626,7 @@
       "get": {
         "operationId": "GetUsers",
         "tags": [
-          "Security and access endpoints",
-          "Users"
+          "Security and access endpoints"
         ],
         "summary": "List all users",
         "parameters": [
@@ -9698,7 +9677,7 @@
       "post": {
         "operationId": "PostUsers",
         "tags": [
-          "Users"
+          "Security and access endpoints"
         ],
         "summary": "Create a user",
         "parameters": [
@@ -9739,8 +9718,7 @@
       "get": {
         "operationId": "GetUsersID",
         "tags": [
-          "Security and access endpoints",
-          "Users"
+          "Security and access endpoints"
         ],
         "summary": "Retrieve a user",
         "parameters": [
@@ -9777,7 +9755,7 @@
       "patch": {
         "operationId": "PatchUsersID",
         "tags": [
-          "Users"
+          "Security and access endpoints"
         ],
         "summary": "Update a user",
         "requestBody": {
@@ -9825,7 +9803,7 @@
       "delete": {
         "operationId": "DeleteUsersID",
         "tags": [
-          "Users"
+          "Security and access endpoints"
         ],
         "summary": "Delete a user",
         "parameters": [
@@ -9924,7 +9902,6 @@
       "get": {
         "operationId": "GetAuthorizations",
         "tags": [
-          "Authorizations",
           "Security and access endpoints"
         ],
         "summary": "List all authorizations",
@@ -9985,7 +9962,7 @@
       "post": {
         "operationId": "PostAuthorizations",
         "tags": [
-          "Authorizations"
+          "Security and access endpoints"
         ],
         "summary": "Create an authorization",
         "parameters": [
@@ -10030,7 +10007,6 @@
       "get": {
         "operationId": "GetAuthorizationsID",
         "tags": [
-          "Authorizations",
           "Security and access endpoints"
         ],
         "summary": "Retrieve an authorization",
@@ -10068,7 +10044,7 @@
       "patch": {
         "operationId": "PatchAuthorizationsID",
         "tags": [
-          "Authorizations"
+          "Security and access endpoints"
         ],
         "summary": "Update an authorization to be active or inactive",
         "requestBody": {
@@ -10116,7 +10092,7 @@
       "delete": {
         "operationId": "DeleteAuthorizationsID",
         "tags": [
-          "Authorizations"
+          "Security and access endpoints"
         ],
         "summary": "Delete an authorization",
         "parameters": [
@@ -11956,7 +11932,6 @@
       "get": {
         "operationId": "GetConfig",
         "tags": [
-          "Config",
           "System information endpoints"
         ],
         "summary": "Retrieve runtime configuration",
@@ -12630,8 +12605,7 @@
       "get": {
         "operationId": "GetTasks",
         "tags": [
-          "Data I/O endpoints",
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "List tasks",
         "description": "Retrieves a list of [tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/).\n\nTo limit which tasks are returned, pass query parameters in your request.\nIf no query parameters are passed, InfluxDB returns all tasks up to the default `limit`.\n",
@@ -12811,8 +12785,7 @@
       "post": {
         "operationId": "PostTasks",
         "tags": [
-          "Data I/O endpoints",
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "Create a task",
         "description": "Creates a [task]({{% INFLUXDB_DOCS_URL %}}/process-data/) and returns the created task.\n\n#### Related guides\n\n- [Create a task]({{% INFLUXDB_DOCS_URL %}}/process-data/manage-tasks/create-task/).\n- [Common tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/common-tasks/)\n- [Task configuration options]({{% INFLUXDB_DOCS_URL %}}/process-data/task-options/)\n",
@@ -12848,7 +12821,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/responses/BadRequestError"
+                  "$ref": "#/components/schemas/Error"
                 },
                 "examples": {
                   "missingFluxError": {
@@ -12892,8 +12865,7 @@
       "get": {
         "operationId": "GetTasksID",
         "tags": [
-          "Data I/O endpoints",
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "Retrieve a task",
         "description": "Retrieves a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task)\nby task ID.\n",
@@ -12942,7 +12914,7 @@
       "patch": {
         "operationId": "PatchTasksID",
         "tags": [
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "Update a task",
         "description": "Updates a task and then cancels all scheduled runs of the task.\n\nUse this endpoint to modify task properties (for example: `cron`, `name`, `flux`, `status`).\nOnce InfluxDB applies the update, it cancels all scheduled runs of the task.\n\nTo update a task, pass an object that contains the updated key-value pairs.\nTo activate or inactivate a task, set the `status` property.\n_`\"status\": \"inactive\"`_ cancels scheduled runs and prevents manual runs of the task.\n",
@@ -13002,7 +12974,7 @@
       "delete": {
         "operationId": "DeleteTasksID",
         "tags": [
-          "Tasks"
+          "Data I/O endpoints"
         ],
         "summary": "Delete a task",
         "description": "Deletes a task and associated records.\n\nUse this endpoint to delete a task and all associated records (task runs, logs, and labels).\nOnce the task is deleted, InfluxDB cancels all scheduled runs of the task.\n\nIf you want to disable a task instead of delete it, [update the task status to `inactive`](#operation/PatchTasksID).\n",

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -200,7 +200,6 @@ paths:
       servers:
         - url: ''
       tags:
-        - Ping
         - System information endpoints
       responses:
         '204':
@@ -223,7 +222,7 @@ paths:
       servers:
         - url: ''
       tags:
-        - Ping
+        - System information endpoints
       responses:
         '204':
           description: |
@@ -243,7 +242,6 @@ paths:
       operationId: GetRoutes
       summary: List all top level routes
       tags:
-        - Routes
         - System information endpoints
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -1041,7 +1039,6 @@ paths:
       operationId: PostWrite
       tags:
         - Data I/O endpoints
-        - Write
       summary: Write data
       description: |
         Writes data to a bucket.
@@ -1358,7 +1355,6 @@ paths:
       operationId: PostDelete
       tags:
         - Data I/O endpoints
-        - Delete
       summary: Delete data
       description: |
         Deletes data from a bucket.
@@ -2302,7 +2298,7 @@ paths:
     post:
       operationId: PostQueryAst
       tags:
-        - Query
+        - Data I/O endpoints
       summary: Generate a query Abstract Syntax Tree (AST)
       description: |
         Analyzes a Flux query and returns a complete package source [Abstract Syntax
@@ -2725,7 +2721,7 @@ paths:
     get:
       operationId: GetQuerySuggestions
       tags:
-        - Query
+        - Data I/O endpoints
       summary: Retrieve query suggestions
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -2746,7 +2742,7 @@ paths:
     get:
       operationId: GetQuerySuggestionsName
       tags:
-        - Query
+        - Data I/O endpoints
       summary: Retrieve query suggestions for a branching suggestion
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -2773,7 +2769,7 @@ paths:
     post:
       operationId: PostQueryAnalyze
       tags:
-        - Query
+        - Data I/O endpoints
       summary: Analyze a Flux query
       description: |
         Analyzes a [Flux query](https://docs.influxdata.com/flux/v0.x/) for syntax
@@ -2924,7 +2920,6 @@ paths:
       operationId: PostQuery
       tags:
         - Data I/O endpoints
-        - Query
       summary: Query data
       description: |
         Retrieves data from buckets.
@@ -3526,7 +3521,6 @@ paths:
     get:
       operationId: GetOrgs
       tags:
-        - Organizations
         - Security and access endpoints
       summary: List all organizations
       parameters:
@@ -3565,7 +3559,7 @@ paths:
     post:
       operationId: PostOrgs
       tags:
-        - Organizations
+        - Security and access endpoints
       summary: Create an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3593,7 +3587,6 @@ paths:
     get:
       operationId: GetOrgsID
       tags:
-        - Organizations
         - Security and access endpoints
       summary: Retrieve an organization
       parameters:
@@ -3620,7 +3613,7 @@ paths:
     patch:
       operationId: PatchOrgsID
       tags:
-        - Organizations
+        - Security and access endpoints
       summary: Update an organization
       requestBody:
         description: Organization update to apply
@@ -3653,7 +3646,7 @@ paths:
     delete:
       operationId: DeleteOrgsID
       tags:
-        - Organizations
+        - Security and access endpoints
       summary: Delete an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3682,7 +3675,6 @@ paths:
     get:
       operationId: GetOrgsIDSecrets
       tags:
-        - Secrets
         - Security and access endpoints
       summary: List all secret keys for an organization
       parameters:
@@ -3709,7 +3701,7 @@ paths:
     patch:
       operationId: PatchOrgsIDSecrets
       tags:
-        - Secrets
+        - Security and access endpoints
       summary: Update secrets in an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3739,7 +3731,6 @@ paths:
     get:
       operationId: GetOrgsIDMembers
       tags:
-        - Organizations
         - Security and access endpoints
       summary: List all members of an organization
       parameters:
@@ -3772,7 +3763,7 @@ paths:
     post:
       operationId: PostOrgsIDMembers
       tags:
-        - Organizations
+        - Security and access endpoints
       summary: Add a member to an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3806,7 +3797,6 @@ paths:
     delete:
       operationId: DeleteOrgsIDMembersID
       tags:
-        - Organizations
         - Security and access endpoints
       summary: Remove a member from an organization
       parameters:
@@ -3836,7 +3826,6 @@ paths:
     get:
       operationId: GetOrgsIDOwners
       tags:
-        - Organizations
         - Security and access endpoints
       summary: List all owners of an organization
       parameters:
@@ -3869,7 +3858,7 @@ paths:
     post:
       operationId: PostOrgsIDOwners
       tags:
-        - Organizations
+        - Security and access endpoints
       summary: Add an owner to an organization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -3903,7 +3892,6 @@ paths:
     delete:
       operationId: DeleteOrgsIDOwnersID
       tags:
-        - Organizations
         - Security and access endpoints
       summary: Remove an owner from an organization
       parameters:
@@ -3934,7 +3922,6 @@ paths:
       deprecated: true
       operationId: PostOrgsIDSecrets
       tags:
-        - Secrets
         - Security and access endpoints
       summary: Delete secrets from an organization
       parameters:
@@ -3965,7 +3952,6 @@ paths:
     delete:
       operationId: DeleteOrgsIDSecretsID
       tags:
-        - Secrets
         - Security and access endpoints
       summary: Delete a secret from an organization
       parameters:
@@ -3992,7 +3978,6 @@ paths:
     get:
       operationId: GetResources
       tags:
-        - Resources
         - System information endpoints
       summary: List all known resources
       parameters:
@@ -4319,7 +4304,7 @@ paths:
     get:
       operationId: GetTasksIDRuns
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: List runs for a task
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -4371,7 +4356,6 @@ paths:
       operationId: PostTasksIDRuns
       tags:
         - Data I/O endpoints
-        - Tasks
       summary: 'Manually start a task run, overriding the current schedule'
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -4402,7 +4386,7 @@ paths:
     get:
       operationId: GetTasksIDRunsID
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Retrieve a run for a task.
       description: |
         Retrieves a specific run for a [task](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#task).
@@ -4465,7 +4449,7 @@ paths:
     delete:
       operationId: DeleteTasksIDRunsID
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Cancel a running task
       description: |
         Cancels a running [task](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#task).
@@ -4526,7 +4510,7 @@ paths:
     post:
       operationId: PostTasksIDRunsIDRetry
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Retry a task run
       requestBody:
         content:
@@ -4564,7 +4548,7 @@ paths:
     get:
       operationId: GetTasksIDLogs
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Retrieve all logs for a task
       description: |
         Retrieves a list of all logs for a [task](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#task).
@@ -4630,7 +4614,7 @@ paths:
     get:
       operationId: GetTasksIDRunsIDLogs
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Retrieve all logs for a run
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -4663,7 +4647,7 @@ paths:
     get:
       operationId: GetTasksIDLabels
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: List labels for a task
       description: |
         Retrieves a list of all labels for a task.
@@ -4697,7 +4681,7 @@ paths:
     post:
       operationId: PostTasksIDLabels
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Add a label to a task
       description: |
         Adds a label to a task.
@@ -4739,7 +4723,7 @@ paths:
     delete:
       operationId: DeleteTasksIDLabelsID
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Delete a label from a task
       description: |
         Deletes a label from a task.
@@ -4851,7 +4835,7 @@ paths:
     get:
       operationId: GetTasksIDMembers
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: List all task members
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -4877,7 +4861,7 @@ paths:
     post:
       operationId: PostTasksIDMembers
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Add a member to a task
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -4911,7 +4895,7 @@ paths:
     delete:
       operationId: DeleteTasksIDMembersID
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Remove a member from a task
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -4940,7 +4924,7 @@ paths:
     get:
       operationId: GetTasksIDOwners
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: List all owners of a task
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -4966,7 +4950,7 @@ paths:
     post:
       operationId: PostTasksIDOwners
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Add an owner to a task
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -5000,7 +4984,7 @@ paths:
     delete:
       operationId: DeleteTasksIDOwnersID
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Remove an owner from a task
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -5030,7 +5014,6 @@ paths:
       operationId: PostUsersIDPassword
       tags:
         - Security and access endpoints
-        - Users
       summary: Update a password
       description: |
         #### InfluxDB Cloud
@@ -6743,7 +6726,6 @@ paths:
     get:
       operationId: GetHealth
       tags:
-        - Health
         - System information endpoints
       summary: Retrieve the health of the instance
       description: Returns the health of the instance.
@@ -6773,7 +6755,6 @@ paths:
     get:
       operationId: GetMetrics
       tags:
-        - Metrics
         - System information endpoints
       summary: Retrieve workload performance metrics
       description: |
@@ -6828,7 +6809,6 @@ paths:
     get:
       operationId: GetReady
       tags:
-        - Ready
         - System information endpoints
       summary: Get the readiness of an instance at startup
       servers:
@@ -6850,7 +6830,6 @@ paths:
       operationId: GetUsers
       tags:
         - Security and access endpoints
-        - Users
       summary: List all users
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -6878,7 +6857,7 @@ paths:
     post:
       operationId: PostUsers
       tags:
-        - Users
+        - Security and access endpoints
       summary: Create a user
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -6904,7 +6883,6 @@ paths:
       operationId: GetUsersID
       tags:
         - Security and access endpoints
-        - Users
       summary: Retrieve a user
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -6927,7 +6905,7 @@ paths:
     patch:
       operationId: PatchUsersID
       tags:
-        - Users
+        - Security and access endpoints
       summary: Update a user
       requestBody:
         description: User update to apply
@@ -6957,7 +6935,7 @@ paths:
     delete:
       operationId: DeleteUsersID
       tags:
-        - Users
+        - Security and access endpoints
       summary: Delete a user
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -7018,7 +6996,6 @@ paths:
     get:
       operationId: GetAuthorizations
       tags:
-        - Authorizations
         - Security and access endpoints
       summary: List all authorizations
       parameters:
@@ -7056,7 +7033,7 @@ paths:
     post:
       operationId: PostAuthorizations
       tags:
-        - Authorizations
+        - Security and access endpoints
       summary: Create an authorization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -7084,7 +7061,6 @@ paths:
     get:
       operationId: GetAuthorizationsID
       tags:
-        - Authorizations
         - Security and access endpoints
       summary: Retrieve an authorization
       parameters:
@@ -7108,7 +7084,7 @@ paths:
     patch:
       operationId: PatchAuthorizationsID
       tags:
-        - Authorizations
+        - Security and access endpoints
       summary: Update an authorization to be active or inactive
       requestBody:
         description: Authorization to update
@@ -7138,7 +7114,7 @@ paths:
     delete:
       operationId: DeleteAuthorizationsID
       tags:
-        - Authorizations
+        - Security and access endpoints
       summary: Delete an authorization
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
@@ -8286,7 +8262,6 @@ paths:
     get:
       operationId: GetConfig
       tags:
-        - Config
         - System information endpoints
       summary: Retrieve runtime configuration
       description: |
@@ -8704,7 +8679,6 @@ paths:
       operationId: GetTasks
       tags:
         - Data I/O endpoints
-        - Tasks
       summary: List tasks
       description: |
         Retrieves a list of [tasks](https://docs.influxdata.com/influxdb/v2.3/process-data/).
@@ -8862,7 +8836,6 @@ paths:
       operationId: PostTasks
       tags:
         - Data I/O endpoints
-        - Tasks
       summary: Create a task
       description: |
         Creates a [task](https://docs.influxdata.com/influxdb/v2.3/process-data/) and returns the created task.
@@ -8893,7 +8866,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/responses/BadRequestError'
+                $ref: '#/components/schemas/Error'
               examples:
                 missingFluxError:
                   summary: Task in request body is missing Flux query
@@ -8934,7 +8907,6 @@ paths:
       operationId: GetTasksID
       tags:
         - Data I/O endpoints
-        - Tasks
       summary: Retrieve a task
       description: |
         Retrieves a [task](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#task)
@@ -8967,7 +8939,7 @@ paths:
     patch:
       operationId: PatchTasksID
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Update a task
       description: |
         Updates a task and then cancels all scheduled runs of the task.
@@ -9013,7 +8985,7 @@ paths:
     delete:
       operationId: DeleteTasksID
       tags:
-        - Tasks
+        - Data I/O endpoints
       summary: Delete a task
       description: |
         Deletes a task and associated records.

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -6175,7 +6175,6 @@ paths:
           description: All routes
       summary: List all top level routes
       tags:
-      - Routes
       - System information endpoints
   /api/v2/authorizations:
     get:
@@ -6219,7 +6218,7 @@ paths:
           description: Unexpected error
       summary: List all authorizations
       tags:
-      - Authorizations
+      - Security and access endpoints
     post:
       operationId: PostAuthorizations
       parameters:
@@ -6246,7 +6245,7 @@ paths:
           description: Unexpected error
       summary: Create an authorization
       tags:
-      - Authorizations
+      - Security and access endpoints
   /api/v2/authorizations/{authID}:
     delete:
       operationId: DeleteAuthorizationsID
@@ -6266,7 +6265,7 @@ paths:
           description: Unexpected error
       summary: Delete an authorization
       tags:
-      - Authorizations
+      - Security and access endpoints
     get:
       operationId: GetAuthorizationsID
       parameters:
@@ -6289,7 +6288,7 @@ paths:
           description: Unexpected error
       summary: Retrieve an authorization
       tags:
-      - Authorizations
+      - Security and access endpoints
     patch:
       description: Update an authorization's status to `active` or `inactive`.
       operationId: PatchAuthorizationsID
@@ -6320,7 +6319,7 @@ paths:
           description: Unexpected error
       summary: Update authorization status
       tags:
-      - Authorizations
+      - Security and access endpoints
   /api/v2/buckets:
     get:
       operationId: GetBuckets
@@ -8431,7 +8430,6 @@ paths:
       summary: Delete data
       tags:
       - Data I/O endpoints
-      - Delete
       x-codeSamples:
       - label: cURL
         lang: Shell
@@ -9327,7 +9325,6 @@ paths:
           description: Unexpected error
       summary: List all organizations
       tags:
-      - Organizations
       - Security and access endpoints
     post:
       operationId: PostOrgs
@@ -9355,7 +9352,7 @@ paths:
           description: Unexpected error
       summary: Create an organization
       tags:
-      - Organizations
+      - Security and access endpoints
   /api/v2/orgs/{orgID}:
     delete:
       operationId: DeleteOrgsID
@@ -9384,7 +9381,7 @@ paths:
           description: Unexpected error
       summary: Delete an organization
       tags:
-      - Organizations
+      - Security and access endpoints
     get:
       operationId: GetOrgsID
       parameters:
@@ -9410,7 +9407,6 @@ paths:
           description: Unexpected error
       summary: Retrieve an organization
       tags:
-      - Organizations
       - Security and access endpoints
     patch:
       operationId: PatchOrgsID
@@ -9444,7 +9440,7 @@ paths:
           description: Unexpected error
       summary: Update an organization
       tags:
-      - Organizations
+      - Security and access endpoints
   /api/v2/orgs/{orgID}/limits:
     get:
       operationId: GetOrgLimitsID
@@ -9507,7 +9503,6 @@ paths:
           description: Unexpected error
       summary: List all members of an organization
       tags:
-      - Organizations
       - Security and access endpoints
     post:
       operationId: PostOrgsIDMembers
@@ -9541,7 +9536,7 @@ paths:
           description: Unexpected error
       summary: Add a member to an organization
       tags:
-      - Organizations
+      - Security and access endpoints
   /api/v2/orgs/{orgID}/members/{userID}:
     delete:
       operationId: DeleteOrgsIDMembersID
@@ -9570,7 +9565,6 @@ paths:
           description: Unexpected error
       summary: Remove a member from an organization
       tags:
-      - Organizations
       - Security and access endpoints
   /api/v2/orgs/{orgID}/owners:
     get:
@@ -9604,7 +9598,6 @@ paths:
           description: Unexpected error
       summary: List all owners of an organization
       tags:
-      - Organizations
       - Security and access endpoints
     post:
       operationId: PostOrgsIDOwners
@@ -9638,7 +9631,7 @@ paths:
           description: Unexpected error
       summary: Add an owner to an organization
       tags:
-      - Organizations
+      - Security and access endpoints
   /api/v2/orgs/{orgID}/owners/{userID}:
     delete:
       operationId: DeleteOrgsIDOwnersID
@@ -9667,7 +9660,6 @@ paths:
           description: Unexpected error
       summary: Remove an owner from an organization
       tags:
-      - Organizations
       - Security and access endpoints
   /api/v2/orgs/{orgID}/secrets:
     get:
@@ -9695,7 +9687,6 @@ paths:
           description: Unexpected error
       summary: List all secret keys for an organization
       tags:
-      - Secrets
       - Security and access endpoints
     patch:
       operationId: PatchOrgsIDSecrets
@@ -9725,7 +9716,7 @@ paths:
           description: Unexpected error
       summary: Update secrets in an organization
       tags:
-      - Secrets
+      - Security and access endpoints
   /api/v2/orgs/{orgID}/secrets/{secretID}:
     delete:
       operationId: DeleteOrgsIDSecretsID
@@ -9751,7 +9742,6 @@ paths:
           description: Unexpected error
       summary: Delete a secret from an organization
       tags:
-      - Secrets
       - Security and access endpoints
   /api/v2/orgs/{orgID}/secrets/delete:
     post:
@@ -9783,7 +9773,6 @@ paths:
           description: Unexpected error
       summary: Delete secrets from an organization
       tags:
-      - Secrets
       - Security and access endpoints
   /api/v2/orgs/{orgID}/usage:
     get:
@@ -9869,7 +9858,6 @@ paths:
       - url: ""
       summary: Get the status and version of the instance
       tags:
-      - Ping
       - System information endpoints
     head:
       description: Returns the status and InfluxDB version of the instance.
@@ -9892,7 +9880,7 @@ paths:
       - url: ""
       summary: Get the status and version of the instance
       tags:
-      - Ping
+      - System information endpoints
   /api/v2/query:
     post:
       description: |
@@ -10050,7 +10038,6 @@ paths:
       summary: Query data
       tags:
       - Data I/O endpoints
-      - Query
       x-codeSamples:
       - label: cURL
         lang: Shell
@@ -10197,7 +10184,7 @@ paths:
                 type: string
       summary: Analyze a Flux query
       tags:
-      - Query
+      - Data I/O endpoints
       x-codeSamples:
       - label: 'cURL: Analyze a Flux query'
         lang: Shell
@@ -10629,7 +10616,7 @@ paths:
           description: Internal server error.
       summary: Generate a query Abstract Syntax Tree (AST)
       tags:
-      - Query
+      - Data I/O endpoints
       x-codeSamples:
       - label: cURL
         lang: Shell
@@ -10661,7 +10648,7 @@ paths:
           description: Any response other than 200 is an internal server error
       summary: Retrieve query suggestions
       tags:
-      - Query
+      - Data I/O endpoints
   /api/v2/query/suggestions/{name}:
     get:
       operationId: GetQuerySuggestionsName
@@ -10688,7 +10675,7 @@ paths:
           description: Any response other than 200 is an internal server error
       summary: Retrieve query suggestions for a branching suggestion
       tags:
-      - Query
+      - Data I/O endpoints
   /api/v2/resources:
     get:
       operationId: GetResources
@@ -10711,7 +10698,6 @@ paths:
           description: Internal server error
       summary: List all known resources
       tags:
-      - Resources
       - System information endpoints
   /api/v2/scripts:
     get:
@@ -10809,7 +10795,6 @@ paths:
       summary: List scripts
       tags:
       - Data I/O endpoints
-      - Invokable Scripts
       x-codeSamples:
       - label: cUrl
         lang: Shell
@@ -10901,7 +10886,7 @@ paths:
           description: Internal Server Error
       summary: Create a script
       tags:
-      - Invokable Scripts
+      - Data I/O endpoints
       x-codeSamples:
       - label: cURL
         lang: Shell
@@ -10936,7 +10921,7 @@ paths:
           description: Unexpected error
       summary: Delete a script
       tags:
-      - Invokable Scripts
+      - Data I/O endpoints
     get:
       description: Uses script ID to retrieve details of an invokable script.
       operationId: GetScriptsID
@@ -10960,7 +10945,6 @@ paths:
       summary: Retrieve a script
       tags:
       - Data I/O endpoints
-      - Invokable Scripts
     patch:
       description: |
         Updates properties (`name`, `description`, and `script`) of an invokable script.
@@ -10991,7 +10975,7 @@ paths:
           description: Unexpected error
       summary: Update a script
       tags:
-      - Invokable Scripts
+      - Data I/O endpoints
   /api/v2/scripts/{scriptID}/invoke:
     post:
       description: Invokes a script and substitutes `params` keys referenced in the
@@ -11021,7 +11005,6 @@ paths:
       summary: Invoke a script
       tags:
       - Data I/O endpoints
-      - Invokable Scripts
   /api/v2/setup:
     get:
       description: Check if setup is allowed. Returns `true` if no default user, organization,
@@ -11486,7 +11469,6 @@ paths:
       summary: List all tasks
       tags:
       - Data I/O endpoints
-      - Tasks
       x-codeSamples:
       - label: 'cURL: all tasks, `basic` output'
         lang: Shell
@@ -11568,7 +11550,6 @@ paths:
       summary: Create a task
       tags:
       - Data I/O endpoints
-      - Tasks
       x-codeSamples:
       - label: 'cURL: create a flux query task'
         lang: Shell
@@ -11642,7 +11623,7 @@ paths:
           $ref: '#/components/responses/GeneralServerError'
       summary: Delete a task
       tags:
-      - Tasks
+      - Data I/O endpoints
     get:
       description: |
         Retrieves a [task](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#task)
@@ -11676,7 +11657,6 @@ paths:
       summary: Retrieve a task
       tags:
       - Data I/O endpoints
-      - Tasks
     patch:
       description: |
         Updates a task and then cancels all scheduled runs of the task.
@@ -11722,7 +11702,7 @@ paths:
           $ref: '#/components/responses/GeneralServerError'
       summary: Update a task
       tags:
-      - Tasks
+      - Data I/O endpoints
   /api/v2/tasks/{taskID}/labels:
     get:
       description: |
@@ -11758,7 +11738,7 @@ paths:
           $ref: '#/components/responses/GeneralServerError'
       summary: List labels for a task
       tags:
-      - Tasks
+      - Data I/O endpoints
     post:
       description: |
         Adds a label to a task.
@@ -11800,7 +11780,7 @@ paths:
           $ref: '#/components/responses/GeneralServerError'
       summary: Add a label to a task
       tags:
-      - Tasks
+      - Data I/O endpoints
   /api/v2/tasks/{taskID}/labels/{labelID}:
     delete:
       description: |
@@ -11835,7 +11815,7 @@ paths:
           $ref: '#/components/responses/GeneralServerError'
       summary: Delete a label from a task
       tags:
-      - Tasks
+      - Data I/O endpoints
   /api/v2/tasks/{taskID}/logs:
     get:
       description: |
@@ -11908,7 +11888,7 @@ paths:
           $ref: '#/components/responses/GeneralServerError'
       summary: Retrieve all logs for a task
       tags:
-      - Tasks
+      - Data I/O endpoints
   /api/v2/tasks/{taskID}/members:
     get:
       operationId: GetTasksIDMembers
@@ -11935,7 +11915,7 @@ paths:
           description: Unexpected error
       summary: List all task members
       tags:
-      - Tasks
+      - Data I/O endpoints
     post:
       operationId: PostTasksIDMembers
       parameters:
@@ -11968,7 +11948,7 @@ paths:
           description: Unexpected error
       summary: Add a member to a task
       tags:
-      - Tasks
+      - Data I/O endpoints
   /api/v2/tasks/{taskID}/members/{userID}:
     delete:
       operationId: DeleteTasksIDMembersID
@@ -11997,7 +11977,7 @@ paths:
           description: Unexpected error
       summary: Remove a member from a task
       tags:
-      - Tasks
+      - Data I/O endpoints
   /api/v2/tasks/{taskID}/owners:
     get:
       operationId: GetTasksIDOwners
@@ -12024,7 +12004,7 @@ paths:
           description: Unexpected error
       summary: List all owners of a task
       tags:
-      - Tasks
+      - Data I/O endpoints
     post:
       operationId: PostTasksIDOwners
       parameters:
@@ -12057,7 +12037,7 @@ paths:
           description: Unexpected error
       summary: Add an owner to a task
       tags:
-      - Tasks
+      - Data I/O endpoints
   /api/v2/tasks/{taskID}/owners/{userID}:
     delete:
       operationId: DeleteTasksIDOwnersID
@@ -12086,7 +12066,7 @@ paths:
           description: Unexpected error
       summary: Remove an owner from a task
       tags:
-      - Tasks
+      - Data I/O endpoints
   /api/v2/tasks/{taskID}/runs:
     get:
       operationId: GetTasksIDRuns
@@ -12138,7 +12118,7 @@ paths:
           description: Unexpected error
       summary: List runs for a task
       tags:
-      - Tasks
+      - Data I/O endpoints
     post:
       operationId: PostTasksIDRuns
       parameters:
@@ -12169,7 +12149,6 @@ paths:
       summary: Manually start a task run, overriding the current schedule
       tags:
       - Data I/O endpoints
-      - Tasks
   /api/v2/tasks/{taskID}/runs/{runID}:
     delete:
       description: |
@@ -12230,7 +12209,7 @@ paths:
           $ref: '#/components/responses/GeneralServerError'
       summary: Cancel a running task
       tags:
-      - Tasks
+      - Data I/O endpoints
     get:
       description: |
         Retrieves a specific run for a [task](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#task).
@@ -12296,7 +12275,7 @@ paths:
           $ref: '#/components/responses/GeneralServerError'
       summary: Retrieve a run for a task.
       tags:
-      - Tasks
+      - Data I/O endpoints
   /api/v2/tasks/{taskID}/runs/{runID}/logs:
     get:
       operationId: GetTasksIDRunsIDLogs
@@ -12329,7 +12308,7 @@ paths:
           description: Unexpected error
       summary: Retrieve all logs for a run
       tags:
-      - Tasks
+      - Data I/O endpoints
   /api/v2/tasks/{taskID}/runs/{runID}/retry:
     post:
       operationId: PostTasksIDRunsIDRetry
@@ -12367,7 +12346,7 @@ paths:
           description: Unexpected error
       summary: Retry a task run
       tags:
-      - Tasks
+      - Data I/O endpoints
   /api/v2/telegraf/plugins:
     get:
       operationId: GetTelegrafPlugins
@@ -12930,7 +12909,7 @@ paths:
           description: Unexpected error
       summary: List all users
       tags:
-      - Users
+      - Security and access endpoints
     post:
       operationId: PostUsers
       parameters:
@@ -12954,7 +12933,7 @@ paths:
           description: Unexpected error
       summary: Create a user
       tags:
-      - Users
+      - Security and access endpoints
   /api/v2/users/{userID}:
     delete:
       operationId: DeleteUsersID
@@ -12974,7 +12953,7 @@ paths:
           description: Unexpected error
       summary: Delete a user
       tags:
-      - Users
+      - Security and access endpoints
     get:
       operationId: GetUsersID
       parameters:
@@ -12997,7 +12976,7 @@ paths:
           description: Unexpected error
       summary: Retrieve a user
       tags:
-      - Users
+      - Security and access endpoints
     patch:
       operationId: PatchUsersID
       parameters:
@@ -13027,7 +13006,7 @@ paths:
           description: Unexpected error
       summary: Update a user
       tags:
-      - Users
+      - Security and access endpoints
   /api/v2/users/{userID}/password:
     post:
       description: |
@@ -13069,7 +13048,6 @@ paths:
       summary: Update a password
       tags:
       - Security and access endpoints
-      - Users
   /api/v2/variables:
     get:
       operationId: GetVariables
@@ -13648,7 +13626,6 @@ paths:
       summary: Write data
       tags:
       - Data I/O endpoints
-      - Write
   /legacy/authorizations:
     get:
       operationId: GetLegacyAuthorizations

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -6247,7 +6247,6 @@ paths:
           description: All routes
       summary: List all top level routes
       tags:
-      - Routes
       - System information endpoints
   /api/v2/authorizations:
     get:
@@ -6286,7 +6285,6 @@ paths:
           description: Unexpected error
       summary: List all authorizations
       tags:
-      - Authorizations
       - Security and access endpoints
     post:
       operationId: PostAuthorizations
@@ -6314,7 +6312,7 @@ paths:
           description: Unexpected error
       summary: Create an authorization
       tags:
-      - Authorizations
+      - Security and access endpoints
   /api/v2/authorizations/{authID}:
     delete:
       operationId: DeleteAuthorizationsID
@@ -6334,7 +6332,7 @@ paths:
           description: Unexpected error
       summary: Delete an authorization
       tags:
-      - Authorizations
+      - Security and access endpoints
     get:
       operationId: GetAuthorizationsID
       parameters:
@@ -6357,7 +6355,6 @@ paths:
           description: Unexpected error
       summary: Retrieve an authorization
       tags:
-      - Authorizations
       - Security and access endpoints
     patch:
       operationId: PatchAuthorizationsID
@@ -6388,7 +6385,7 @@ paths:
           description: Unexpected error
       summary: Update an authorization to be active or inactive
       tags:
-      - Authorizations
+      - Security and access endpoints
   /api/v2/backup/kv:
     get:
       deprecated: true
@@ -7303,7 +7300,6 @@ paths:
           $ref: '#/components/responses/GeneralServerError'
       summary: Retrieve runtime configuration
       tags:
-      - Config
       - System information endpoints
   /api/v2/dashboards:
     get:
@@ -9167,7 +9163,6 @@ paths:
       summary: Delete data
       tags:
       - Data I/O endpoints
-      - Delete
       x-codeSamples:
       - label: cURL
         lang: Shell
@@ -9229,7 +9224,6 @@ paths:
       - url: ""
       summary: Retrieve the health of the instance
       tags:
-      - Health
       - System information endpoints
   /api/v2/labels:
     get:
@@ -9489,7 +9483,6 @@ paths:
       - url: ""
       summary: Retrieve workload performance metrics
       tags:
-      - Metrics
       - System information endpoints
   /api/v2/notificationEndpoints:
     get:
@@ -10148,7 +10141,6 @@ paths:
           description: Unexpected error
       summary: List all organizations
       tags:
-      - Organizations
       - Security and access endpoints
     post:
       operationId: PostOrgs
@@ -10176,7 +10168,7 @@ paths:
           description: Unexpected error
       summary: Create an organization
       tags:
-      - Organizations
+      - Security and access endpoints
   /api/v2/orgs/{orgID}:
     delete:
       operationId: DeleteOrgsID
@@ -10205,7 +10197,7 @@ paths:
           description: Unexpected error
       summary: Delete an organization
       tags:
-      - Organizations
+      - Security and access endpoints
     get:
       operationId: GetOrgsID
       parameters:
@@ -10231,7 +10223,6 @@ paths:
           description: Unexpected error
       summary: Retrieve an organization
       tags:
-      - Organizations
       - Security and access endpoints
     patch:
       operationId: PatchOrgsID
@@ -10265,7 +10256,7 @@ paths:
           description: Unexpected error
       summary: Update an organization
       tags:
-      - Organizations
+      - Security and access endpoints
   /api/v2/orgs/{orgID}/members:
     get:
       operationId: GetOrgsIDMembers
@@ -10298,7 +10289,6 @@ paths:
           description: Unexpected error
       summary: List all members of an organization
       tags:
-      - Organizations
       - Security and access endpoints
     post:
       operationId: PostOrgsIDMembers
@@ -10332,7 +10322,7 @@ paths:
           description: Unexpected error
       summary: Add a member to an organization
       tags:
-      - Organizations
+      - Security and access endpoints
   /api/v2/orgs/{orgID}/members/{userID}:
     delete:
       operationId: DeleteOrgsIDMembersID
@@ -10361,7 +10351,6 @@ paths:
           description: Unexpected error
       summary: Remove a member from an organization
       tags:
-      - Organizations
       - Security and access endpoints
   /api/v2/orgs/{orgID}/owners:
     get:
@@ -10395,7 +10384,6 @@ paths:
           description: Unexpected error
       summary: List all owners of an organization
       tags:
-      - Organizations
       - Security and access endpoints
     post:
       operationId: PostOrgsIDOwners
@@ -10429,7 +10417,7 @@ paths:
           description: Unexpected error
       summary: Add an owner to an organization
       tags:
-      - Organizations
+      - Security and access endpoints
   /api/v2/orgs/{orgID}/owners/{userID}:
     delete:
       operationId: DeleteOrgsIDOwnersID
@@ -10458,7 +10446,6 @@ paths:
           description: Unexpected error
       summary: Remove an owner from an organization
       tags:
-      - Organizations
       - Security and access endpoints
   /api/v2/orgs/{orgID}/secrets:
     get:
@@ -10486,7 +10473,6 @@ paths:
           description: Unexpected error
       summary: List all secret keys for an organization
       tags:
-      - Secrets
       - Security and access endpoints
     patch:
       operationId: PatchOrgsIDSecrets
@@ -10516,7 +10502,7 @@ paths:
           description: Unexpected error
       summary: Update secrets in an organization
       tags:
-      - Secrets
+      - Security and access endpoints
   /api/v2/orgs/{orgID}/secrets/{secretID}:
     delete:
       operationId: DeleteOrgsIDSecretsID
@@ -10542,7 +10528,6 @@ paths:
           description: Unexpected error
       summary: Delete a secret from an organization
       tags:
-      - Secrets
       - Security and access endpoints
   /api/v2/orgs/{orgID}/secrets/delete:
     post:
@@ -10574,7 +10559,6 @@ paths:
           description: Unexpected error
       summary: Delete secrets from an organization
       tags:
-      - Secrets
       - Security and access endpoints
   /ping:
     get:
@@ -10598,7 +10582,6 @@ paths:
       - url: ""
       summary: Get the status and version of the instance
       tags:
-      - Ping
       - System information endpoints
     head:
       description: Returns the status and InfluxDB version of the instance.
@@ -10621,7 +10604,7 @@ paths:
       - url: ""
       summary: Get the status and version of the instance
       tags:
-      - Ping
+      - System information endpoints
   /api/v2/query:
     post:
       description: |
@@ -10779,7 +10762,6 @@ paths:
       summary: Query data
       tags:
       - Data I/O endpoints
-      - Query
       x-codeSamples:
       - label: cURL
         lang: Shell
@@ -10926,7 +10908,7 @@ paths:
                 type: string
       summary: Analyze a Flux query
       tags:
-      - Query
+      - Data I/O endpoints
       x-codeSamples:
       - label: 'cURL: Analyze a Flux query'
         lang: Shell
@@ -11358,7 +11340,7 @@ paths:
           description: Internal server error.
       summary: Generate a query Abstract Syntax Tree (AST)
       tags:
-      - Query
+      - Data I/O endpoints
       x-codeSamples:
       - label: cURL
         lang: Shell
@@ -11390,7 +11372,7 @@ paths:
           description: Any response other than 200 is an internal server error
       summary: Retrieve query suggestions
       tags:
-      - Query
+      - Data I/O endpoints
   /api/v2/query/suggestions/{name}:
     get:
       operationId: GetQuerySuggestionsName
@@ -11417,7 +11399,7 @@ paths:
           description: Any response other than 200 is an internal server error
       summary: Retrieve query suggestions for a branching suggestion
       tags:
-      - Query
+      - Data I/O endpoints
   /ready:
     get:
       operationId: GetReady
@@ -11437,7 +11419,6 @@ paths:
       - url: ""
       summary: Get the readiness of an instance at startup
       tags:
-      - Ready
       - System information endpoints
   /api/v2/remotes:
     get:
@@ -11763,7 +11744,6 @@ paths:
           description: Internal server error
       summary: List all known resources
       tags:
-      - Resources
       - System information endpoints
   /api/v2/restore/bucket/{bucketID}:
     post:
@@ -13092,7 +13072,6 @@ paths:
       summary: List tasks
       tags:
       - Data I/O endpoints
-      - Tasks
     post:
       description: |
         Creates a [task](https://docs.influxdata.com/influxdb/v2.3/process-data/) and returns the created task.
@@ -13130,7 +13109,7 @@ paths:
                     code: invalid
                     message: 'failed to decode request: missing flux'
               schema:
-                $ref: '#/components/responses/BadRequestError'
+                $ref: '#/components/schemas/Error'
           description: Bad request
         "401":
           $ref: '#/components/responses/AuthorizationError'
@@ -13145,7 +13124,6 @@ paths:
       summary: Create a task
       tags:
       - Data I/O endpoints
-      - Tasks
       x-codeSamples:
       - label: 'cURL: create a task'
         lang: Shell
@@ -13198,7 +13176,7 @@ paths:
           $ref: '#/components/responses/GeneralServerError'
       summary: Delete a task
       tags:
-      - Tasks
+      - Data I/O endpoints
     get:
       description: |
         Retrieves a [task](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#task)
@@ -13232,7 +13210,6 @@ paths:
       summary: Retrieve a task
       tags:
       - Data I/O endpoints
-      - Tasks
     patch:
       description: |
         Updates a task and then cancels all scheduled runs of the task.
@@ -13278,7 +13255,7 @@ paths:
           $ref: '#/components/responses/GeneralServerError'
       summary: Update a task
       tags:
-      - Tasks
+      - Data I/O endpoints
   /api/v2/tasks/{taskID}/labels:
     get:
       description: |
@@ -13314,7 +13291,7 @@ paths:
           $ref: '#/components/responses/GeneralServerError'
       summary: List labels for a task
       tags:
-      - Tasks
+      - Data I/O endpoints
     post:
       description: |
         Adds a label to a task.
@@ -13356,7 +13333,7 @@ paths:
           $ref: '#/components/responses/GeneralServerError'
       summary: Add a label to a task
       tags:
-      - Tasks
+      - Data I/O endpoints
   /api/v2/tasks/{taskID}/labels/{labelID}:
     delete:
       description: |
@@ -13391,7 +13368,7 @@ paths:
           $ref: '#/components/responses/GeneralServerError'
       summary: Delete a label from a task
       tags:
-      - Tasks
+      - Data I/O endpoints
   /api/v2/tasks/{taskID}/logs:
     get:
       description: |
@@ -13464,7 +13441,7 @@ paths:
           $ref: '#/components/responses/GeneralServerError'
       summary: Retrieve all logs for a task
       tags:
-      - Tasks
+      - Data I/O endpoints
   /api/v2/tasks/{taskID}/members:
     get:
       operationId: GetTasksIDMembers
@@ -13491,7 +13468,7 @@ paths:
           description: Unexpected error
       summary: List all task members
       tags:
-      - Tasks
+      - Data I/O endpoints
     post:
       operationId: PostTasksIDMembers
       parameters:
@@ -13524,7 +13501,7 @@ paths:
           description: Unexpected error
       summary: Add a member to a task
       tags:
-      - Tasks
+      - Data I/O endpoints
   /api/v2/tasks/{taskID}/members/{userID}:
     delete:
       operationId: DeleteTasksIDMembersID
@@ -13553,7 +13530,7 @@ paths:
           description: Unexpected error
       summary: Remove a member from a task
       tags:
-      - Tasks
+      - Data I/O endpoints
   /api/v2/tasks/{taskID}/owners:
     get:
       operationId: GetTasksIDOwners
@@ -13580,7 +13557,7 @@ paths:
           description: Unexpected error
       summary: List all owners of a task
       tags:
-      - Tasks
+      - Data I/O endpoints
     post:
       operationId: PostTasksIDOwners
       parameters:
@@ -13613,7 +13590,7 @@ paths:
           description: Unexpected error
       summary: Add an owner to a task
       tags:
-      - Tasks
+      - Data I/O endpoints
   /api/v2/tasks/{taskID}/owners/{userID}:
     delete:
       operationId: DeleteTasksIDOwnersID
@@ -13642,7 +13619,7 @@ paths:
           description: Unexpected error
       summary: Remove an owner from a task
       tags:
-      - Tasks
+      - Data I/O endpoints
   /api/v2/tasks/{taskID}/runs:
     get:
       operationId: GetTasksIDRuns
@@ -13694,7 +13671,7 @@ paths:
           description: Unexpected error
       summary: List runs for a task
       tags:
-      - Tasks
+      - Data I/O endpoints
     post:
       operationId: PostTasksIDRuns
       parameters:
@@ -13725,7 +13702,6 @@ paths:
       summary: Manually start a task run, overriding the current schedule
       tags:
       - Data I/O endpoints
-      - Tasks
   /api/v2/tasks/{taskID}/runs/{runID}:
     delete:
       description: |
@@ -13786,7 +13762,7 @@ paths:
           $ref: '#/components/responses/GeneralServerError'
       summary: Cancel a running task
       tags:
-      - Tasks
+      - Data I/O endpoints
     get:
       description: |
         Retrieves a specific run for a [task](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#task).
@@ -13852,7 +13828,7 @@ paths:
           $ref: '#/components/responses/GeneralServerError'
       summary: Retrieve a run for a task.
       tags:
-      - Tasks
+      - Data I/O endpoints
   /api/v2/tasks/{taskID}/runs/{runID}/logs:
     get:
       operationId: GetTasksIDRunsIDLogs
@@ -13885,7 +13861,7 @@ paths:
           description: Unexpected error
       summary: Retrieve all logs for a run
       tags:
-      - Tasks
+      - Data I/O endpoints
   /api/v2/tasks/{taskID}/runs/{runID}/retry:
     post:
       operationId: PostTasksIDRunsIDRetry
@@ -13923,7 +13899,7 @@ paths:
           description: Unexpected error
       summary: Retry a task run
       tags:
-      - Tasks
+      - Data I/O endpoints
   /api/v2/telegraf/plugins:
     get:
       operationId: GetTelegrafPlugins
@@ -14498,7 +14474,6 @@ paths:
       summary: List all users
       tags:
       - Security and access endpoints
-      - Users
     post:
       operationId: PostUsers
       parameters:
@@ -14522,7 +14497,7 @@ paths:
           description: Unexpected error
       summary: Create a user
       tags:
-      - Users
+      - Security and access endpoints
   /api/v2/users/{userID}:
     delete:
       operationId: DeleteUsersID
@@ -14542,7 +14517,7 @@ paths:
           description: Unexpected error
       summary: Delete a user
       tags:
-      - Users
+      - Security and access endpoints
     get:
       operationId: GetUsersID
       parameters:
@@ -14566,7 +14541,6 @@ paths:
       summary: Retrieve a user
       tags:
       - Security and access endpoints
-      - Users
     patch:
       operationId: PatchUsersID
       parameters:
@@ -14596,7 +14570,7 @@ paths:
           description: Unexpected error
       summary: Update a user
       tags:
-      - Users
+      - Security and access endpoints
   /api/v2/users/{userID}/password:
     post:
       description: |
@@ -14638,7 +14612,6 @@ paths:
       summary: Update a password
       tags:
       - Security and access endpoints
-      - Users
   /api/v2/variables:
     get:
       operationId: GetVariables
@@ -15217,7 +15190,6 @@ paths:
       summary: Write data
       tags:
       - Data I/O endpoints
-      - Write
   /legacy/authorizations:
     get:
       operationId: GetLegacyAuthorizations

--- a/contracts/svc/invocable-scripts.yml
+++ b/contracts/svc/invocable-scripts.yml
@@ -21,7 +21,6 @@ paths:
       operationId: GetScripts
       tags:
         - Data I/O endpoints
-        - Invokable Scripts
       summary: List scripts
       description: |
         Retrieves a list of [scripts](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/).
@@ -121,7 +120,7 @@ paths:
     post:
       operationId: PostScripts
       tags:
-        - Invokable Scripts
+        - Data I/O endpoints
       summary: Create a script
       description: |
         Creates an [invokable script](https://docs.influxdata.com/resources/videos/api-invokable-scripts/)
@@ -220,7 +219,6 @@ paths:
       operationId: GetScriptsID
       tags:
         - Data I/O endpoints
-        - Invokable Scripts
       summary: Retrieve a script
       description: Uses script ID to retrieve details of an invokable script.
       parameters:
@@ -243,7 +241,7 @@ paths:
     patch:
       operationId: PatchScriptsID
       tags:
-        - Invokable Scripts
+        - Data I/O endpoints
       summary: Update a script
       description: |
         Updates properties (`name`, `description`, and `script`) of an invokable script.
@@ -274,7 +272,7 @@ paths:
     delete:
       operationId: DeleteScriptsID
       tags:
-        - Invokable Scripts
+        - Data I/O endpoints
       summary: Delete a script
       description: Deletes a script and all associated records.
       parameters:
@@ -295,7 +293,6 @@ paths:
       operationId: PostScriptsIDInvoke
       tags:
         - Data I/O endpoints
-        - Invokable Scripts
       summary: Invoke a script
       description: Invokes a script and substitutes `params` keys referenced in the script with `params` key-values sent in the request body.
       parameters:

--- a/src/cloud/paths/authorizations.yml
+++ b/src/cloud/paths/authorizations.yml
@@ -1,7 +1,7 @@
 get:
   operationId: GetAuthorizations
   tags:
-    - Authorizations
+    - Security and access endpoints
   summary: List all authorizations
   parameters:
     - $ref: "../../common/parameters/TraceSpan.yml"
@@ -43,7 +43,7 @@ get:
 post:
   operationId: PostAuthorizations
   tags:
-    - Authorizations
+    - Security and access endpoints
   summary: Create an authorization
   parameters:
     - $ref: "../../common/parameters/TraceSpan.yml"

--- a/src/cloud/paths/authorizations_authID.yml
+++ b/src/cloud/paths/authorizations_authID.yml
@@ -1,7 +1,7 @@
 get:
   operationId: GetAuthorizationsID
   tags:
-    - Authorizations
+    - Security and access endpoints
   summary: Retrieve an authorization
   parameters:
     - $ref: "../../common/parameters/TraceSpan.yml"
@@ -24,7 +24,7 @@ get:
 patch:
   operationId: PatchAuthorizationsID
   tags:
-    - Authorizations
+    - Security and access endpoints
   summary: Update authorization status
   description: Update an authorization's status to `active` or `inactive`.
   requestBody:
@@ -55,7 +55,7 @@ patch:
 delete:
   operationId: DeleteAuthorizationsID
   tags:
-    - Authorizations
+    - Security and access endpoints
   summary: Delete an authorization
   parameters:
     - $ref: "../../common/parameters/TraceSpan.yml"

--- a/src/cloud/paths/tasks.yml
+++ b/src/cloud/paths/tasks.yml
@@ -2,7 +2,6 @@ get:
   operationId: GetTasks
   tags:
     - Data I/O endpoints
-    - Tasks
   summary: List all tasks
   description: |
     Retrieves a list of [tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/).
@@ -132,7 +131,6 @@ post:
   operationId: PostTasks
   tags:
     - Data I/O endpoints
-    - Tasks
   summary: Create a task
   description: |
     Creates a [task]({{% INFLUXDB_DOCS_URL %}}/process-data/) and returns the created task.

--- a/src/cloud/paths/tasks_taskID.yml
+++ b/src/cloud/paths/tasks_taskID.yml
@@ -2,7 +2,6 @@ get:
   operationId: GetTasksID
   tags:
     - Data I/O endpoints
-    - Tasks
   summary: Retrieve a task
   description: |
     Retrieves a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task)
@@ -35,7 +34,7 @@ get:
 patch:
   operationId: PatchTasksID
   tags:
-    - Tasks
+    - Data I/O endpoints
   summary: Update a task
   description: |
     Updates a task and then cancels all scheduled runs of the task.
@@ -81,7 +80,7 @@ patch:
 delete:
   operationId: DeleteTasksID
   tags:
-    - Tasks
+    - Data I/O endpoints
   summary: Delete a task
   description: |
     Deletes a task and associated records.

--- a/src/cloud/paths/users.yml
+++ b/src/cloud/paths/users.yml
@@ -1,7 +1,7 @@
 get:
   operationId: GetUsers
   tags:
-    - Users
+    - Security and access endpoints
   summary: List all users
   parameters:
     - $ref: "../../common/parameters/TraceSpan.yml"
@@ -18,7 +18,7 @@ get:
 post:
   operationId: PostUsers
   tags:
-    - Users
+    - Security and access endpoints
   summary: Create a user
   parameters:
     - $ref: "../../common/parameters/TraceSpan.yml"

--- a/src/cloud/paths/users_userID.yml
+++ b/src/cloud/paths/users_userID.yml
@@ -1,7 +1,7 @@
 get:
   operationId: GetUsersID
   tags:
-    - Users
+    - Security and access endpoints
   summary: Retrieve a user
   parameters:
     - $ref: "../../common/parameters/TraceSpan.yml"
@@ -24,7 +24,7 @@ get:
 patch:
   operationId: PatchUsersID
   tags:
-    - Users
+    - Security and access endpoints
   summary: Update a user
   requestBody:
     description: User update to apply
@@ -54,7 +54,7 @@ patch:
 delete:
   operationId: DeleteUsersID
   tags:
-    - Users
+    - Security and access endpoints
   summary: Delete a user
   parameters:
     - $ref: "../../common/parameters/TraceSpan.yml"

--- a/src/common/paths/0slash.yml
+++ b/src/common/paths/0slash.yml
@@ -2,7 +2,6 @@ get:
   operationId: GetRoutes
   summary: List all top level routes
   tags:
-    - Routes
     - System information endpoints
   parameters:
     - $ref: "../parameters/TraceSpan.yml"

--- a/src/common/paths/authorizations.yml
+++ b/src/common/paths/authorizations.yml
@@ -1,7 +1,6 @@
 get:
   operationId: GetAuthorizations
   tags:
-    - Authorizations
     - Security and access endpoints
   summary: List all authorizations
   parameters:
@@ -39,7 +38,7 @@ get:
 post:
   operationId: PostAuthorizations
   tags:
-    - Authorizations
+    - Security and access endpoints
   summary: Create an authorization
   parameters:
     - $ref: "../../common/parameters/TraceSpan.yml"

--- a/src/common/paths/authorizations_authID.yml
+++ b/src/common/paths/authorizations_authID.yml
@@ -1,7 +1,6 @@
 get:
   operationId: GetAuthorizationsID
   tags:
-    - Authorizations
     - Security and access endpoints
   summary: Retrieve an authorization
   parameters:
@@ -25,7 +24,7 @@ get:
 patch:
   operationId: PatchAuthorizationsID
   tags:
-    - Authorizations
+    - Security and access endpoints
   summary: Update an authorization to be active or inactive
   requestBody:
     description: Authorization to update
@@ -55,7 +54,7 @@ patch:
 delete:
   operationId: DeleteAuthorizationsID
   tags:
-    - Authorizations
+    - Security and access endpoints
   summary: Delete an authorization
   parameters:
     - $ref: "../../common/parameters/TraceSpan.yml"

--- a/src/common/paths/delete.yml
+++ b/src/common/paths/delete.yml
@@ -2,7 +2,6 @@ post:
   operationId: PostDelete
   tags:
     - Data I/O endpoints
-    - Delete
   summary: Delete data
   description: |
     Deletes data from a bucket.

--- a/src/common/paths/orgs.yml
+++ b/src/common/paths/orgs.yml
@@ -1,7 +1,6 @@
 get:
   operationId: GetOrgs
   tags:
-    - Organizations
     - Security and access endpoints
   summary: List all organizations
   parameters:
@@ -40,7 +39,7 @@ get:
 post:
   operationId: PostOrgs
   tags:
-    - Organizations
+    - Security and access endpoints
   summary: Create an organization
   parameters:
     - $ref: "../parameters/TraceSpan.yml"

--- a/src/common/paths/orgs_orgID.yml
+++ b/src/common/paths/orgs_orgID.yml
@@ -1,7 +1,6 @@
 get:
   operationId: GetOrgsID
   tags:
-    - Organizations
     - Security and access endpoints
   summary: Retrieve an organization
   parameters:
@@ -28,7 +27,7 @@ get:
 patch:
   operationId: PatchOrgsID
   tags:
-    - Organizations
+    - Security and access endpoints
   summary: Update an organization
   requestBody:
     description: Organization update to apply
@@ -61,7 +60,7 @@ patch:
 delete:
   operationId: DeleteOrgsID
   tags:
-    - Organizations
+    - Security and access endpoints
   summary: Delete an organization
   parameters:
     - $ref: "../parameters/TraceSpan.yml"

--- a/src/common/paths/orgs_orgID_members.yml
+++ b/src/common/paths/orgs_orgID_members.yml
@@ -1,7 +1,6 @@
 get:
   operationId: GetOrgsIDMembers
   tags:
-    - Organizations
     - Security and access endpoints
   summary: List all members of an organization
   parameters:
@@ -34,7 +33,7 @@ get:
 post:
   operationId: PostOrgsIDMembers
   tags:
-    - Organizations
+    - Security and access endpoints
   summary: Add a member to an organization
   parameters:
     - $ref: "../parameters/TraceSpan.yml"

--- a/src/common/paths/orgs_orgID_members_userID.yml
+++ b/src/common/paths/orgs_orgID_members_userID.yml
@@ -1,7 +1,6 @@
 delete:
   operationId: DeleteOrgsIDMembersID
   tags:
-    - Organizations
     - Security and access endpoints
   summary: Remove a member from an organization
   parameters:

--- a/src/common/paths/orgs_orgID_owners.yml
+++ b/src/common/paths/orgs_orgID_owners.yml
@@ -1,7 +1,6 @@
 get:
   operationId: GetOrgsIDOwners
   tags:
-    - Organizations
     - Security and access endpoints
   summary: List all owners of an organization
   parameters:
@@ -34,7 +33,7 @@ get:
 post:
   operationId: PostOrgsIDOwners
   tags:
-    - Organizations
+    - Security and access endpoints
   summary: Add an owner to an organization
   parameters:
     - $ref: "../parameters/TraceSpan.yml"

--- a/src/common/paths/orgs_orgID_owners_userID.yml
+++ b/src/common/paths/orgs_orgID_owners_userID.yml
@@ -1,7 +1,6 @@
 delete:
   operationId: DeleteOrgsIDOwnersID
   tags:
-    - Organizations
     - Security and access endpoints
   summary: Remove an owner from an organization
   parameters:

--- a/src/common/paths/orgs_orgID_secrets.yml
+++ b/src/common/paths/orgs_orgID_secrets.yml
@@ -1,7 +1,6 @@
 get:
   operationId: GetOrgsIDSecrets
   tags:
-    - Secrets
     - Security and access endpoints
   summary: List all secret keys for an organization
   parameters:
@@ -28,7 +27,7 @@ get:
 patch:
   operationId: PatchOrgsIDSecrets
   tags:
-    - Secrets
+    - Security and access endpoints
   summary: Update secrets in an organization
   parameters:
     - $ref: "../parameters/TraceSpan.yml"

--- a/src/common/paths/orgs_orgID_secrets_delete.yml
+++ b/src/common/paths/orgs_orgID_secrets_delete.yml
@@ -2,7 +2,6 @@ post:
   deprecated: true
   operationId: PostOrgsIDSecrets
   tags:
-    - Secrets
     - Security and access endpoints
   summary: Delete secrets from an organization
   parameters:

--- a/src/common/paths/orgs_orgID_secrets_secretID.yml
+++ b/src/common/paths/orgs_orgID_secrets_secretID.yml
@@ -1,7 +1,6 @@
 delete:
   operationId: DeleteOrgsIDSecretsID
   tags:
-    - Secrets
     - Security and access endpoints
   summary: Delete a secret from an organization
   parameters:

--- a/src/common/paths/ping.yml
+++ b/src/common/paths/ping.yml
@@ -5,7 +5,6 @@ get:
   servers:
     - url: ''
   tags:
-    - Ping
     - System information endpoints
   responses:
     '204':
@@ -28,7 +27,7 @@ head:
   servers:
     - url: ''
   tags:
-    - Ping
+    - System information endpoints
   responses:
     '204':
       description: |

--- a/src/common/paths/query.yml
+++ b/src/common/paths/query.yml
@@ -2,7 +2,6 @@ post:
   operationId: PostQuery
   tags:
     - Data I/O endpoints
-    - Query
   summary: Query data
   description: |
     Retrieves data from buckets.

--- a/src/common/paths/query_analyze.yml
+++ b/src/common/paths/query_analyze.yml
@@ -1,7 +1,7 @@
 post:
   operationId: PostQueryAnalyze
   tags:
-    - Query
+    - Data I/O endpoints
   summary: Analyze a Flux query
   description: |
     Analyzes a [Flux query](https://docs.influxdata.com/flux/v0.x/) for syntax

--- a/src/common/paths/query_ast.yml
+++ b/src/common/paths/query_ast.yml
@@ -1,7 +1,7 @@
 post:
   operationId: PostQueryAst
   tags:
-    - Query
+    - Data I/O endpoints
   summary: Generate a query Abstract Syntax Tree (AST)
   description: |
     Analyzes a Flux query and returns a complete package source [Abstract Syntax

--- a/src/common/paths/query_suggestions.yml
+++ b/src/common/paths/query_suggestions.yml
@@ -1,7 +1,7 @@
 get:
   operationId: GetQuerySuggestions
   tags:
-    - Query
+    - Data I/O endpoints
   summary: Retrieve query suggestions
   parameters:
     - $ref: "../parameters/TraceSpan.yml"

--- a/src/common/paths/query_suggestions_name.yml
+++ b/src/common/paths/query_suggestions_name.yml
@@ -1,7 +1,7 @@
 get:
   operationId: GetQuerySuggestionsName
   tags:
-    - Query
+    - Data I/O endpoints
   summary: Retrieve query suggestions for a branching suggestion
   parameters:
     - $ref: "../parameters/TraceSpan.yml"

--- a/src/common/paths/resources.yml
+++ b/src/common/paths/resources.yml
@@ -1,7 +1,6 @@
 get:
   operationId: GetResources
   tags:
-    - Resources
     - System information endpoints
   summary: List all known resources
   parameters:

--- a/src/common/paths/tasks.yml
+++ b/src/common/paths/tasks.yml
@@ -2,7 +2,6 @@ get:
   operationId: GetTasks
   tags:
     - Data I/O endpoints
-    - Tasks
   summary: List tasks
   description: |
     Retrieves a list of [tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/).
@@ -169,7 +168,6 @@ post:
   operationId: PostTasks
   tags:
     - Data I/O endpoints
-    - Tasks
   summary: Create a task
   description: |
     Creates a [task]({{% INFLUXDB_DOCS_URL %}}/process-data/) and returns the created task.
@@ -200,7 +198,7 @@ post:
       content:
         application/json:
           schema:
-            $ref: "../responses/BadRequestError.yml"
+            $ref: "../schemas/Error.yml"
           examples:
             missingFluxError:
               summary: Task in request body is missing Flux query

--- a/src/common/paths/tasks_taskID.yml
+++ b/src/common/paths/tasks_taskID.yml
@@ -2,7 +2,6 @@ get:
   operationId: GetTasksID
   tags:
     - Data I/O endpoints
-    - Tasks
   summary: Retrieve a task
   description: |
     Retrieves a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task)
@@ -35,7 +34,7 @@ get:
 patch:
   operationId: PatchTasksID
   tags:
-    - Tasks
+    - Data I/O endpoints
   summary: Update a task
   description: |
     Updates a task and then cancels all scheduled runs of the task.
@@ -81,7 +80,7 @@ patch:
 delete:
   operationId: DeleteTasksID
   tags:
-    - Tasks
+    - Data I/O endpoints
   summary: Delete a task
   description: |
     Deletes a task and associated records.

--- a/src/common/paths/tasks_taskID_labels.yml
+++ b/src/common/paths/tasks_taskID_labels.yml
@@ -1,7 +1,7 @@
 get:
   operationId: GetTasksIDLabels
   tags:
-    - Tasks
+    - Data I/O endpoints
   summary: List labels for a task
   description: |
     Retrieves a list of all labels for a task.
@@ -35,7 +35,7 @@ get:
 post:
   operationId: PostTasksIDLabels
   tags:
-    - Tasks
+    - Data I/O endpoints
   summary: Add a label to a task
   description: |
     Adds a label to a task.

--- a/src/common/paths/tasks_taskID_labels_labelID.yml
+++ b/src/common/paths/tasks_taskID_labels_labelID.yml
@@ -1,7 +1,7 @@
 delete:
   operationId: DeleteTasksIDLabelsID
   tags:
-    - Tasks
+    - Data I/O endpoints
   summary: Delete a label from a task
   description: |
     Deletes a label from a task.

--- a/src/common/paths/tasks_taskID_logs.yml
+++ b/src/common/paths/tasks_taskID_logs.yml
@@ -1,7 +1,7 @@
 get:
   operationId: GetTasksIDLogs
   tags:
-    - Tasks
+    - Data I/O endpoints
   summary: Retrieve all logs for a task
   description: |
     Retrieves a list of all logs for a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task).

--- a/src/common/paths/tasks_taskID_members.yml
+++ b/src/common/paths/tasks_taskID_members.yml
@@ -1,7 +1,7 @@
 get:
   operationId: GetTasksIDMembers
   tags:
-    - Tasks
+    - Data I/O endpoints
   summary: List all task members
   parameters:
     - $ref: "../parameters/TraceSpan.yml"
@@ -27,7 +27,7 @@ get:
 post:
   operationId: PostTasksIDMembers
   tags:
-    - Tasks
+    - Data I/O endpoints
   summary: Add a member to a task
   parameters:
     - $ref: "../parameters/TraceSpan.yml"

--- a/src/common/paths/tasks_taskID_members_userID.yml
+++ b/src/common/paths/tasks_taskID_members_userID.yml
@@ -1,7 +1,7 @@
 delete:
   operationId: DeleteTasksIDMembersID
   tags:
-    - Tasks
+    - Data I/O endpoints
   summary: Remove a member from a task
   parameters:
     - $ref: "../parameters/TraceSpan.yml"

--- a/src/common/paths/tasks_taskID_owners.yml
+++ b/src/common/paths/tasks_taskID_owners.yml
@@ -1,7 +1,7 @@
 get:
   operationId: GetTasksIDOwners
   tags:
-    - Tasks
+    - Data I/O endpoints
   summary: List all owners of a task
   parameters:
     - $ref: "../parameters/TraceSpan.yml"
@@ -27,7 +27,7 @@ get:
 post:
   operationId: PostTasksIDOwners
   tags:
-    - Tasks
+    - Data I/O endpoints
   summary: Add an owner to a task
   parameters:
     - $ref: "../parameters/TraceSpan.yml"

--- a/src/common/paths/tasks_taskID_owners_userID.yml
+++ b/src/common/paths/tasks_taskID_owners_userID.yml
@@ -1,7 +1,7 @@
 delete:
   operationId: DeleteTasksIDOwnersID
   tags:
-    - Tasks
+    - Data I/O endpoints
   summary: Remove an owner from a task
   parameters:
     - $ref: "../parameters/TraceSpan.yml"

--- a/src/common/paths/tasks_taskID_runs.yml
+++ b/src/common/paths/tasks_taskID_runs.yml
@@ -1,7 +1,7 @@
 get:
   operationId: GetTasksIDRuns
   tags:
-    - Tasks
+    - Data I/O endpoints
   summary: List runs for a task
   parameters:
     - $ref: "../parameters/TraceSpan.yml"
@@ -53,7 +53,6 @@ post:
   operationId: PostTasksIDRuns
   tags:
     - Data I/O endpoints
-    - Tasks
   summary: Manually start a task run, overriding the current schedule
   parameters:
     - $ref: "../parameters/TraceSpan.yml"

--- a/src/common/paths/tasks_taskID_runs_runID.yml
+++ b/src/common/paths/tasks_taskID_runs_runID.yml
@@ -1,7 +1,7 @@
 get:
   operationId: GetTasksIDRunsID
   tags:
-    - Tasks
+    - Data I/O endpoints
   summary: Retrieve a run for a task.
   description: |
     Retrieves a specific run for a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task).
@@ -72,7 +72,7 @@ get:
 delete:
   operationId: DeleteTasksIDRunsID
   tags:
-    - Tasks
+    - Data I/O endpoints
   summary: Cancel a running task
   description: |
     Cancels a running [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task).

--- a/src/common/paths/tasks_taskID_runs_runID_logs.yml
+++ b/src/common/paths/tasks_taskID_runs_runID_logs.yml
@@ -1,7 +1,7 @@
 get:
   operationId: GetTasksIDRunsIDLogs
   tags:
-    - Tasks
+    - Data I/O endpoints
   summary: Retrieve all logs for a run
   parameters:
     - $ref: "../parameters/TraceSpan.yml"

--- a/src/common/paths/tasks_taskID_runs_runID_retry.yml
+++ b/src/common/paths/tasks_taskID_runs_runID_retry.yml
@@ -1,7 +1,7 @@
 post:
   operationId: PostTasksIDRunsIDRetry
   tags:
-    - Tasks
+    - Data I/O endpoints
   summary: Retry a task run
   requestBody:
     content:

--- a/src/common/paths/users.yml
+++ b/src/common/paths/users.yml
@@ -2,7 +2,6 @@ get:
   operationId: GetUsers
   tags:
     - Security and access endpoints
-    - Users
   summary: List all users
   parameters:
     - $ref: "../../common/parameters/TraceSpan.yml"
@@ -30,7 +29,7 @@ get:
 post:
   operationId: PostUsers
   tags:
-    - Users
+    - Security and access endpoints
   summary: Create a user
   parameters:
     - $ref: "../../common/parameters/TraceSpan.yml"

--- a/src/common/paths/users_userID.yml
+++ b/src/common/paths/users_userID.yml
@@ -2,7 +2,6 @@ get:
   operationId: GetUsersID
   tags:
     - Security and access endpoints
-    - Users
   summary: Retrieve a user
   parameters:
     - $ref: "../../common/parameters/TraceSpan.yml"
@@ -25,7 +24,7 @@ get:
 patch:
   operationId: PatchUsersID
   tags:
-    - Users
+    - Security and access endpoints
   summary: Update a user
   requestBody:
     description: User update to apply
@@ -55,7 +54,7 @@ patch:
 delete:
   operationId: DeleteUsersID
   tags:
-    - Users
+    - Security and access endpoints
   summary: Delete a user
   parameters:
     - $ref: "../../common/parameters/TraceSpan.yml"

--- a/src/common/paths/users_userID_password.yml
+++ b/src/common/paths/users_userID_password.yml
@@ -2,7 +2,6 @@ post:
   operationId: PostUsersIDPassword
   tags:
     - Security and access endpoints
-    - Users
   summary: Update a password
   description: |
     #### InfluxDB Cloud

--- a/src/common/paths/write.yml
+++ b/src/common/paths/write.yml
@@ -2,7 +2,6 @@ post:
   operationId: PostWrite
   tags:
     - Data I/O endpoints
-    - Write
   summary: Write data
   description: |
     Writes data to a bucket.

--- a/src/oss/paths/config.yml
+++ b/src/oss/paths/config.yml
@@ -1,7 +1,6 @@
 get:
   operationId: GetConfig
   tags:
-    - Config
     - System information endpoints
   summary: Retrieve runtime configuration
   description: |

--- a/src/oss/paths/health.yml
+++ b/src/oss/paths/health.yml
@@ -1,7 +1,6 @@
 get:
   operationId: GetHealth
   tags:
-    - Health
     - System information endpoints
   summary: Retrieve the health of the instance
   description: Returns the health of the instance.

--- a/src/oss/paths/metrics.yml
+++ b/src/oss/paths/metrics.yml
@@ -1,7 +1,6 @@
 get:
   operationId: GetMetrics
   tags:
-    - Metrics
     - System information endpoints
   summary: Retrieve workload performance metrics
   description: |

--- a/src/oss/paths/ready.yml
+++ b/src/oss/paths/ready.yml
@@ -1,7 +1,6 @@
 get:
   operationId: GetReady
   tags:
-    - Ready
     - System information endpoints
   summary: Get the readiness of an instance at startup
   servers:

--- a/src/svc/invocable-scripts/paths/scripts.yml
+++ b/src/svc/invocable-scripts/paths/scripts.yml
@@ -2,7 +2,6 @@ get:
   operationId: GetScripts
   tags:
     - Data I/O endpoints
-    - Invokable Scripts
   summary: List scripts
   description: |
     Retrieves a list of [scripts](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/).
@@ -87,7 +86,7 @@ get:
 post:
   operationId: PostScripts
   tags:
-    - Invokable Scripts
+    - Data I/O endpoints
   summary: Create a script
   description: |
     Creates an [invokable script](https://docs.influxdata.com/resources/videos/api-invokable-scripts/)

--- a/src/svc/invocable-scripts/paths/scripts_scriptID.yml
+++ b/src/svc/invocable-scripts/paths/scripts_scriptID.yml
@@ -2,7 +2,6 @@ get:
   operationId: GetScriptsID
   tags:
     - Data I/O endpoints
-    - Invokable Scripts
   summary: Retrieve a script
   description: Uses script ID to retrieve details of an invokable script.
   parameters:
@@ -25,7 +24,7 @@ get:
 patch:
   operationId: PatchScriptsID
   tags:
-    - Invokable Scripts
+    - Data I/O endpoints
   summary: Update a script
   description: |
     Updates properties (`name`, `description`, and `script`) of an invokable script.
@@ -56,7 +55,7 @@ patch:
 delete:
   operationId: DeleteScriptsID
   tags:
-    - Invokable Scripts
+    - Data I/O endpoints
   summary: Delete a script
   description: Deletes a script and all associated records.
   parameters:

--- a/src/svc/invocable-scripts/paths/scripts_scriptID_invoke.yml
+++ b/src/svc/invocable-scripts/paths/scripts_scriptID_invoke.yml
@@ -2,7 +2,6 @@ post:
   operationId: PostScriptsIDInvoke
   tags:
     - Data I/O endpoints
-    - Invokable Scripts
   summary: Invoke a script
   description: Invokes a script and substitutes `params` keys referenced in the script with `params` key-values sent in the request body.
   parameters:


### PR DESCRIPTION
This PR fixes the codegen used by the CLI tool, which broke in https://github.com/influxdata/openapi/pull/427. The root of the problem is when the generator sees an operation with multiple tags (eg. `Delete` and `Data I/O endpoints`), it will generate conflicting definitions in each tag's interface. To fix this, the tags have been condensed into the more general grouping tag, in the example case the `Data I/O endpoints` take would replace the `Delete` tag.

Note there is also a fix to additional broken codegen introduced in https://github.com/influxdata/openapi/pull/360, where the 400 status error type has been changed to `Error.yml` instead of the more specific `BadRequestError.yml`, which wouldn't compile. Affects `src/common/paths/tasks.yml`