### PR TITLE
fix: removed incorrect schema tag in PostTasks 400 response to fix CLI codegen

### DIFF
--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -2808,21 +2808,18 @@ paths:
 
               - Returns this error if the task doesn't contain one of _`flux`_ or _`scriptID`_.
               - Returns this error if the task contains _`flux`_ _and_ _`scriptID`_.
-          content:
-            application/json:
-              schema:
-                $ref: '#/paths/~1tasks~1%7BtaskID%7D/get/responses/400'
-              examples:
-                fluxAndScriptError:
-                  summary: The request body can't contain both flux and scriptID
-                  value:
-                    code: invalid
-                    message: 'failed to decode request: can not provide both scriptID and flux'
-                missingFluxError:
-                  summary: The request body requires either flux or scriptID
-                  value:
-                    code: invalid
-                    message: 'failed to decode request: flux required'
+          $ref: '#/paths/~1tasks~1%7BtaskID%7D/get/responses/400'
+          examples:
+            fluxAndScriptError:
+              summary: The request body can't contain both flux and scriptID
+              value:
+                code: invalid
+                message: 'failed to decode request: can not provide both scriptID and flux'
+            missingFluxError:
+              summary: The request body requires either flux or scriptID
+              value:
+                code: invalid
+                message: 'failed to decode request: flux required'
         '401':
           $ref: '#/paths/~1tasks/get/responses/401'
         '500':

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -10347,26 +10347,20 @@
           },
           "400": {
             "description": "Bad request\n\n#### InfluxDB Cloud\n\n  - Returns this error if the task doesn't contain one of _`flux`_ or _`scriptID`_.\n  - Returns this error if the task contains _`flux`_ _and_ _`scriptID`_.\n",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/responses/BadRequestError"
-                },
-                "examples": {
-                  "fluxAndScriptError": {
-                    "summary": "The request body can't contain both flux and scriptID",
-                    "value": {
-                      "code": "invalid",
-                      "message": "failed to decode request: can not provide both scriptID and flux"
-                    }
-                  },
-                  "missingFluxError": {
-                    "summary": "The request body requires either flux or scriptID",
-                    "value": {
-                      "code": "invalid",
-                      "message": "failed to decode request: flux required"
-                    }
-                  }
+            "$ref": "#/components/responses/BadRequestError",
+            "examples": {
+              "fluxAndScriptError": {
+                "summary": "The request body can't contain both flux and scriptID",
+                "value": {
+                  "code": "invalid",
+                  "message": "failed to decode request: can not provide both scriptID and flux"
+                }
+              },
+              "missingFluxError": {
+                "summary": "The request body requires either flux or scriptID",
+                "value": {
+                  "code": "invalid",
+                  "message": "failed to decode request: flux required"
                 }
               }
             }

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -7063,21 +7063,18 @@ paths:
 
               - Returns this error if the task doesn't contain one of _`flux`_ or _`scriptID`_.
               - Returns this error if the task contains _`flux`_ _and_ _`scriptID`_.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/responses/BadRequestError'
-              examples:
-                fluxAndScriptError:
-                  summary: The request body can't contain both flux and scriptID
-                  value:
-                    code: invalid
-                    message: 'failed to decode request: can not provide both scriptID and flux'
-                missingFluxError:
-                  summary: The request body requires either flux or scriptID
-                  value:
-                    code: invalid
-                    message: 'failed to decode request: flux required'
+          $ref: '#/components/responses/BadRequestError'
+          examples:
+            fluxAndScriptError:
+              summary: The request body can't contain both flux and scriptID
+              value:
+                code: invalid
+                message: 'failed to decode request: can not provide both scriptID and flux'
+            missingFluxError:
+              summary: The request body requires either flux or scriptID
+              value:
+                code: invalid
+                message: 'failed to decode request: flux required'
         '401':
           $ref: '#/components/responses/AuthorizationError'
         '500':

--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -1411,7 +1411,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
     get:
       operationId: GetSources
       tags:
@@ -1436,7 +1436,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   '/sources/{sourceID}':
     delete:
       operationId: DeleteSourcesID
@@ -1459,13 +1459,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
         default:
           description: Unexpected error
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
     patch:
       operationId: PatchSourcesID
       tags:
@@ -1498,13 +1498,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
         default:
           description: Unexpected error
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
     get:
       operationId: GetSourcesID
       tags:
@@ -1530,13 +1530,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
         default:
           description: Unexpected error
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   '/sources/{sourceID}/health':
     get:
       operationId: GetSourcesIDHealth
@@ -1569,7 +1569,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   '/sources/{sourceID}/buckets':
     get:
       operationId: GetSourcesIDBuckets
@@ -1610,13 +1610,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
         default:
           description: Unexpected error
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   /scrapers:
     get:
       operationId: GetScrapers
@@ -1680,7 +1680,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   '/scrapers/{scraperTargetID}':
     get:
       operationId: GetScrapersID
@@ -1707,7 +1707,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
     delete:
       operationId: DeleteScrapersID
       tags:
@@ -1729,7 +1729,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
     patch:
       operationId: PatchScrapersID
       summary: Update a scraper target
@@ -1762,7 +1762,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   '/scrapers/{scraperTargetID}/labels':
     get:
       operationId: GetScrapersIDLabels
@@ -1794,7 +1794,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
     post:
       operationId: PostScrapersIDLabels
       tags:
@@ -1854,7 +1854,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   '/scrapers/{scraperTargetID}/labels/{labelID}':
     delete:
       operationId: DeleteScrapersIDLabelsID
@@ -1883,13 +1883,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
         default:
           description: Unexpected error
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   '/scrapers/{scraperTargetID}/members':
     get:
       operationId: GetScrapersIDMembers
@@ -1927,7 +1927,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
     post:
       operationId: PostScrapersIDMembers
       tags:
@@ -1968,7 +1968,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   '/scrapers/{scraperTargetID}/members/{userID}':
     delete:
       operationId: DeleteScrapersIDMembersID
@@ -1997,7 +1997,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   '/scrapers/{scraperTargetID}/owners':
     get:
       operationId: GetScrapersIDOwners
@@ -2035,7 +2035,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
     post:
       operationId: PostScrapersIDOwners
       tags:
@@ -2083,7 +2083,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   '/scrapers/{scraperTargetID}/owners/{userID}':
     delete:
       operationId: DeleteScrapersIDOwnersID
@@ -2112,7 +2112,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   /backup/kv:
     get:
       operationId: GetBackupKV
@@ -2227,7 +2227,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
         default:
           description: Unexpected error
           $ref: '#/paths/~1config/get/responses/401'
@@ -2468,7 +2468,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
         default:
           $ref: '#/paths/~1config/get/responses/401'
   /remotes:
@@ -4479,7 +4479,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
     get:
       operationId: GetDashboards
       tags:
@@ -4554,7 +4554,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   /tasks:
     get:
       operationId: GetTasks
@@ -4718,7 +4718,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
               examples:
                 tokenNotAuthorized:
                   summary: Token is not authorized to access a resource
@@ -4732,7 +4732,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
         default:
           $ref: '#/paths/~1config/get/responses/401'
     post:
@@ -4770,22 +4770,6 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks~1%7BtaskID%7D/get/responses/400'
-              examples:
-                missingFluxError:
-                  summary: Task in request body is missing Flux query
-                  value:
-                    code: invalid
-                    message: 'failed to decode request: missing flux'
-        '401':
-          $ref: '#/paths/~1tasks/get/responses/401'
-        '500':
-          $ref: '#/paths/~1tasks/get/responses/500'
-        default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
                 properties:
                   code:
                     description: code is the machine-readable error code.
@@ -4819,6 +4803,22 @@ paths:
                     type: string
                 required:
                   - code
+              examples:
+                missingFluxError:
+                  summary: Task in request body is missing Flux query
+                  value:
+                    code: invalid
+                    message: 'failed to decode request: missing flux'
+        '401':
+          $ref: '#/paths/~1tasks/get/responses/401'
+        '500':
+          $ref: '#/paths/~1tasks/get/responses/500'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
       x-codeSamples:
         - lang: Shell
           label: 'cURL: create a task'
@@ -4874,7 +4874,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
               examples:
                 orgProvidedNotFound:
                   summary: The org or orgID passed doesn't own the token passed in the header
@@ -4896,7 +4896,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
               examples:
                 org-not-found:
                   summary: Organization name not found

--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -1411,7 +1411,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
     get:
       operationId: GetSources
       tags:
@@ -1436,7 +1436,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
   '/sources/{sourceID}':
     delete:
       operationId: DeleteSourcesID
@@ -1459,13 +1459,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
         default:
           description: Unexpected error
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
     patch:
       operationId: PatchSourcesID
       tags:
@@ -1498,13 +1498,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
         default:
           description: Unexpected error
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
     get:
       operationId: GetSourcesID
       tags:
@@ -1530,13 +1530,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
         default:
           description: Unexpected error
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
   '/sources/{sourceID}/health':
     get:
       operationId: GetSourcesIDHealth
@@ -1569,7 +1569,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
   '/sources/{sourceID}/buckets':
     get:
       operationId: GetSourcesIDBuckets
@@ -1610,13 +1610,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
         default:
           description: Unexpected error
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
   /scrapers:
     get:
       operationId: GetScrapers
@@ -1680,7 +1680,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
   '/scrapers/{scraperTargetID}':
     get:
       operationId: GetScrapersID
@@ -1707,7 +1707,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
     delete:
       operationId: DeleteScrapersID
       tags:
@@ -1729,7 +1729,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
     patch:
       operationId: PatchScrapersID
       summary: Update a scraper target
@@ -1762,7 +1762,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
   '/scrapers/{scraperTargetID}/labels':
     get:
       operationId: GetScrapersIDLabels
@@ -1794,7 +1794,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
     post:
       operationId: PostScrapersIDLabels
       tags:
@@ -1854,7 +1854,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
   '/scrapers/{scraperTargetID}/labels/{labelID}':
     delete:
       operationId: DeleteScrapersIDLabelsID
@@ -1883,13 +1883,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
         default:
           description: Unexpected error
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
   '/scrapers/{scraperTargetID}/members':
     get:
       operationId: GetScrapersIDMembers
@@ -1927,7 +1927,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
     post:
       operationId: PostScrapersIDMembers
       tags:
@@ -1968,7 +1968,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
   '/scrapers/{scraperTargetID}/members/{userID}':
     delete:
       operationId: DeleteScrapersIDMembersID
@@ -1997,7 +1997,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
   '/scrapers/{scraperTargetID}/owners':
     get:
       operationId: GetScrapersIDOwners
@@ -2035,7 +2035,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
     post:
       operationId: PostScrapersIDOwners
       tags:
@@ -2083,7 +2083,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
   '/scrapers/{scraperTargetID}/owners/{userID}':
     delete:
       operationId: DeleteScrapersIDOwnersID
@@ -2112,7 +2112,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
   /backup/kv:
     get:
       operationId: GetBackupKV
@@ -2227,7 +2227,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
         default:
           description: Unexpected error
           $ref: '#/paths/~1config/get/responses/401'
@@ -2468,7 +2468,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
         default:
           $ref: '#/paths/~1config/get/responses/401'
   /remotes:
@@ -4479,7 +4479,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
     get:
       operationId: GetDashboards
       tags:
@@ -4554,7 +4554,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
   /tasks:
     get:
       operationId: GetTasks
@@ -4718,7 +4718,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
               examples:
                 tokenNotAuthorized:
                   summary: Token is not authorized to access a resource
@@ -4732,7 +4732,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
         default:
           $ref: '#/paths/~1config/get/responses/401'
     post:
@@ -4767,6 +4767,19 @@ paths:
                 $ref: '#/components/schemas/Task'
         '400':
           description: Bad request
+          $ref: '#/paths/~1tasks~1%7BtaskID%7D/get/responses/400'
+          examples:
+            missingFluxError:
+              summary: Task in request body is missing Flux query
+              value:
+                code: invalid
+                message: 'failed to decode request: missing flux'
+        '401':
+          $ref: '#/paths/~1tasks/get/responses/401'
+        '500':
+          $ref: '#/paths/~1tasks/get/responses/500'
+        default:
+          description: Unexpected error
           content:
             application/json:
               schema:
@@ -4803,22 +4816,6 @@ paths:
                     type: string
                 required:
                   - code
-              examples:
-                missingFluxError:
-                  summary: Task in request body is missing Flux query
-                  value:
-                    code: invalid
-                    message: 'failed to decode request: missing flux'
-        '401':
-          $ref: '#/paths/~1tasks/get/responses/401'
-        '500':
-          $ref: '#/paths/~1tasks/get/responses/500'
-        default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
       x-codeSamples:
         - lang: Shell
           label: 'cURL: create a task'
@@ -4874,7 +4871,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
               examples:
                 orgProvidedNotFound:
                   summary: The org or orgID passed doesn't own the token passed in the header
@@ -4896,7 +4893,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
               examples:
                 org-not-found:
                   summary: Organization name not found

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -12845,19 +12845,13 @@
           },
           "400": {
             "description": "Bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                },
-                "examples": {
-                  "missingFluxError": {
-                    "summary": "Task in request body is missing Flux query",
-                    "value": {
-                      "code": "invalid",
-                      "message": "failed to decode request: missing flux"
-                    }
-                  }
+            "$ref": "#/components/responses/BadRequestError",
+            "examples": {
+              "missingFluxError": {
+                "summary": "Task in request body is missing Flux query",
+                "value": {
+                  "code": "invalid",
+                  "message": "failed to decode request: missing flux"
                 }
               }
             }

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -12848,7 +12848,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/responses/BadRequestError"
+                  "$ref": "#/components/schemas/Error"
                 },
                 "examples": {
                   "missingFluxError": {

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -8890,16 +8890,13 @@ paths:
                 $ref: '#/components/schemas/Task'
         '400':
           description: Bad request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missingFluxError:
-                  summary: Task in request body is missing Flux query
-                  value:
-                    code: invalid
-                    message: 'failed to decode request: missing flux'
+          $ref: '#/components/responses/BadRequestError'
+          examples:
+            missingFluxError:
+              summary: Task in request body is missing Flux query
+              value:
+                code: invalid
+                message: 'failed to decode request: missing flux'
         '401':
           $ref: '#/components/responses/AuthorizationError'
         '500':

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -8893,7 +8893,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/responses/BadRequestError'
+                $ref: '#/components/schemas/Error'
               examples:
                 missingFluxError:
                   summary: Task in request body is missing Flux query

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -11532,22 +11532,7 @@ paths:
           description: Success. The response body contains a `tasks` list with the
             new task.
         "400":
-          content:
-            application/json:
-              examples:
-                fluxAndScriptError:
-                  summary: The request body can't contain both flux and scriptID
-                  value:
-                    code: invalid
-                    message: 'failed to decode request: can not provide both scriptID
-                      and flux'
-                missingFluxError:
-                  summary: The request body requires either flux or scriptID
-                  value:
-                    code: invalid
-                    message: 'failed to decode request: flux required'
-              schema:
-                $ref: '#/components/responses/BadRequestError'
+          $ref: '#/components/responses/BadRequestError'
           description: |
             Bad request
 
@@ -11555,6 +11540,18 @@ paths:
 
               - Returns this error if the task doesn't contain one of _`flux`_ or _`scriptID`_.
               - Returns this error if the task contains _`flux`_ _and_ _`scriptID`_.
+          examples:
+            fluxAndScriptError:
+              summary: The request body can't contain both flux and scriptID
+              value:
+                code: invalid
+                message: 'failed to decode request: can not provide both scriptID
+                  and flux'
+            missingFluxError:
+              summary: The request body requires either flux or scriptID
+              value:
+                code: invalid
+                message: 'failed to decode request: flux required'
         "401":
           $ref: '#/components/responses/AuthorizationError'
         "500":

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -13130,7 +13130,7 @@ paths:
                     code: invalid
                     message: 'failed to decode request: missing flux'
               schema:
-                $ref: '#/components/responses/BadRequestError'
+                $ref: '#/components/schemas/Error'
           description: Bad request
         "401":
           $ref: '#/components/responses/AuthorizationError'

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -13121,17 +13121,14 @@ paths:
           description: Success. The response body contains a `tasks` list with the
             new task.
         "400":
-          content:
-            application/json:
-              examples:
-                missingFluxError:
-                  summary: Task in request body is missing Flux query
-                  value:
-                    code: invalid
-                    message: 'failed to decode request: missing flux'
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/BadRequestError'
           description: Bad request
+          examples:
+            missingFluxError:
+              summary: Task in request body is missing Flux query
+              value:
+                code: invalid
+                message: 'failed to decode request: missing flux'
         "401":
           $ref: '#/components/responses/AuthorizationError'
         "500":

--- a/src/cloud/paths/tasks.yml
+++ b/src/cloud/paths/tasks.yml
@@ -176,25 +176,22 @@ post:
 
           - Returns this error if the task doesn't contain one of _`flux`_ or _`scriptID`_.
           - Returns this error if the task contains _`flux`_ _and_ _`scriptID`_.
-      content:
-        application/json:
-          schema:
-            $ref: "../../common/responses/BadRequestError.yml"
-          examples:
-            fluxAndScriptError:
-              summary: The request body can't contain both flux and scriptID
-              value:
-                {
-                  "code": "invalid",
-                  "message": "failed to decode request: can not provide both scriptID and flux"
-                }
-            missingFluxError:
-              summary: The request body requires either flux or scriptID
-              value:
-                {
-                  "code": "invalid",
-                  "message": "failed to decode request: flux required"
-                }
+      $ref: "../../common/responses/BadRequestError.yml"
+      examples:
+        fluxAndScriptError:
+          summary: The request body can't contain both flux and scriptID
+          value:
+            {
+              "code": "invalid",
+              "message": "failed to decode request: can not provide both scriptID and flux"
+            }
+        missingFluxError:
+          summary: The request body requires either flux or scriptID
+          value:
+            {
+              "code": "invalid",
+              "message": "failed to decode request: flux required"
+            }
     "401":
       $ref: "../../common/responses/AuthorizationError.yml"
     "500":

--- a/src/common/paths/tasks.yml
+++ b/src/common/paths/tasks.yml
@@ -200,7 +200,7 @@ post:
       content:
         application/json:
           schema:
-            $ref: "../responses/BadRequestError.yml"
+            $ref: "../schemas/Error.yml"
           examples:
             missingFluxError:
               summary: Task in request body is missing Flux query

--- a/src/common/paths/tasks.yml
+++ b/src/common/paths/tasks.yml
@@ -197,17 +197,14 @@ post:
             $ref: "../schemas/Task.yml"
     "400":
       description: Bad request
-      content:
-        application/json:
-          schema:
-            $ref: "../schemas/Error.yml"
-          examples:
-            missingFluxError:
-              summary: Task in request body is missing Flux query
-              value: {
-                "code":"invalid",
-                "message": "failed to decode request: missing flux"
-                }
+      $ref: "../responses/BadRequestError.yml"
+      examples:
+        missingFluxError:
+          summary: Task in request body is missing Flux query
+          value: {
+            "code":"invalid",
+            "message": "failed to decode request: missing flux"
+            }
     "401":
       $ref: "../responses/AuthorizationError.yml"
     "500":


### PR DESCRIPTION
In `tasks.yml`, the 400 response of the `PostTasks` operation has an incorrect `content/application/schema` tag structure that no other responses use. This has now been flattened and the `description`/`examples` tags moved up.