### PR TITLE
chore: Add endpoint for getting orgs by account

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -165,6 +165,34 @@ paths:
         default:
           description: Unexpected error
           $ref: '#/components/responses/ServerError'
+  '/accounts/{accountId}/orgs':
+    get:
+      operationId: GetAccountOrganizations
+      tags:
+        - Accounts
+        - Organizations
+      summary: Get the list of Organizations for the given Account
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: path
+          name: accountId
+          schema:
+            type: string
+          required: true
+          description: The ID of the Account for which to list Organizations.
+      responses:
+        '200':
+          description: Organizations
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationSummaries'
+        '401':
+          description: Unauthorized
+          $ref: '#/components/responses/ServerError'
+        default:
+          description: Unexpected error
+          $ref: '#/components/responses/ServerError'
   /accounts/default:
     put:
       operationId: PutDefaultAccount

--- a/src/unity.yml
+++ b/src/unity.yml
@@ -15,6 +15,8 @@ paths:
     $ref: './unity/paths/accounts.yml'
   '/accounts/{accountId}':
     $ref: './unity/paths/accounts_accountId.yml'
+  '/accounts/{accountId}/orgs':
+    $ref: './unity/paths/accounts_accountId_orgs.yml'
   '/accounts/default':
     $ref: './unity/paths/accounts_default.yml'
   '/billing':

--- a/src/unity/paths/accounts_accountId_orgs.yml
+++ b/src/unity/paths/accounts_accountId_orgs.yml
@@ -1,0 +1,27 @@
+get:
+  operationId: GetAccountOrganizations
+  tags:
+    - Accounts
+    - Organizations
+  summary: Get the list of Organizations for the given Account
+  parameters:
+    - $ref: "../../common/parameters/TraceSpan.yml"
+    - in: path
+      name: accountId
+      schema:
+        type: string
+      required: true
+      description: The ID of the Account for which to list Organizations.
+  responses:
+    '200':
+      description: Organizations
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/OrganizationSummaries.yml'
+    '401':
+      description: Unauthorized
+      $ref: '../../common/responses/ServerError.yml'
+    default:
+      description: Unexpected error
+      $ref: '../../common/responses/ServerError.yml'


### PR DESCRIPTION
part of https://github.com/influxdata/quartz/issues/6604

Adds endpoint for returning a list of Organizations for the given account. Returns the same payload as `/orgs`.