### PR TITLE
Docs/404 create a task

### DIFF
--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -625,7 +625,7 @@ paths:
                     code: invalid
                     message: At least one field column is required
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   '/buckets/{bucketID}/schema/measurements/{measurementID}':
     summary: Bucket Schema
     get:
@@ -720,7 +720,7 @@ paths:
                     code: invalid
                     message: Unable to delete columns from schema
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   '/orgs/{orgID}/limits':
     get:
       tags:
@@ -1658,7 +1658,7 @@ paths:
                                                               type: string
                                                             latestCompleted:
                                                               type: string
-                                                              description: 'Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.'
+                                                              description: 'A timestamp ([RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp)) of the latest scheduled and completed run.'
                                                               format: date-time
                                                               readOnly: true
                                                             lastRunStatus:
@@ -2516,7 +2516,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
     get:
       operationId: GetDashboards
       tags:
@@ -2603,7 +2603,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   /tasks:
     get:
       operationId: GetTasks
@@ -2690,10 +2690,12 @@ paths:
             type: integer
             minimum: 0
             default: 0
-          description: The number of records to skip
+          description: The number of records to skip.
         - in: query
           name: sortBy
-          description: Field that records should be sorted by
+          description: |
+            The field used for sorting records in the list.
+            Only `name` is supported.
           required: false
           schema:
             type: string
@@ -2732,7 +2734,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
               examples:
                 tokenNotAuthorized:
                   summary: Token is not authorized to access a resource
@@ -2746,16 +2748,16 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
         default:
           description: Non 2XX error response from server.
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
       x-codeSamples:
         - lang: Shell
-          label: 'cURL: all tasks, `basic` output'
+          label: 'cURL: all tasks, basic output'
           source: |
             curl https://cloud2.influxdata.com/api/v2/tasks/?limit=-1&type=basic \
               --header 'Content-Type: application/json' \
@@ -2781,7 +2783,8 @@ paths:
 
         #### Related guides
 
-        - [Create a task]({{% INFLUXDB_DOCS_URL %}}/process-data/manage-tasks/create-task/).
+        - [Get started with tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/get-started/)
+        - [Create a task]({{% INFLUXDB_DOCS_URL %}}/process-data/manage-tasks/create-task/)
         - [Common tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/common-tasks/)
         - [Task configuration options]({{% INFLUXDB_DOCS_URL %}}/process-data/task-options/)
       parameters:
@@ -2802,30 +2805,13 @@ paths:
                 $ref: '#/components/schemas/Task'
         '400':
           description: |
-            Bad request
+            Bad request.
+            The response body contains detail about the error.
 
             #### InfluxDB Cloud
 
               - Returns this error if the task doesn't contain one of _`flux`_ or _`scriptID`_.
               - Returns this error if the task contains _`flux`_ _and_ _`scriptID`_.
-          $ref: '#/paths/~1tasks~1%7BtaskID%7D/get/responses/400'
-          examples:
-            fluxAndScriptError:
-              summary: The request body can't contain both flux and scriptID
-              value:
-                code: invalid
-                message: 'failed to decode request: can not provide both scriptID and flux'
-            missingFluxError:
-              summary: The request body requires either flux or scriptID
-              value:
-                code: invalid
-                message: 'failed to decode request: flux required'
-        '401':
-          $ref: '#/paths/~1tasks/get/responses/401'
-        '500':
-          $ref: '#/paths/~1tasks/get/responses/500'
-        default:
-          description: Unexpected error
           content:
             application/json:
               schema:
@@ -2862,44 +2848,63 @@ paths:
                     type: string
                 required:
                   - code
+              examples:
+                fluxAndScriptError:
+                  summary: The request body can't contain both flux and scriptID
+                  value:
+                    code: invalid
+                    message: 'failed to decode request: can not provide both scriptID and flux'
+                missingFluxError:
+                  summary: The request body requires either a flux parameter or scriptID parameter
+                  value:
+                    code: invalid
+                    message: 'failed to decode request: flux required'
+        '401':
+          $ref: '#/paths/~1tasks/get/responses/401'
+        '500':
+          $ref: '#/paths/~1tasks/get/responses/500'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
       x-codeSamples:
         - lang: Shell
-          label: 'cURL: create a flux query task'
+          label: 'cURL: create a Flux script task'
           source: |
-            curl -v --request POST \
-            https://cloud2.influxdata.com/api/v2/tasks \
+            curl https://cloud2.influxdata.com/api/v2/tasks \
             --header "Content-type: application/json" \
             --header "Authorization: Token INFLUX_TOKEN" \
             --data-binary @- << EOF
               {
-              "orgID": "INFLUX_ORG_ID",
-              "description": "IoT Center 30d environment average.",
-              "flux": "option task = {name: \"iot-center-task-1\", every: 30m}\
-                      from(bucket: \"iot_center\")\
-                        |> range(start: -30d)\
-                        |> filter(fn: (r) => r._measurement == \"environment\")\
-                        |> aggregateWindow(every: 1h, fn: mean)"
+                "orgID": "INFLUX_ORG_ID",
+                "description": "IoT Center 30d environment average.",
+                "flux": "option task = {name: \"iot-center-task-1\", every: 30m}\
+                        from(bucket: \"iot_center\")\
+                          |> range(start: -30d)\
+                          |> filter(fn: (r) => r._measurement == \"environment\")\
+                          |> aggregateWindow(every: 1h, fn: mean)"
               }
             EOF
         - lang: Shell
-          label: 'cURL: create a script task'
+          label: 'cURL: create a Flux script reference task'
           source: |
-            curl -v --request POST \
-            https://cloud2.influxdata.com/api/v2/tasks \
+            curl https://cloud2.influxdata.com/api/v2/tasks \
             --header "Content-type: application/json" \
             --header "Authorization: Token INFLUX_TOKEN" \
             --data-binary @- << EOF
               {
-              "orgID": "INFLUX_ORG_ID",
-              "description": "IoT Center 30d environment average.",
-              "scriptID": "085138a111448000",
-              "scriptParameters":
-                {
-                  "rangeStart": "-30d",
-                  "bucket": "air_sensor",
-                  "filterField": "temperature",
-                  "groupColumn": "_time"
-                }
+                "orgID": "INFLUX_ORG_ID",
+                "description": "IoT Center 30d environment average.",
+                "scriptID": "085138a111448000",
+                "scriptParameters":
+                  {
+                    "rangeStart": "-30d",
+                    "bucket": "air_sensor",
+                    "filterField": "temperature",
+                    "groupColumn": "_time"
+                  }
               }
             EOF
   '/tasks/{taskID}':
@@ -2911,7 +2916,7 @@ paths:
       summary: Retrieve a task
       description: |
         Retrieves a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task)
-        by task ID.
+        by ID.
       parameters:
         - $ref: '#/paths/~1users/get/parameters/0'
         - in: path
@@ -2919,7 +2924,7 @@ paths:
           schema:
             type: string
           required: true
-          description: The task ID.
+          description: The ID of the task to retrieve.
       responses:
         '200':
           description: Success. The response body contains the task.
@@ -2938,7 +2943,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
               examples:
                 orgProvidedNotFound:
                   summary: The org or orgID passed doesn't own the token passed in the header
@@ -2960,7 +2965,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
               examples:
                 org-not-found:
                   summary: Organization name not found
@@ -2990,7 +2995,7 @@ paths:
         Updates a task and then cancels all scheduled runs of the task.
 
         Use this endpoint to modify task properties (for example: `cron`, `name`, `flux`, `status`).
-        Once InfluxDB applies the update, it cancels all scheduled runs of the task.
+        Once InfluxDB applies the update, it cancels all previously scheduled runs of the task.
 
         To update a task, pass an object that contains the updated key-value pairs.
         To activate or inactivate a task, set the `status` property.
@@ -3903,18 +3908,18 @@ components:
             - If you use the `flux` property, you can't use the `scriptID` and `scriptParameters` properties.
           type: string
         every:
-          description: 'The interval ([duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals))) at which the task runs. `every` also determines when the task first runs, depending on the specified time.'
+          description: 'The interval ([duration literal]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp)) at which the task runs. `every` also determines when the task first runs, depending on the specified time.'
           type: string
           format: duration
         cron:
-          description: 'A [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview) that defines the schedule on which the task runs. InfluxDB bases cron runs on the system time.'
+          description: 'A [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview) that defines the schedule on which the task runs. InfluxDB uses the system time when evaluating Cron expressions.'
           type: string
         offset:
           description: 'A [duration](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals) to delay execution of the task after the scheduled time has elapsed. `0` removes the offset.'
           type: string
           format: duration
         latestCompleted:
-          description: 'A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/flux/v0.x/data-types/basic/time/#time-syntax)) of the latest scheduled and completed run.'
+          description: 'A timestamp ([RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp)) of the latest scheduled and completed run.'
           type: string
           format: date-time
           readOnly: true

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -29,7 +29,7 @@
     },
     {
       "name": "Tasks",
-      "description": "Process and analyze your data with tasks in the InfluxDB task engine.\nWith tasks, you can schedule Flux scripts to query, analyze, modify, and act on data.\nIn InfluxDB Cloud, you can create tasks that run [invokable scripts](#tag/Invokable-Scripts)\nwith parameters.\n\nUse the `/api/v2/tasks` endpoints to create and manage tasks, retry task runs, and retrieve run logs.\n\n#### Related guides\n\n- [Common data processing tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/common-tasks/)\n- [Invoke custom scripts as API endpoints](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/)\n"
+      "description": "Process and analyze your data with tasks in the InfluxDB task engine.\nWith tasks, you can schedule Flux scripts to query, analyze, modify, and act on data.\nIn InfluxDB Cloud, you can create tasks that run [invokable scripts](#tag/Invokable-Scripts)\nwith parameters.\n\nUse the `/api/v2/tasks` endpoints to create and manage tasks, retry task runs, and retrieve run logs.\n\n#### Related guides\n\n- [Get started with tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/get-started/)\n- [Common data processing tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/common-tasks/)\n- [Create a script](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/#create-an-invokable-script).\n"
     },
     {
       "name": "Write",
@@ -58,7 +58,7 @@
     {
       "name": "Response codes",
       "x-traitTag": true,
-      "description": "The InfluxDB API uses standard HTTP status codes for success and failure responses.\nThe response body may include additional details. For details about a specific operation's response, see **Responses** and **Response Samples** for that operation.\n\nAPI operations may return the following HTTP status codes:\n\n| &nbsp;Code&nbsp; | Status                   | Description      |\n|:-----------:|:------------------------ |:--------------------- |\n| `200`       | Success                  |                       |\n| `204`       | No content               | For a `POST` request, `204` indicates that InfluxDB accepted the request and request data is valid. Asynchronous operations, such as `write`, might not have completed yet. |\n| `400`       | Bad request              | May indicate one of the following: <li>Line protocol is malformed. The response body contains the first malformed line in the data and indicates what was expected. For partial writes, the number of points written and the number of points rejected are also included. For more information, check the `rejected_points` measurement in your `_monitoring` bucket.</li><li>`Authorization` header is missing or malformed or the API token does not have permission for the operation.</li> |\n| `401`       | Unauthorized             | May indicate one of the following: <li>`Authorization: Token` header is missing or malformed</li><li>API token value is missing from the header</li><li>API token does not have permission. For more information about token types and permissions, see [Manage API tokens](https://docs.influxdata.com/influxdb/cloud/security/tokens/)</li> |\n| `404`       | Not found                | Requested resource was not found. `message` in the response body provides details about the requested resource. |\n| `413`       | Request entity too large | Request payload exceeds the size limit. |\n| `422`       | Unprocessable entity     | Request data is invalid. `code` and `message` in the response body provide details about the problem. |\n| `429`       | Too many requests        | API token is temporarily over the request quota. The `Retry-After` header describes when to try the request again. |\n| `500`       | Internal server error    |                       |\n| `503`       | Service unavailable      | Server is temporarily unavailable to process the request. The `Retry-After` header describes when to try the request again. |\n"
+      "description": "The InfluxDB API uses standard HTTP status codes for success and failure responses.\nThe response body may include additional details. For details about a specific operation's response, see **Responses** and **Response Samples** for that operation.\n\nAPI operations may return the following HTTP status codes:\n\n| &nbsp;Code&nbsp; | Status                   | Description      |\n|:-----------:|:------------------------ |:--------------------- |\n| `200`       | Success                  |                       |\n| `204`       | No content               | For a `POST` request, `204` indicates that InfluxDB accepted the request and request data is valid. Asynchronous operations, such as `write`, might not have completed yet. |\n| `400`       | Bad request              | May indicate one of the following: <ul><li>Line protocol is malformed. The response body contains the first malformed line in the data and indicates what was expected. For partial writes, the number of points written and the number of points rejected are also included. For more information, check the `rejected_points` measurement in your `_monitoring` bucket.</li><li>`Authorization` header is missing or malformed or the API token does not have permission for the operation.</li></ul> |\n| `401`       | Unauthorized             | May indicate one of the following: <ul><li>`Authorization: Token` header is missing or malformed</li><li>API token value is missing from the header</li><li>API token does not have permission. For more information about token types and permissions, see [Manage API tokens](https://docs.influxdata.com/influxdb/cloud/security/tokens/)</li></ul> |\n| `404`       | Not found                | Requested resource was not found. `message` in the response body provides details about the requested resource. |\n| `413`       | Request entity too large | Request payload exceeds the size limit. |\n| `422`       | Unprocessable entity     | Request data is invalid. `code` and `message` in the response body provide details about the problem. |\n| `429`       | Too many requests        | API token is temporarily over the request quota. The `Retry-After` header describes when to try the request again. |\n| `500`       | Internal server error    |                       |\n| `503`       | Service unavailable      | Server is temporarily unavailable to process the request. The `Retry-After` header describes when to try the request again. |\n"
     }
   ],
   "x-tagGroups": [
@@ -3140,7 +3140,7 @@
           "Query"
         ],
         "summary": "Generate a query Abstract Syntax Tree (AST)",
-        "description": "Analyzes a Flux query and returns a complete package source [Abstract Syntax\nTree (AST)](https://https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#abstract-syntax-tree)\nfor the query.\n\nUse this endpoint for deep query analysis such as debugging unexpected query\nresults.\n\nA Flux query AST provides a semantic, tree-like representation with contextual\ninformation about the query. The AST illustrates how the query is distributed\ninto different components for execution.\n\n\n#### Limitations\n\n-  The endpoint doesn't validate values in the query--for example:\n\n    The following query has correct syntax, but contains an incorrect `from()` property key:\n    ```json\n    { \"query\": \"from(foo: \\\"iot_center\\\")\\\n                |> range(start: -90d)\\\n                |> filter(fn: (r) => r._measurement == \\\"environment\\\")\"\n    }\n    ```\n    Passing this to `/api/v2/query/ast` will return a successful response\n    with a generated AST.\n",
+        "description": "Analyzes a Flux query and returns a complete package source [Abstract Syntax\nTree (AST)]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#abstract-syntax-tree-ast)\nfor the query.\n\nUse this endpoint for deep query analysis such as debugging unexpected query\nresults.\n\nA Flux query AST provides a semantic, tree-like representation with contextual\ninformation about the query. The AST illustrates how the query is distributed\ninto different components for execution.\n\n#### Limitations\n\n-  The endpoint doesn't validate values in the query--for example:\n\n    The following query has correct syntax, but contains an incorrect `from()` property key:\n\n    ```json\n    { \"query\": \"from(foo: \\\"iot_center\\\")\\\n                |> range(start: -90d)\\\n                |> filter(fn: (r) => r._measurement == \\\"environment\\\")\"\n    }\n    ```\n\n    Passing this to `/api/v2/query/ast` will return a successful response\n    with a generated AST.\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -3170,7 +3170,7 @@
           {
             "lang": "Shell",
             "label": "cURL",
-            "source": "curl --request POST 'INFLUX_URL/api/v2/query/ast' \\\n  --header 'Content-Type: application/json' \\\n  --header 'Accept: application/json \\\n  --header 'Authorization: Token INFLUX_TOKEN' \\\n  --data 'from(bucket: \"example-bucket\")\n            |> range(start: -5m)\n            |> filter(fn: (r) => r._measurement == \"example-measurement\")'\n"
+            "source": "curl --request POST 'http://localhost:8086/api/v2/query/ast' \\\n--header 'Content-Type: application/json' \\\n--header 'Accept: application/json' \\\n--header 'Authorization: Token INFLUX_TOKEN' \\\n--data 'from(bucket: \"example-bucket\")\n          |> range(start: -5m)\n          |> filter(fn: (r) => r._measurement == \"example-measurement\")'\n"
           }
         ],
         "responses": {
@@ -4770,7 +4770,7 @@
           "Query"
         ],
         "summary": "Analyze a Flux query",
-        "description": "Analyzes a [Flux query](https://docs.influxdata.com/flux/v0.x/) for syntax\nerrors and returns the list of errors.\n\nIn the following example `Query` object, `query` is missing a `from()` property key:\n\n    ```json\n    { \"query\": \"from(: \\\"iot_center\\\")\\\n                |> range(start: -90d)\\\n                |> filter(fn: (r) => r._measurement == \\\"environment\\\")\",\n      \"type\": \"flux\"\n    }\n    ```\n\nPassing this to `/api/v2/analyze` returns an `errors` list that contains an error object for the missing key.\n\n#### Limitations\n\n-  The endpoint doesn't validate values in the query--for example:\n\n  - The following query has correct syntax, but contains an incorrect `from()` property key:\n\n    ```json\n    { \"query\": \"from(foo: \\\"iot_center\\\")\\\n                |> range(start: -90d)\\\n                |> filter(fn: (r) => r._measurement == \\\"environment\\\")\",\n      \"type\": \"flux\"\n    }\n    ```\n\n    Passing this to `/api/v2/analyze` returns an empty `errors` list.\n",
+        "description": "Analyzes a [Flux query](https://docs.influxdata.com/flux/v0.x/) for syntax\nerrors and returns the list of errors.\n\nIn the following sample query, `from()` is missing the property key.\n\n    ```json\n    { \"query\": \"from(: \\\"iot_center\\\")\\\n                |> range(start: -90d)\\\n                |> filter(fn: (r) => r._measurement == \\\"environment\\\")\",\n      \"type\": \"flux\"\n    }\n    ```\n\nIf you pass this in a request to the `/api/v2/analyze` endpoint,\nInfluxDB returns an `errors` list that contains an error object for the missing key.\n\n#### Limitations\n\n-  The endpoint doesn't validate values in the query--for example:\n\n  - The following sample query has correct syntax, but contains an incorrect `from()` property key:\n\n    ```json\n    { \"query\": \"from(foo: \\\"iot_center\\\")\\\n                |> range(start: -90d)\\\n                |> filter(fn: (r) => r._measurement == \\\"environment\\\")\",\n      \"type\": \"flux\"\n    }\n    ```\n\n    If you pass this in a request to the `/api/v2/analyze` endpoint,\n    InfluxDB returns an empty `errors` list.\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -4807,7 +4807,7 @@
                 "examples": {
                   "missingQueryPropertyKey": {
                     "summary": "Missing property key error",
-                    "description": "Returns an error object if the Flux query is missing a property key.\n\nThe following example is missing the `bucket` property key:\n\n  ```json\n  {\n    \"query\": \"from(: \\\"iot_center\\\")\\\n\n    ...\n\n  }\n  ```\n",
+                    "description": "Returns an error object if the Flux query is missing a property key.\n\nThe following sample query is missing the _`bucket`_ property key:\n\n  ```json\n  {\n    \"query\": \"from(: \\\"iot_center\\\")\\\n\n    ...\n\n  }\n  ```\n",
                     "value": {
                       "errors": [
                         {
@@ -7080,6 +7080,7 @@
           "Tasks"
         ],
         "summary": "List runs for a task",
+        "description": "Retrieves a list of runs for a [task]({{% INFLUXDB_DOCS_URL %}}/process-data/).\n\nTo limit which task runs are returned, pass query parameters in your request.\nIf no query parameters are passed, InfluxDB returns all task runs up to the default `limit`.\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -7091,7 +7092,7 @@
               "type": "string"
             },
             "required": true,
-            "description": "The ID of the task to get runs for."
+            "description": "The ID of the task to get runs for.\nOnly returns runs for this task.\n"
           },
           {
             "in": "query",
@@ -7099,7 +7100,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Returns runs after a specific ID."
+            "description": "A task run ID. Only returns runs created after this run."
           },
           {
             "in": "query",
@@ -7110,7 +7111,7 @@
               "maximum": 500,
               "default": 100
             },
-            "description": "The number of runs to return"
+            "description": "Limits the number of task runs returned. Default is `100`.\n"
           },
           {
             "in": "query",
@@ -7119,7 +7120,7 @@
               "type": "string",
               "format": "date-time"
             },
-            "description": "Filter runs to those scheduled after this time, RFC3339"
+            "description": "A timestamp ([RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp)).\nOnly returns runs scheduled after this time.\n"
           },
           {
             "in": "query",
@@ -7128,12 +7129,12 @@
               "type": "string",
               "format": "date-time"
             },
-            "description": "Filter runs to those scheduled before this time, RFC3339"
+            "description": "A timestamp ([RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp)).\nOnly returns runs scheduled before this time.\n"
           }
         ],
         "responses": {
           "200": {
-            "description": "A list of task runs",
+            "description": "Success. The response body contains the list of task runs.",
             "content": {
               "application/json": {
                 "schema": {
@@ -7142,15 +7143,14 @@
               }
             }
           },
+          "401": {
+            "$ref": "#/components/responses/AuthorizationError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          },
           "default": {
-            "description": "Unexpected error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
+            "$ref": "#/components/responses/GeneralServerError"
           }
         }
       },
@@ -7160,7 +7160,8 @@
           "Data I/O endpoints",
           "Tasks"
         ],
-        "summary": "Manually start a task run, overriding the current schedule",
+        "summary": "Start a task run, overriding the schedule",
+        "description": "Schedules a task run to start immediately, ignoring scheduled runs.\n\nUse this endpoint to manually start a task run.\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -7185,7 +7186,7 @@
         },
         "responses": {
           "201": {
-            "description": "Run scheduled to start",
+            "description": "Success. The run is scheduled to start.",
             "content": {
               "application/json": {
                 "schema": {
@@ -7194,15 +7195,14 @@
               }
             }
           },
+          "401": {
+            "$ref": "#/components/responses/AuthorizationError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          },
           "default": {
-            "description": "Unexpected error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
+            "$ref": "#/components/responses/GeneralServerError"
           }
         }
       }
@@ -7455,7 +7455,7 @@
                 },
                 "examples": {
                   "taskSuccess": {
-                    "summary": "Events for successful task.",
+                    "summary": "Events for a successful task run.",
                     "value": {
                       "events": [
                         {
@@ -7472,7 +7472,7 @@
                     }
                   },
                   "taskFailure": {
-                    "summary": "Events for a failed task.",
+                    "summary": "Events for a failed task run.",
                     "value": {
                       "events": [
                         {
@@ -7533,7 +7533,7 @@
               "type": "string"
             },
             "required": true,
-            "description": "ID of task to get logs for."
+            "description": "The ID of the task to get logs for."
           },
           {
             "in": "path",
@@ -7542,29 +7542,75 @@
               "type": "string"
             },
             "required": true,
-            "description": "ID of run to get logs for."
+            "description": "The ID of the run to get logs for."
           }
         ],
         "responses": {
           "200": {
-            "description": "All logs for a run",
+            "description": "Success. The response body contains an `events` list with logs for the task run.\nEach log event `message` contains detail about the event.\nIf a run fails, InfluxDB logs an event with the reason for the failure.\n",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Logs"
+                },
+                "examples": {
+                  "taskSuccess": {
+                    "summary": "Events for a successful task run.",
+                    "value": {
+                      "events": [
+                        {
+                          "runID": "09b070dadaa7d000",
+                          "time": "2022-07-18T14:46:07.101231Z",
+                          "message": "Started task from script: \"option task = {name: \\\"task1\\\", every: 30m} from(bucket: \\\"iot_center\\\") |> range(start: -90d) |> filter(fn: (r) => r._measurement == \\\"environment\\\") |> aggregateWindow(every: 1h, fn: mean)\""
+                        },
+                        {
+                          "runID": "09b070dadaa7d000",
+                          "time": "2022-07-18T14:46:07.242859Z",
+                          "message": "Completed(success)"
+                        }
+                      ]
+                    }
+                  },
+                  "taskFailure": {
+                    "summary": "Events for a failed task.",
+                    "value": {
+                      "events": [
+                        {
+                          "runID": "09a946fc3167d000",
+                          "time": "2022-07-13T07:06:54.198167Z",
+                          "message": "Started task from script: \"option task = {name: \\\"test task\\\", every: 3d, offset: 0s}\""
+                        },
+                        {
+                          "runID": "09a946fc3167d000",
+                          "time": "2022-07-13T07:07:13.104037Z",
+                          "message": "Completed(failed)"
+                        },
+                        {
+                          "runID": "09a946fc3167d000",
+                          "time": "2022-07-13T08:24:37.115323Z",
+                          "message": "error exhausting result iterator: error in query specification while starting program: this Flux script returns no streaming data. Consider adding a \"yield\" or invoking streaming functions directly, without performing an assignment"
+                        }
+                      ]
+                    }
+                  }
                 }
               }
             }
           },
+          "400": {
+            "$ref": "#/components/responses/BadRequestError"
+          },
+          "401": {
+            "$ref": "#/components/responses/AuthorizationError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ResourceNotFoundError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          },
           "default": {
-            "description": "Unexpected error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
+            "$ref": "#/components/responses/GeneralServerError"
           }
         }
       }
@@ -11237,12 +11283,12 @@
               "minimum": 0,
               "default": 0
             },
-            "description": "The number of records to skip"
+            "description": "The number of records to skip."
           },
           {
             "in": "query",
             "name": "sortBy",
-            "description": "Field that records should be sorted by",
+            "description": "The field used for sorting records in the list.\nOnly `name` is supported.\n",
             "required": false,
             "schema": {
               "type": "string",
@@ -11290,7 +11336,7 @@
         "x-codeSamples": [
           {
             "lang": "Shell",
-            "label": "cURL: all tasks, `basic` output",
+            "label": "cURL: all tasks, basic output",
             "source": "curl https://cloud2.influxdata.com/api/v2/tasks/?limit=-1&type=basic \\\n  --header 'Content-Type: application/json' \\\n  --header 'Authorization: Token INFLUX_API_TOKEN'\n"
           }
         ]
@@ -11302,7 +11348,7 @@
           "Tasks"
         ],
         "summary": "Create a task",
-        "description": "Creates a [task]({{% INFLUXDB_DOCS_URL %}}/process-data/) and returns the created task.\n\nUse this endpoint to create a scheduled task that runs a Flux script.\nIn your task, provide one of the following:\n\n  - _`flux`_ property with an inline Flux script\n  - _`scriptID`_ property with an [invokable script](#tag/Invokable-Scripts) ID\n\n#### InfluxDB Cloud\n\n  - Requires either _`flux`_ (Flux query) or _`scriptID`_ (invokable script ID) in the task.\n\n#### Related guides\n\n- [Create a task]({{% INFLUXDB_DOCS_URL %}}/process-data/manage-tasks/create-task/).\n- [Common tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/common-tasks/)\n- [Task configuration options]({{% INFLUXDB_DOCS_URL %}}/process-data/task-options/)\n",
+        "description": "Creates a [task]({{% INFLUXDB_DOCS_URL %}}/process-data/) and returns the created task.\n\nUse this endpoint to create a scheduled task that runs a Flux script.\nIn your task, provide one of the following:\n\n  - _`flux`_ property with an inline Flux script\n  - _`scriptID`_ property with an [invokable script](#tag/Invokable-Scripts) ID\n\n#### InfluxDB Cloud\n\n  - Requires either _`flux`_ (Flux query) or _`scriptID`_ (invokable script ID) in the task.\n\n#### Related guides\n\n- [Get started with tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/get-started/)\n- [Create a task]({{% INFLUXDB_DOCS_URL %}}/process-data/manage-tasks/create-task/)\n- [Common tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/common-tasks/)\n- [Task configuration options]({{% INFLUXDB_DOCS_URL %}}/process-data/task-options/)\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -11331,21 +11377,27 @@
             }
           },
           "400": {
-            "description": "Bad request\n\n#### InfluxDB Cloud\n\n  - Returns this error if the task doesn't contain one of _`flux`_ or _`scriptID`_.\n  - Returns this error if the task contains _`flux`_ _and_ _`scriptID`_.\n",
-            "$ref": "#/components/responses/BadRequestError",
-            "examples": {
-              "fluxAndScriptError": {
-                "summary": "The request body can't contain both flux and scriptID",
-                "value": {
-                  "code": "invalid",
-                  "message": "failed to decode request: can not provide both scriptID and flux"
-                }
-              },
-              "missingFluxError": {
-                "summary": "The request body requires either flux or scriptID",
-                "value": {
-                  "code": "invalid",
-                  "message": "failed to decode request: flux required"
+            "description": "Bad request.\nThe response body contains detail about the error.\n\n#### InfluxDB Cloud\n\n  - Returns this error if the task doesn't contain one of _`flux`_ or _`scriptID`_.\n  - Returns this error if the task contains _`flux`_ _and_ _`scriptID`_.\n",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "fluxAndScriptError": {
+                    "summary": "The request body can't contain both flux and scriptID",
+                    "value": {
+                      "code": "invalid",
+                      "message": "failed to decode request: can not provide both scriptID and flux"
+                    }
+                  },
+                  "missingFluxError": {
+                    "summary": "The request body requires either a flux parameter or scriptID parameter",
+                    "value": {
+                      "code": "invalid",
+                      "message": "failed to decode request: flux required"
+                    }
+                  }
                 }
               }
             }
@@ -11370,13 +11422,13 @@
         "x-codeSamples": [
           {
             "lang": "Shell",
-            "label": "cURL: create a flux query task",
-            "source": "curl -v --request POST \\\nhttps://cloud2.influxdata.com/api/v2/tasks \\\n--header \"Content-type: application/json\" \\\n--header \"Authorization: Token INFLUX_TOKEN\" \\\n--data-binary @- << EOF\n  {\n  \"orgID\": \"INFLUX_ORG_ID\",\n  \"description\": \"IoT Center 30d environment average.\",\n  \"flux\": \"option task = {name: \\\"iot-center-task-1\\\", every: 30m}\\\n          from(bucket: \\\"iot_center\\\")\\\n            |> range(start: -30d)\\\n            |> filter(fn: (r) => r._measurement == \\\"environment\\\")\\\n            |> aggregateWindow(every: 1h, fn: mean)\"\n  }\nEOF\n"
+            "label": "cURL: create a Flux script task",
+            "source": "curl https://cloud2.influxdata.com/api/v2/tasks \\\n--header \"Content-type: application/json\" \\\n--header \"Authorization: Token INFLUX_TOKEN\" \\\n--data-binary @- << EOF\n  {\n    \"orgID\": \"INFLUX_ORG_ID\",\n    \"description\": \"IoT Center 30d environment average.\",\n    \"flux\": \"option task = {name: \\\"iot-center-task-1\\\", every: 30m}\\\n            from(bucket: \\\"iot_center\\\")\\\n              |> range(start: -30d)\\\n              |> filter(fn: (r) => r._measurement == \\\"environment\\\")\\\n              |> aggregateWindow(every: 1h, fn: mean)\"\n  }\nEOF\n"
           },
           {
             "lang": "Shell",
-            "label": "cURL: create a script task",
-            "source": "curl -v --request POST \\\nhttps://cloud2.influxdata.com/api/v2/tasks \\\n--header \"Content-type: application/json\" \\\n--header \"Authorization: Token INFLUX_TOKEN\" \\\n--data-binary @- << EOF\n  {\n  \"orgID\": \"INFLUX_ORG_ID\",\n  \"description\": \"IoT Center 30d environment average.\",\n  \"scriptID\": \"085138a111448000\",\n  \"scriptParameters\":\n    {\n      \"rangeStart\": \"-30d\",\n      \"bucket\": \"air_sensor\",\n      \"filterField\": \"temperature\",\n      \"groupColumn\": \"_time\"\n    }\n  }\nEOF\n"
+            "label": "cURL: create a Flux script reference task",
+            "source": "curl https://cloud2.influxdata.com/api/v2/tasks \\\n--header \"Content-type: application/json\" \\\n--header \"Authorization: Token INFLUX_TOKEN\" \\\n--data-binary @- << EOF\n  {\n    \"orgID\": \"INFLUX_ORG_ID\",\n    \"description\": \"IoT Center 30d environment average.\",\n    \"scriptID\": \"085138a111448000\",\n    \"scriptParameters\":\n      {\n        \"rangeStart\": \"-30d\",\n        \"bucket\": \"air_sensor\",\n        \"filterField\": \"temperature\",\n        \"groupColumn\": \"_time\"\n      }\n  }\nEOF\n"
           }
         ]
       }
@@ -11389,7 +11441,7 @@
           "Tasks"
         ],
         "summary": "Retrieve a task",
-        "description": "Retrieves a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task)\nby task ID.\n",
+        "description": "Retrieves a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task)\nby ID.\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -11401,7 +11453,7 @@
               "type": "string"
             },
             "required": true,
-            "description": "The task ID."
+            "description": "The ID of the task to retrieve."
           }
         ],
         "responses": {
@@ -11438,7 +11490,7 @@
           "Tasks"
         ],
         "summary": "Update a task",
-        "description": "Updates a task and then cancels all scheduled runs of the task.\n\nUse this endpoint to modify task properties (for example: `cron`, `name`, `flux`, `status`).\nOnce InfluxDB applies the update, it cancels all scheduled runs of the task.\n\nTo update a task, pass an object that contains the updated key-value pairs.\nTo activate or inactivate a task, set the `status` property.\n_`\"status\": \"inactive\"`_ cancels scheduled runs and prevents manual runs of the task.\n",
+        "description": "Updates a task and then cancels all scheduled runs of the task.\n\nUse this endpoint to modify task properties (for example: `cron`, `name`, `flux`, `status`).\nOnce InfluxDB applies the update, it cancels all previously scheduled runs of the task.\n\nTo update a task, pass an object that contains the updated key-value pairs.\nTo activate or inactivate a task, set the `status` property.\n_`\"status\": \"inactive\"`_ cancels scheduled runs and prevents manual runs of the task.\n",
         "requestBody": {
           "description": "An object that contains updated task properties to apply.",
           "required": true,
@@ -11741,12 +11793,12 @@
         ],
         "properties": {
           "start": {
-            "description": "A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/flux/v0.x/data-types/basic/time/#time-syntax)).",
+            "description": "A timestamp ([RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp)).\nThe earliest time to delete from.\n",
             "type": "string",
             "format": "date-time"
           },
           "stop": {
-            "description": "A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/flux/v0.x/data-types/basic/time/#time-syntax)).",
+            "description": "A timestamp ([RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp)).\nThe latest time to delete from.\n",
             "type": "string",
             "format": "date-time"
           },
@@ -12238,7 +12290,7 @@
         }
       },
       "DateTimeLiteral": {
-        "description": "Represents an instant in time with nanosecond precision using the syntax of golang's RFC3339 Nanosecond variant",
+        "description": "Represents an instant in time with nanosecond precision in [RFC3339Nano date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339nano-timestamp).",
         "type": "object",
         "properties": {
           "type": {
@@ -12388,23 +12440,23 @@
         }
       },
       "Dialect": {
-        "description": "Dialect are options to change the default CSV output format; https://www.w3.org/TR/2015/REC-tabular-metadata-20151217/#dialect-descriptions",
+        "description": "Options for tabular data output.\nDefault output is [annotated CSV]({{% INFLUXDB_DOCS_URL %}}/reference/syntax/annotated-csv/#csv-response-format) with headers.\n\nFor more information about tabular data **dialect**,\nsee [W3 metadata vocabulary for tabular data](https://www.w3.org/TR/2015/REC-tabular-metadata-20151217/#dialect-descriptions).\n",
         "type": "object",
         "properties": {
           "header": {
-            "description": "If true, the results will contain a header row",
+            "description": "If true, the results contain a header row.",
             "type": "boolean",
             "default": true
           },
           "delimiter": {
-            "description": "Separator between cells; the default is ,",
+            "description": "The separator used between cells. Default is a comma (`,`).",
             "type": "string",
             "default": ",",
             "maxLength": 1,
             "minLength": 1
           },
           "annotations": {
-            "description": "https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/#columns",
+            "description": "Annotation rows to include in the results.\nAn _annotation_ is metadata associated with an object (column) in the data model.\n\n#### Related guides\n\n- See [Annotated CSV annotations]({{% INFLUXDB_DOCS_URL %}}/reference/syntax/annotated-csv/#annotations) for examples and more information.\n\nFor more information about **annotations** in tabular data,\nsee [W3 metadata vocabulary for tabular data](https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/#columns).\n",
             "type": "array",
             "uniqueItems": true,
             "items": {
@@ -12417,14 +12469,14 @@
             }
           },
           "commentPrefix": {
-            "description": "Character prefixed to comment strings",
+            "description": "The character prefixed to comment strings. Default is a number sign (`#`).",
             "type": "string",
             "default": "#",
             "maxLength": 1,
             "minLength": 0
           },
           "dateTimeFormat": {
-            "description": "Format of timestamps",
+            "description": "The format for timestamps in results.\nDefault is [`RFC3339` date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp).\nTo include nanoseconds in timestamps, use `RFC3339Nano`.\n\n#### Example formatted date/time values\n\n| Format      | Value                       |\n|:------------|:----------------------------|\n| `RFC3339`    | `\"2006-01-02T15:04:05Z07:00\"` |\n| `RFC3339Nano` | `\"2006-01-02T15:04:05.999999999Z07:00\"` |\n",
             "type": "string",
             "default": "RFC3339",
             "enum": [
@@ -12710,9 +12762,10 @@
         "properties": {
           "time": {
             "readOnly": true,
-            "description": "Time event occurred, RFC3339Nano.",
+            "description": "The time ([RFC3339Nano date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339nano-timestamp)) that the event occurred.",
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "example": "2006-01-02T15:04:05.999999999Z07:00"
           },
           "message": {
             "readOnly": true,
@@ -12722,7 +12775,7 @@
           },
           "runID": {
             "readOnly": true,
-            "description": "the ID of the task that logged",
+            "description": "The ID of the task run that generated the event.",
             "type": "string"
           }
         }
@@ -14341,7 +14394,7 @@
             ]
           },
           "scheduledFor": {
-            "description": "Time used for run's \"now\" option, RFC3339.",
+            "description": "The time [RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp) used for the run's `now` option.",
             "type": "string",
             "format": "date-time"
           },
@@ -14360,21 +14413,24 @@
           },
           "startedAt": {
             "readOnly": true,
-            "description": "Time run started executing, RFC3339Nano.",
+            "description": "The time ([RFC3339Nano date/time format](https://go.dev/src/time/format.go)) the run started executing.",
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "example": "2006-01-02T15:04:05.999999999Z07:00"
           },
           "finishedAt": {
             "readOnly": true,
-            "description": "Time run finished executing, RFC3339Nano.",
+            "description": "The time ([RFC3339Nano date/time format](https://go.dev/src/time/format.go)) the run finished executing.",
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "example": "2006-01-02T15:04:05.999999999Z07:00"
           },
           "requestedAt": {
             "readOnly": true,
-            "description": "Time run was manually requested, RFC3339Nano.",
+            "description": "The time ([RFC3339Nano date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339nano-timestamp)) the run was manually requested.",
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "example": "2006-01-02T15:04:05.999999999Z07:00"
           },
           "links": {
             "type": "object",
@@ -14405,7 +14461,7 @@
         "properties": {
           "scheduledFor": {
             "nullable": true,
-            "description": "Time used for run's \"now\" option, RFC3339.  Default is the server's now time.",
+            "description": "The time [RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp)\nused for the run's `now` option.\nDefault is the server _now_ time.\n",
             "type": "string",
             "format": "date-time"
           }
@@ -17744,7 +17800,7 @@
           },
           "latestCompleted": {
             "type": "string",
-            "description": "Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.",
+            "description": "A timestamp ([RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp)) of the latest scheduled and completed run.",
             "format": "date-time",
             "readOnly": true
           },
@@ -18169,7 +18225,7 @@
         ],
         "properties": {
           "latestCompleted": {
-            "description": "Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.",
+            "description": "A timestamp ([RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp)) of the latest scheduled and completed run.",
             "type": "string",
             "format": "date-time",
             "readOnly": true
@@ -19768,12 +19824,12 @@
             "type": "string"
           },
           "every": {
-            "description": "The interval ([duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals))) at which the task runs. `every` also determines when the task first runs, depending on the specified time.",
+            "description": "The interval ([duration literal]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp)) at which the task runs. `every` also determines when the task first runs, depending on the specified time.",
             "type": "string",
             "format": "duration"
           },
           "cron": {
-            "description": "A [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview) that defines the schedule on which the task runs. InfluxDB bases cron runs on the system time.",
+            "description": "A [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview) that defines the schedule on which the task runs. InfluxDB uses the system time when evaluating Cron expressions.",
             "type": "string"
           },
           "offset": {
@@ -19782,7 +19838,7 @@
             "format": "duration"
           },
           "latestCompleted": {
-            "description": "A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/flux/v0.x/data-types/basic/time/#time-syntax)) of the latest scheduled and completed run.",
+            "description": "A timestamp ([RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp)) of the latest scheduled and completed run.",
             "type": "string",
             "format": "date-time",
             "readOnly": true

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -52,8 +52,9 @@ tags:
 
       #### Related guides
 
+      - [Get started with tasks](https://docs.influxdata.com/influxdb/cloud/process-data/get-started/)
       - [Common data processing tasks](https://docs.influxdata.com/influxdb/cloud/process-data/common-tasks/)
-      - [Invoke custom scripts as API endpoints](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/)
+      - [Create a script](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/#create-an-invokable-script).
   - name: Write
     description: |
       Write time series data to buckets.
@@ -114,8 +115,8 @@ tags:
       |:-----------:|:------------------------ |:--------------------- |
       | `200`       | Success                  |                       |
       | `204`       | No content               | For a `POST` request, `204` indicates that InfluxDB accepted the request and request data is valid. Asynchronous operations, such as `write`, might not have completed yet. |
-      | `400`       | Bad request              | May indicate one of the following: <li>Line protocol is malformed. The response body contains the first malformed line in the data and indicates what was expected. For partial writes, the number of points written and the number of points rejected are also included. For more information, check the `rejected_points` measurement in your `_monitoring` bucket.</li><li>`Authorization` header is missing or malformed or the API token does not have permission for the operation.</li> |
-      | `401`       | Unauthorized             | May indicate one of the following: <li>`Authorization: Token` header is missing or malformed</li><li>API token value is missing from the header</li><li>API token does not have permission. For more information about token types and permissions, see [Manage API tokens](https://docs.influxdata.com/influxdb/cloud/security/tokens/)</li> |
+      | `400`       | Bad request              | May indicate one of the following: <ul><li>Line protocol is malformed. The response body contains the first malformed line in the data and indicates what was expected. For partial writes, the number of points written and the number of points rejected are also included. For more information, check the `rejected_points` measurement in your `_monitoring` bucket.</li><li>`Authorization` header is missing or malformed or the API token does not have permission for the operation.</li></ul> |
+      | `401`       | Unauthorized             | May indicate one of the following: <ul><li>`Authorization: Token` header is missing or malformed</li><li>API token value is missing from the header</li><li>API token does not have permission. For more information about token types and permissions, see [Manage API tokens](https://docs.influxdata.com/influxdb/cloud/security/tokens/)</li></ul> |
       | `404`       | Not found                | Requested resource was not found. `message` in the response body provides details about the requested resource. |
       | `413`       | Request entity too large | Request payload exceeds the size limit. |
       | `422`       | Unprocessable entity     | Request data is invalid. `code` and `message` in the response body provide details about the problem. |
@@ -2308,7 +2309,7 @@ paths:
       summary: Generate a query Abstract Syntax Tree (AST)
       description: |
         Analyzes a Flux query and returns a complete package source [Abstract Syntax
-        Tree (AST)](https://https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#abstract-syntax-tree)
+        Tree (AST)](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#abstract-syntax-tree-ast)
         for the query.
 
         Use this endpoint for deep query analysis such as debugging unexpected query
@@ -2318,18 +2319,19 @@ paths:
         information about the query. The AST illustrates how the query is distributed
         into different components for execution.
 
-
         #### Limitations
 
         -  The endpoint doesn't validate values in the query--for example:
 
             The following query has correct syntax, but contains an incorrect `from()` property key:
+
             ```json
             { "query": "from(foo: \"iot_center\")\
                         |> range(start: -90d)\
                         |> filter(fn: (r) => r._measurement == \"environment\")"
             }
             ```
+
             Passing this to `/api/v2/query/ast` will return a successful response
             with a generated AST.
       parameters:
@@ -2350,13 +2352,13 @@ paths:
         - lang: Shell
           label: cURL
           source: |
-            curl --request POST 'INFLUX_URL/api/v2/query/ast' \
-              --header 'Content-Type: application/json' \
-              --header 'Accept: application/json \
-              --header 'Authorization: Token INFLUX_TOKEN' \
-              --data 'from(bucket: "example-bucket")
-                        |> range(start: -5m)
-                        |> filter(fn: (r) => r._measurement == "example-measurement")'
+            curl --request POST 'http://localhost:8086/api/v2/query/ast' \
+            --header 'Content-Type: application/json' \
+            --header 'Accept: application/json' \
+            --header 'Authorization: Token INFLUX_TOKEN' \
+            --data 'from(bucket: "example-bucket")
+                      |> range(start: -5m)
+                      |> filter(fn: (r) => r._measurement == "example-measurement")'
       responses:
         '200':
           description: |
@@ -3466,7 +3468,7 @@ paths:
         Analyzes a [Flux query](https://docs.influxdata.com/flux/v0.x/) for syntax
         errors and returns the list of errors.
 
-        In the following example `Query` object, `query` is missing a `from()` property key:
+        In the following sample query, `from()` is missing the property key.
 
             ```json
             { "query": "from(: \"iot_center\")\
@@ -3476,13 +3478,14 @@ paths:
             }
             ```
 
-        Passing this to `/api/v2/analyze` returns an `errors` list that contains an error object for the missing key.
+        If you pass this in a request to the `/api/v2/analyze` endpoint,
+        InfluxDB returns an `errors` list that contains an error object for the missing key.
 
         #### Limitations
 
         -  The endpoint doesn't validate values in the query--for example:
 
-          - The following query has correct syntax, but contains an incorrect `from()` property key:
+          - The following sample query has correct syntax, but contains an incorrect `from()` property key:
 
             ```json
             { "query": "from(foo: \"iot_center\")\
@@ -3492,7 +3495,8 @@ paths:
             }
             ```
 
-            Passing this to `/api/v2/analyze` returns an empty `errors` list.
+            If you pass this in a request to the `/api/v2/analyze` endpoint,
+            InfluxDB returns an empty `errors` list.
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: header
@@ -3523,7 +3527,7 @@ paths:
                   description: |
                     Returns an error object if the Flux query is missing a property key.
 
-                    The following example is missing the `bucket` property key:
+                    The following sample query is missing the _`bucket`_ property key:
 
                       ```json
                       {
@@ -5008,6 +5012,11 @@ paths:
       tags:
         - Tasks
       summary: List runs for a task
+      description: |
+        Retrieves a list of runs for a [task](https://docs.influxdata.com/influxdb/cloud/process-data/).
+
+        To limit which task runs are returned, pass query parameters in your request.
+        If no query parameters are passed, InfluxDB returns all task runs up to the default `limit`.
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -5015,12 +5024,14 @@ paths:
           schema:
             type: string
           required: true
-          description: The ID of the task to get runs for.
+          description: |
+            The ID of the task to get runs for.
+            Only returns runs for this task.
         - in: query
           name: after
           schema:
             type: string
-          description: Returns runs after a specific ID.
+          description: A task run ID. Only returns runs created after this run.
         - in: query
           name: limit
           schema:
@@ -5028,38 +5039,47 @@ paths:
             minimum: 1
             maximum: 500
             default: 100
-          description: The number of runs to return
+          description: |
+            Limits the number of task runs returned. Default is `100`.
         - in: query
           name: afterTime
           schema:
             type: string
             format: date-time
-          description: 'Filter runs to those scheduled after this time, RFC3339'
+          description: |
+            A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#rfc3339-timestamp)).
+            Only returns runs scheduled after this time.
         - in: query
           name: beforeTime
           schema:
             type: string
             format: date-time
-          description: 'Filter runs to those scheduled before this time, RFC3339'
+          description: |
+            A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#rfc3339-timestamp)).
+            Only returns runs scheduled before this time.
       responses:
         '200':
-          description: A list of task runs
+          description: Success. The response body contains the list of task runs.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Runs'
+        '401':
+          $ref: '#/components/responses/AuthorizationError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
         default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/GeneralServerError'
     post:
       operationId: PostTasksIDRuns
       tags:
         - Data I/O endpoints
         - Tasks
-      summary: 'Manually start a task run, overriding the current schedule'
+      summary: 'Start a task run, overriding the schedule'
+      description: |
+        Schedules a task run to start immediately, ignoring scheduled runs.
+
+        Use this endpoint to manually start a task run.
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -5074,17 +5094,17 @@ paths:
               $ref: '#/components/schemas/RunManually'
       responses:
         '201':
-          description: Run scheduled to start
+          description: Success. The run is scheduled to start.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Run'
+        '401':
+          $ref: '#/components/responses/AuthorizationError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
         default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/GeneralServerError'
   '/tasks/{taskID}/runs/{runID}':
     get:
       operationId: GetTasksIDRunsID
@@ -5281,7 +5301,7 @@ paths:
                 $ref: '#/components/schemas/Logs'
               examples:
                 taskSuccess:
-                  summary: Events for successful task.
+                  summary: Events for a successful task run.
                   value:
                     events:
                       - runID: 09b070dadaa7d000
@@ -5291,7 +5311,7 @@ paths:
                         time: '2022-07-18T14:46:07.242859Z'
                         message: Completed(success)
                 taskFailure:
-                  summary: Events for a failed task.
+                  summary: Events for a failed task run.
                   value:
                     events:
                       - runID: 09a946fc3167d000
@@ -5326,26 +5346,57 @@ paths:
           schema:
             type: string
           required: true
-          description: ID of task to get logs for.
+          description: The ID of the task to get logs for.
         - in: path
           name: runID
           schema:
             type: string
           required: true
-          description: ID of run to get logs for.
+          description: The ID of the run to get logs for.
       responses:
         '200':
-          description: All logs for a run
+          description: |
+            Success. The response body contains an `events` list with logs for the task run.
+            Each log event `message` contains detail about the event.
+            If a run fails, InfluxDB logs an event with the reason for the failure.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Logs'
+              examples:
+                taskSuccess:
+                  summary: Events for a successful task run.
+                  value:
+                    events:
+                      - runID: 09b070dadaa7d000
+                        time: '2022-07-18T14:46:07.101231Z'
+                        message: 'Started task from script: "option task = {name: \"task1\", every: 30m} from(bucket: \"iot_center\") |> range(start: -90d) |> filter(fn: (r) => r._measurement == \"environment\") |> aggregateWindow(every: 1h, fn: mean)"'
+                      - runID: 09b070dadaa7d000
+                        time: '2022-07-18T14:46:07.242859Z'
+                        message: Completed(success)
+                taskFailure:
+                  summary: Events for a failed task.
+                  value:
+                    events:
+                      - runID: 09a946fc3167d000
+                        time: '2022-07-13T07:06:54.198167Z'
+                        message: 'Started task from script: "option task = {name: \"test task\", every: 3d, offset: 0s}"'
+                      - runID: 09a946fc3167d000
+                        time: '2022-07-13T07:07:13.104037Z'
+                        message: Completed(failed)
+                      - runID: 09a946fc3167d000
+                        time: '2022-07-13T08:24:37.115323Z'
+                        message: 'error exhausting result iterator: error in query specification while starting program: this Flux script returns no streaming data. Consider adding a "yield" or invoking streaming functions directly, without performing an assignment'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/AuthorizationError'
+        '404':
+          $ref: '#/components/responses/ResourceNotFoundError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
         default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/GeneralServerError'
   '/tasks/{taskID}/labels':
     get:
       operationId: GetTasksIDLabels
@@ -7656,10 +7707,12 @@ paths:
             type: integer
             minimum: 0
             default: 0
-          description: The number of records to skip
+          description: The number of records to skip.
         - in: query
           name: sortBy
-          description: Field that records should be sorted by
+          description: |
+            The field used for sorting records in the list.
+            Only `name` is supported.
           required: false
           schema:
             type: string
@@ -7696,7 +7749,7 @@ paths:
           $ref: '#/components/responses/GeneralServerError'
       x-codeSamples:
         - lang: Shell
-          label: 'cURL: all tasks, `basic` output'
+          label: 'cURL: all tasks, basic output'
           source: |
             curl https://cloud2.influxdata.com/api/v2/tasks/?limit=-1&type=basic \
               --header 'Content-Type: application/json' \
@@ -7722,7 +7775,8 @@ paths:
 
         #### Related guides
 
-        - [Create a task](https://docs.influxdata.com/influxdb/cloud/process-data/manage-tasks/create-task/).
+        - [Get started with tasks](https://docs.influxdata.com/influxdb/cloud/process-data/get-started/)
+        - [Create a task](https://docs.influxdata.com/influxdb/cloud/process-data/manage-tasks/create-task/)
         - [Common tasks](https://docs.influxdata.com/influxdb/cloud/process-data/common-tasks/)
         - [Task configuration options](https://docs.influxdata.com/influxdb/cloud/process-data/task-options/)
       parameters:
@@ -7743,24 +7797,28 @@ paths:
                 $ref: '#/components/schemas/Task'
         '400':
           description: |
-            Bad request
+            Bad request.
+            The response body contains detail about the error.
 
             #### InfluxDB Cloud
 
               - Returns this error if the task doesn't contain one of _`flux`_ or _`scriptID`_.
               - Returns this error if the task contains _`flux`_ _and_ _`scriptID`_.
-          $ref: '#/components/responses/BadRequestError'
-          examples:
-            fluxAndScriptError:
-              summary: The request body can't contain both flux and scriptID
-              value:
-                code: invalid
-                message: 'failed to decode request: can not provide both scriptID and flux'
-            missingFluxError:
-              summary: The request body requires either flux or scriptID
-              value:
-                code: invalid
-                message: 'failed to decode request: flux required'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                fluxAndScriptError:
+                  summary: The request body can't contain both flux and scriptID
+                  value:
+                    code: invalid
+                    message: 'failed to decode request: can not provide both scriptID and flux'
+                missingFluxError:
+                  summary: The request body requires either a flux parameter or scriptID parameter
+                  value:
+                    code: invalid
+                    message: 'failed to decode request: flux required'
         '401':
           $ref: '#/components/responses/AuthorizationError'
         '500':
@@ -7773,42 +7831,40 @@ paths:
                 $ref: '#/components/schemas/Error'
       x-codeSamples:
         - lang: Shell
-          label: 'cURL: create a flux query task'
+          label: 'cURL: create a Flux script task'
           source: |
-            curl -v --request POST \
-            https://cloud2.influxdata.com/api/v2/tasks \
+            curl https://cloud2.influxdata.com/api/v2/tasks \
             --header "Content-type: application/json" \
             --header "Authorization: Token INFLUX_TOKEN" \
             --data-binary @- << EOF
               {
-              "orgID": "INFLUX_ORG_ID",
-              "description": "IoT Center 30d environment average.",
-              "flux": "option task = {name: \"iot-center-task-1\", every: 30m}\
-                      from(bucket: \"iot_center\")\
-                        |> range(start: -30d)\
-                        |> filter(fn: (r) => r._measurement == \"environment\")\
-                        |> aggregateWindow(every: 1h, fn: mean)"
+                "orgID": "INFLUX_ORG_ID",
+                "description": "IoT Center 30d environment average.",
+                "flux": "option task = {name: \"iot-center-task-1\", every: 30m}\
+                        from(bucket: \"iot_center\")\
+                          |> range(start: -30d)\
+                          |> filter(fn: (r) => r._measurement == \"environment\")\
+                          |> aggregateWindow(every: 1h, fn: mean)"
               }
             EOF
         - lang: Shell
-          label: 'cURL: create a script task'
+          label: 'cURL: create a Flux script reference task'
           source: |
-            curl -v --request POST \
-            https://cloud2.influxdata.com/api/v2/tasks \
+            curl https://cloud2.influxdata.com/api/v2/tasks \
             --header "Content-type: application/json" \
             --header "Authorization: Token INFLUX_TOKEN" \
             --data-binary @- << EOF
               {
-              "orgID": "INFLUX_ORG_ID",
-              "description": "IoT Center 30d environment average.",
-              "scriptID": "085138a111448000",
-              "scriptParameters":
-                {
-                  "rangeStart": "-30d",
-                  "bucket": "air_sensor",
-                  "filterField": "temperature",
-                  "groupColumn": "_time"
-                }
+                "orgID": "INFLUX_ORG_ID",
+                "description": "IoT Center 30d environment average.",
+                "scriptID": "085138a111448000",
+                "scriptParameters":
+                  {
+                    "rangeStart": "-30d",
+                    "bucket": "air_sensor",
+                    "filterField": "temperature",
+                    "groupColumn": "_time"
+                  }
               }
             EOF
   '/tasks/{taskID}':
@@ -7820,7 +7876,7 @@ paths:
       summary: Retrieve a task
       description: |
         Retrieves a [task](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#task)
-        by task ID.
+        by ID.
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -7828,7 +7884,7 @@ paths:
           schema:
             type: string
           required: true
-          description: The task ID.
+          description: The ID of the task to retrieve.
       responses:
         '200':
           description: Success. The response body contains the task.
@@ -7855,7 +7911,7 @@ paths:
         Updates a task and then cancels all scheduled runs of the task.
 
         Use this endpoint to modify task properties (for example: `cron`, `name`, `flux`, `status`).
-        Once InfluxDB applies the update, it cancels all scheduled runs of the task.
+        Once InfluxDB applies the update, it cancels all previously scheduled runs of the task.
 
         To update a task, pass an object that contains the updated key-value pairs.
         To activate or inactivate a task, set the `status` property.
@@ -8101,11 +8157,15 @@ components:
         - stop
       properties:
         start:
-          description: 'A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/flux/v0.x/data-types/basic/time/#time-syntax)).'
+          description: |
+            A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#rfc3339-timestamp)).
+            The earliest time to delete from.
           type: string
           format: date-time
         stop:
-          description: 'A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/flux/v0.x/data-types/basic/time/#time-syntax)).'
+          description: |
+            A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#rfc3339-timestamp)).
+            The latest time to delete from.
           type: string
           format: date-time
         predicate:
@@ -8399,7 +8459,7 @@ components:
         value:
           type: boolean
     DateTimeLiteral:
-      description: Represents an instant in time with nanosecond precision using the syntax of golang's RFC3339 Nanosecond variant
+      description: 'Represents an instant in time with nanosecond precision in [RFC3339Nano date/time format](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#rfc3339nano-timestamp).'
       type: object
       properties:
         type:
@@ -8497,21 +8557,35 @@ components:
         name:
           type: string
     Dialect:
-      description: 'Dialect are options to change the default CSV output format; https://www.w3.org/TR/2015/REC-tabular-metadata-20151217/#dialect-descriptions'
+      description: |
+        Options for tabular data output.
+        Default output is [annotated CSV](https://docs.influxdata.com/influxdb/cloud/reference/syntax/annotated-csv/#csv-response-format) with headers.
+
+        For more information about tabular data **dialect**,
+        see [W3 metadata vocabulary for tabular data](https://www.w3.org/TR/2015/REC-tabular-metadata-20151217/#dialect-descriptions).
       type: object
       properties:
         header:
-          description: 'If true, the results will contain a header row'
+          description: 'If true, the results contain a header row.'
           type: boolean
           default: true
         delimiter:
-          description: 'Separator between cells; the default is ,'
+          description: 'The separator used between cells. Default is a comma (`,`).'
           type: string
           default: ','
           maxLength: 1
           minLength: 1
         annotations:
-          description: 'https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/#columns'
+          description: |
+            Annotation rows to include in the results.
+            An _annotation_ is metadata associated with an object (column) in the data model.
+
+            #### Related guides
+
+            - See [Annotated CSV annotations](https://docs.influxdata.com/influxdb/cloud/reference/syntax/annotated-csv/#annotations) for examples and more information.
+
+            For more information about **annotations** in tabular data,
+            see [W3 metadata vocabulary for tabular data](https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/#columns).
           type: array
           uniqueItems: true
           items:
@@ -8521,13 +8595,23 @@ components:
               - datatype
               - default
         commentPrefix:
-          description: Character prefixed to comment strings
+          description: The character prefixed to comment strings. Default is a number sign (`#`).
           type: string
           default: '#'
           maxLength: 1
           minLength: 0
         dateTimeFormat:
-          description: Format of timestamps
+          description: |
+            The format for timestamps in results.
+            Default is [`RFC3339` date/time format](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#rfc3339-timestamp).
+            To include nanoseconds in timestamps, use `RFC3339Nano`.
+
+            #### Example formatted date/time values
+
+            | Format      | Value                       |
+            |:------------|:----------------------------|
+            | `RFC3339`    | `"2006-01-02T15:04:05Z07:00"` |
+            | `RFC3339Nano` | `"2006-01-02T15:04:05.999999999Z07:00"` |
           type: string
           default: RFC3339
           enum:
@@ -8732,9 +8816,10 @@ components:
       properties:
         time:
           readOnly: true
-          description: 'Time event occurred, RFC3339Nano.'
+          description: 'The time ([RFC3339Nano date/time format](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#rfc3339nano-timestamp)) that the event occurred.'
           type: string
           format: date-time
+          example: '2006-01-02T15:04:05.999999999Z07:00'
         message:
           readOnly: true
           description: A description of the event that occurred.
@@ -8742,7 +8827,7 @@ components:
           example: Halt and catch fire
         runID:
           readOnly: true
-          description: the ID of the task that logged
+          description: The ID of the task run that generated the event.
           type: string
     Organization:
       properties:
@@ -9789,7 +9874,7 @@ components:
             - success
             - canceled
         scheduledFor:
-          description: 'Time used for run''s "now" option, RFC3339.'
+          description: 'The time [RFC3339 date/time format](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#rfc3339-timestamp) used for the run''s `now` option.'
           type: string
           format: date-time
         log:
@@ -9804,19 +9889,22 @@ components:
           readOnly: true
         startedAt:
           readOnly: true
-          description: 'Time run started executing, RFC3339Nano.'
+          description: 'The time ([RFC3339Nano date/time format](https://go.dev/src/time/format.go)) the run started executing.'
           type: string
           format: date-time
+          example: '2006-01-02T15:04:05.999999999Z07:00'
         finishedAt:
           readOnly: true
-          description: 'Time run finished executing, RFC3339Nano.'
+          description: 'The time ([RFC3339Nano date/time format](https://go.dev/src/time/format.go)) the run finished executing.'
           type: string
           format: date-time
+          example: '2006-01-02T15:04:05.999999999Z07:00'
         requestedAt:
           readOnly: true
-          description: 'Time run was manually requested, RFC3339Nano.'
+          description: 'The time ([RFC3339Nano date/time format](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#rfc3339nano-timestamp)) the run was manually requested.'
           type: string
           format: date-time
+          example: '2006-01-02T15:04:05.999999999Z07:00'
         links:
           type: object
           readOnly: true
@@ -9838,7 +9926,10 @@ components:
       properties:
         scheduledFor:
           nullable: true
-          description: 'Time used for run''s "now" option, RFC3339.  Default is the server''s now time.'
+          description: |
+            The time [RFC3339 date/time format](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#rfc3339-timestamp)
+            used for the run's `now` option.
+            Default is the server _now_ time.
           type: string
           format: date-time
     TaskStatusType:
@@ -12141,7 +12232,7 @@ components:
           type: string
         latestCompleted:
           type: string
-          description: 'Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.'
+          description: 'A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#rfc3339-timestamp)) of the latest scheduled and completed run.'
           format: date-time
           readOnly: true
         lastRunStatus:
@@ -12411,7 +12502,7 @@ components:
         - endpointID
       properties:
         latestCompleted:
-          description: 'Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.'
+          description: 'A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#rfc3339-timestamp)) of the latest scheduled and completed run.'
           type: string
           format: date-time
           readOnly: true
@@ -13508,18 +13599,18 @@ components:
             - If you use the `flux` property, you can't use the `scriptID` and `scriptParameters` properties.
           type: string
         every:
-          description: 'The interval ([duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals))) at which the task runs. `every` also determines when the task first runs, depending on the specified time.'
+          description: 'The interval ([duration literal](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#rfc3339-timestamp)) at which the task runs. `every` also determines when the task first runs, depending on the specified time.'
           type: string
           format: duration
         cron:
-          description: 'A [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview) that defines the schedule on which the task runs. InfluxDB bases cron runs on the system time.'
+          description: 'A [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview) that defines the schedule on which the task runs. InfluxDB uses the system time when evaluating Cron expressions.'
           type: string
         offset:
           description: 'A [duration](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals) to delay execution of the task after the scheduled time has elapsed. `0` removes the offset.'
           type: string
           format: duration
         latestCompleted:
-          description: 'A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/flux/v0.x/data-types/basic/time/#time-syntax)) of the latest scheduled and completed run.'
+          description: 'A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#rfc3339-timestamp)) of the latest scheduled and completed run.'
           type: string
           format: date-time
           readOnly: true

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -2176,7 +2176,7 @@ paths:
       summary: Generate a query Abstract Syntax Tree (AST)
       description: |
         Analyzes a Flux query and returns a complete package source [Abstract Syntax
-        Tree (AST)](https://https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#abstract-syntax-tree)
+        Tree (AST)](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#abstract-syntax-tree-ast)
         for the query.
 
         Use this endpoint for deep query analysis such as debugging unexpected query
@@ -2186,18 +2186,19 @@ paths:
         information about the query. The AST illustrates how the query is distributed
         into different components for execution.
 
-
         #### Limitations
 
         -  The endpoint doesn't validate values in the query--for example:
 
             The following query has correct syntax, but contains an incorrect `from()` property key:
+
             ```json
             { "query": "from(foo: \"iot_center\")\
                         |> range(start: -90d)\
                         |> filter(fn: (r) => r._measurement == \"environment\")"
             }
             ```
+
             Passing this to `/api/v2/query/ast` will return a successful response
             with a generated AST.
       parameters:
@@ -2218,13 +2219,13 @@ paths:
         - lang: Shell
           label: cURL
           source: |
-            curl --request POST 'INFLUX_URL/api/v2/query/ast' \
-              --header 'Content-Type: application/json' \
-              --header 'Accept: application/json \
-              --header 'Authorization: Token INFLUX_TOKEN' \
-              --data 'from(bucket: "example-bucket")
-                        |> range(start: -5m)
-                        |> filter(fn: (r) => r._measurement == "example-measurement")'
+            curl --request POST 'http://localhost:8086/api/v2/query/ast' \
+            --header 'Content-Type: application/json' \
+            --header 'Accept: application/json' \
+            --header 'Authorization: Token INFLUX_TOKEN' \
+            --data 'from(bucket: "example-bucket")
+                      |> range(start: -5m)
+                      |> filter(fn: (r) => r._measurement == "example-measurement")'
       responses:
         '200':
           description: |
@@ -3334,7 +3335,7 @@ paths:
         Analyzes a [Flux query](https://docs.influxdata.com/flux/v0.x/) for syntax
         errors and returns the list of errors.
 
-        In the following example `Query` object, `query` is missing a `from()` property key:
+        In the following sample query, `from()` is missing the property key.
 
             ```json
             { "query": "from(: \"iot_center\")\
@@ -3344,13 +3345,14 @@ paths:
             }
             ```
 
-        Passing this to `/api/v2/analyze` returns an `errors` list that contains an error object for the missing key.
+        If you pass this in a request to the `/api/v2/analyze` endpoint,
+        InfluxDB returns an `errors` list that contains an error object for the missing key.
 
         #### Limitations
 
         -  The endpoint doesn't validate values in the query--for example:
 
-          - The following query has correct syntax, but contains an incorrect `from()` property key:
+          - The following sample query has correct syntax, but contains an incorrect `from()` property key:
 
             ```json
             { "query": "from(foo: \"iot_center\")\
@@ -3360,7 +3362,8 @@ paths:
             }
             ```
 
-            Passing this to `/api/v2/analyze` returns an empty `errors` list.
+            If you pass this in a request to the `/api/v2/analyze` endpoint,
+            InfluxDB returns an empty `errors` list.
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: header
@@ -3391,7 +3394,7 @@ paths:
                   description: |
                     Returns an error object if the Flux query is missing a property key.
 
-                    The following example is missing the `bucket` property key:
+                    The following sample query is missing the _`bucket`_ property key:
 
                       ```json
                       {
@@ -4876,6 +4879,11 @@ paths:
       tags:
         - Tasks
       summary: List runs for a task
+      description: |
+        Retrieves a list of runs for a [task](https://docs.influxdata.com/influxdb/v2.3/process-data/).
+
+        To limit which task runs are returned, pass query parameters in your request.
+        If no query parameters are passed, InfluxDB returns all task runs up to the default `limit`.
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -4883,12 +4891,14 @@ paths:
           schema:
             type: string
           required: true
-          description: The ID of the task to get runs for.
+          description: |
+            The ID of the task to get runs for.
+            Only returns runs for this task.
         - in: query
           name: after
           schema:
             type: string
-          description: Returns runs after a specific ID.
+          description: A task run ID. Only returns runs created after this run.
         - in: query
           name: limit
           schema:
@@ -4896,38 +4906,47 @@ paths:
             minimum: 1
             maximum: 500
             default: 100
-          description: The number of runs to return
+          description: |
+            Limits the number of task runs returned. Default is `100`.
         - in: query
           name: afterTime
           schema:
             type: string
             format: date-time
-          description: 'Filter runs to those scheduled after this time, RFC3339'
+          description: |
+            A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339-timestamp)).
+            Only returns runs scheduled after this time.
         - in: query
           name: beforeTime
           schema:
             type: string
             format: date-time
-          description: 'Filter runs to those scheduled before this time, RFC3339'
+          description: |
+            A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339-timestamp)).
+            Only returns runs scheduled before this time.
       responses:
         '200':
-          description: A list of task runs
+          description: Success. The response body contains the list of task runs.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Runs'
+        '401':
+          $ref: '#/components/responses/AuthorizationError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
         default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/GeneralServerError'
     post:
       operationId: PostTasksIDRuns
       tags:
         - Data I/O endpoints
         - Tasks
-      summary: 'Manually start a task run, overriding the current schedule'
+      summary: 'Start a task run, overriding the schedule'
+      description: |
+        Schedules a task run to start immediately, ignoring scheduled runs.
+
+        Use this endpoint to manually start a task run.
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -4942,17 +4961,17 @@ paths:
               $ref: '#/components/schemas/RunManually'
       responses:
         '201':
-          description: Run scheduled to start
+          description: Success. The run is scheduled to start.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Run'
+        '401':
+          $ref: '#/components/responses/AuthorizationError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
         default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/GeneralServerError'
   '/tasks/{taskID}/runs/{runID}':
     get:
       operationId: GetTasksIDRunsID
@@ -5149,7 +5168,7 @@ paths:
                 $ref: '#/components/schemas/Logs'
               examples:
                 taskSuccess:
-                  summary: Events for successful task.
+                  summary: Events for a successful task run.
                   value:
                     events:
                       - runID: 09b070dadaa7d000
@@ -5159,7 +5178,7 @@ paths:
                         time: '2022-07-18T14:46:07.242859Z'
                         message: Completed(success)
                 taskFailure:
-                  summary: Events for a failed task.
+                  summary: Events for a failed task run.
                   value:
                     events:
                       - runID: 09a946fc3167d000
@@ -5194,26 +5213,57 @@ paths:
           schema:
             type: string
           required: true
-          description: ID of task to get logs for.
+          description: The ID of the task to get logs for.
         - in: path
           name: runID
           schema:
             type: string
           required: true
-          description: ID of run to get logs for.
+          description: The ID of the run to get logs for.
       responses:
         '200':
-          description: All logs for a run
+          description: |
+            Success. The response body contains an `events` list with logs for the task run.
+            Each log event `message` contains detail about the event.
+            If a run fails, InfluxDB logs an event with the reason for the failure.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Logs'
+              examples:
+                taskSuccess:
+                  summary: Events for a successful task run.
+                  value:
+                    events:
+                      - runID: 09b070dadaa7d000
+                        time: '2022-07-18T14:46:07.101231Z'
+                        message: 'Started task from script: "option task = {name: \"task1\", every: 30m} from(bucket: \"iot_center\") |> range(start: -90d) |> filter(fn: (r) => r._measurement == \"environment\") |> aggregateWindow(every: 1h, fn: mean)"'
+                      - runID: 09b070dadaa7d000
+                        time: '2022-07-18T14:46:07.242859Z'
+                        message: Completed(success)
+                taskFailure:
+                  summary: Events for a failed task.
+                  value:
+                    events:
+                      - runID: 09a946fc3167d000
+                        time: '2022-07-13T07:06:54.198167Z'
+                        message: 'Started task from script: "option task = {name: \"test task\", every: 3d, offset: 0s}"'
+                      - runID: 09a946fc3167d000
+                        time: '2022-07-13T07:07:13.104037Z'
+                        message: Completed(failed)
+                      - runID: 09a946fc3167d000
+                        time: '2022-07-13T08:24:37.115323Z'
+                        message: 'error exhausting result iterator: error in query specification while starting program: this Flux script returns no streaming data. Consider adding a "yield" or invoking streaming functions directly, without performing an assignment'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/AuthorizationError'
+        '404':
+          $ref: '#/components/responses/ResourceNotFoundError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
         default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/GeneralServerError'
   '/tasks/{taskID}/labels':
     get:
       operationId: GetTasksIDLabels
@@ -6734,11 +6784,15 @@ components:
         - stop
       properties:
         start:
-          description: 'A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/flux/v0.x/data-types/basic/time/#time-syntax)).'
+          description: |
+            A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339-timestamp)).
+            The earliest time to delete from.
           type: string
           format: date-time
         stop:
-          description: 'A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/flux/v0.x/data-types/basic/time/#time-syntax)).'
+          description: |
+            A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339-timestamp)).
+            The latest time to delete from.
           type: string
           format: date-time
         predicate:
@@ -7032,7 +7086,7 @@ components:
         value:
           type: boolean
     DateTimeLiteral:
-      description: Represents an instant in time with nanosecond precision using the syntax of golang's RFC3339 Nanosecond variant
+      description: 'Represents an instant in time with nanosecond precision in [RFC3339Nano date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339nano-timestamp).'
       type: object
       properties:
         type:
@@ -7130,21 +7184,35 @@ components:
         name:
           type: string
     Dialect:
-      description: 'Dialect are options to change the default CSV output format; https://www.w3.org/TR/2015/REC-tabular-metadata-20151217/#dialect-descriptions'
+      description: |
+        Options for tabular data output.
+        Default output is [annotated CSV](https://docs.influxdata.com/influxdb/v2.3/reference/syntax/annotated-csv/#csv-response-format) with headers.
+
+        For more information about tabular data **dialect**,
+        see [W3 metadata vocabulary for tabular data](https://www.w3.org/TR/2015/REC-tabular-metadata-20151217/#dialect-descriptions).
       type: object
       properties:
         header:
-          description: 'If true, the results will contain a header row'
+          description: 'If true, the results contain a header row.'
           type: boolean
           default: true
         delimiter:
-          description: 'Separator between cells; the default is ,'
+          description: 'The separator used between cells. Default is a comma (`,`).'
           type: string
           default: ','
           maxLength: 1
           minLength: 1
         annotations:
-          description: 'https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/#columns'
+          description: |
+            Annotation rows to include in the results.
+            An _annotation_ is metadata associated with an object (column) in the data model.
+
+            #### Related guides
+
+            - See [Annotated CSV annotations](https://docs.influxdata.com/influxdb/v2.3/reference/syntax/annotated-csv/#annotations) for examples and more information.
+
+            For more information about **annotations** in tabular data,
+            see [W3 metadata vocabulary for tabular data](https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/#columns).
           type: array
           uniqueItems: true
           items:
@@ -7154,13 +7222,23 @@ components:
               - datatype
               - default
         commentPrefix:
-          description: Character prefixed to comment strings
+          description: The character prefixed to comment strings. Default is a number sign (`#`).
           type: string
           default: '#'
           maxLength: 1
           minLength: 0
         dateTimeFormat:
-          description: Format of timestamps
+          description: |
+            The format for timestamps in results.
+            Default is [`RFC3339` date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339-timestamp).
+            To include nanoseconds in timestamps, use `RFC3339Nano`.
+
+            #### Example formatted date/time values
+
+            | Format      | Value                       |
+            |:------------|:----------------------------|
+            | `RFC3339`    | `"2006-01-02T15:04:05Z07:00"` |
+            | `RFC3339Nano` | `"2006-01-02T15:04:05.999999999Z07:00"` |
           type: string
           default: RFC3339
           enum:
@@ -7365,9 +7443,10 @@ components:
       properties:
         time:
           readOnly: true
-          description: 'Time event occurred, RFC3339Nano.'
+          description: 'The time ([RFC3339Nano date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339nano-timestamp)) that the event occurred.'
           type: string
           format: date-time
+          example: '2006-01-02T15:04:05.999999999Z07:00'
         message:
           readOnly: true
           description: A description of the event that occurred.
@@ -7375,7 +7454,7 @@ components:
           example: Halt and catch fire
         runID:
           readOnly: true
-          description: the ID of the task that logged
+          description: The ID of the task run that generated the event.
           type: string
     Organization:
       properties:
@@ -8422,7 +8501,7 @@ components:
             - success
             - canceled
         scheduledFor:
-          description: 'Time used for run''s "now" option, RFC3339.'
+          description: 'The time [RFC3339 date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339-timestamp) used for the run''s `now` option.'
           type: string
           format: date-time
         log:
@@ -8437,19 +8516,22 @@ components:
           readOnly: true
         startedAt:
           readOnly: true
-          description: 'Time run started executing, RFC3339Nano.'
+          description: 'The time ([RFC3339Nano date/time format](https://go.dev/src/time/format.go)) the run started executing.'
           type: string
           format: date-time
+          example: '2006-01-02T15:04:05.999999999Z07:00'
         finishedAt:
           readOnly: true
-          description: 'Time run finished executing, RFC3339Nano.'
+          description: 'The time ([RFC3339Nano date/time format](https://go.dev/src/time/format.go)) the run finished executing.'
           type: string
           format: date-time
+          example: '2006-01-02T15:04:05.999999999Z07:00'
         requestedAt:
           readOnly: true
-          description: 'Time run was manually requested, RFC3339Nano.'
+          description: 'The time ([RFC3339Nano date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339nano-timestamp)) the run was manually requested.'
           type: string
           format: date-time
+          example: '2006-01-02T15:04:05.999999999Z07:00'
         links:
           type: object
           readOnly: true
@@ -8471,7 +8553,10 @@ components:
       properties:
         scheduledFor:
           nullable: true
-          description: 'Time used for run''s "now" option, RFC3339.  Default is the server''s now time.'
+          description: |
+            The time [RFC3339 date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339-timestamp)
+            used for the run's `now` option.
+            Default is the server _now_ time.
           type: string
           format: date-time
     TaskStatusType:
@@ -10774,7 +10859,7 @@ components:
           type: string
         latestCompleted:
           type: string
-          description: 'Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.'
+          description: 'A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339-timestamp)) of the latest scheduled and completed run.'
           format: date-time
           readOnly: true
         lastRunStatus:
@@ -11044,7 +11129,7 @@ components:
         - endpointID
       properties:
         latestCompleted:
-          description: 'Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.'
+          description: 'A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339-timestamp)) of the latest scheduled and completed run.'
           type: string
           format: date-time
           readOnly: true

--- a/contracts/legacy.yml
+++ b/contracts/legacy.yml
@@ -21,7 +21,7 @@ paths:
             description: |
               Media type that the client can understand.
 
-              **Note**: With `application/csv`, query results include [unix timestamps]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#unix-timestamp) instead of RFC3339 timestamps.
+              **Note**: With `application/csv`, query results include [**unix timestamps**]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#unix-timestamp) instead of [RFC3339 timestamps]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp).
             default: application/json
             enum:
               - application/json
@@ -79,7 +79,10 @@ paths:
             type: string
         - in: query
           name: epoch
-          description: 'Return results with [unix (epoch) timestamps]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#unix-timestamp) in the specified precision instead of RFC3339 timestamps with nanosecond precision.'
+          description: |
+            A unix timestamp precision.
+            Formats timestamps as [unix (epoch) timestamps]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#unix-timestamp) the specified precision
+            instead of [RFC3339 timestamps]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp) with nanosecond precision.
           schema:
             type: string
             enum:

--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -1411,7 +1411,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
     get:
       operationId: GetSources
       tags:
@@ -1436,7 +1436,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   '/sources/{sourceID}':
     delete:
       operationId: DeleteSourcesID
@@ -1459,13 +1459,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
         default:
           description: Unexpected error
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
     patch:
       operationId: PatchSourcesID
       tags:
@@ -1498,13 +1498,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
         default:
           description: Unexpected error
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
     get:
       operationId: GetSourcesID
       tags:
@@ -1530,13 +1530,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
         default:
           description: Unexpected error
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   '/sources/{sourceID}/health':
     get:
       operationId: GetSourcesIDHealth
@@ -1569,7 +1569,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   '/sources/{sourceID}/buckets':
     get:
       operationId: GetSourcesIDBuckets
@@ -1610,13 +1610,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
         default:
           description: Unexpected error
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   /scrapers:
     get:
       operationId: GetScrapers
@@ -1680,7 +1680,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   '/scrapers/{scraperTargetID}':
     get:
       operationId: GetScrapersID
@@ -1707,7 +1707,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
     delete:
       operationId: DeleteScrapersID
       tags:
@@ -1729,7 +1729,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
     patch:
       operationId: PatchScrapersID
       summary: Update a scraper target
@@ -1762,7 +1762,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   '/scrapers/{scraperTargetID}/labels':
     get:
       operationId: GetScrapersIDLabels
@@ -1794,7 +1794,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
     post:
       operationId: PostScrapersIDLabels
       tags:
@@ -1854,7 +1854,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   '/scrapers/{scraperTargetID}/labels/{labelID}':
     delete:
       operationId: DeleteScrapersIDLabelsID
@@ -1883,13 +1883,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
         default:
           description: Unexpected error
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   '/scrapers/{scraperTargetID}/members':
     get:
       operationId: GetScrapersIDMembers
@@ -1927,7 +1927,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
     post:
       operationId: PostScrapersIDMembers
       tags:
@@ -1968,7 +1968,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   '/scrapers/{scraperTargetID}/members/{userID}':
     delete:
       operationId: DeleteScrapersIDMembersID
@@ -1997,7 +1997,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   '/scrapers/{scraperTargetID}/owners':
     get:
       operationId: GetScrapersIDOwners
@@ -2035,7 +2035,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
     post:
       operationId: PostScrapersIDOwners
       tags:
@@ -2083,7 +2083,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   '/scrapers/{scraperTargetID}/owners/{userID}':
     delete:
       operationId: DeleteScrapersIDOwnersID
@@ -2112,19 +2112,23 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   /backup/kv:
     get:
       operationId: GetBackupKV
       tags:
         - Backup
-      summary: 'Download snapshot of metadata stored in the server''s embedded KV store. Should not be used in versions greater than 2.1.x, as it doesn''t include metadata stored in embedded SQL.'
+      summary: Download snapshot of metadata stored in the server's embedded KV store. Don't use with InfluxDB versions greater than InfluxDB 2.1.x.
+      description: |
+        Retrieves a snapshot of metadata stored in the server's embedded KV store.
+        InfluxDB versions greater than 2.1.x don't include metadata stored in embedded SQL;
+        avoid using this endpoint with versions greater than 2.1.x.
       deprecated: true
       parameters:
         - $ref: '#/paths/~1ready/get/parameters/0'
       responses:
         '200':
-          description: Snapshot of KV metadata
+          description: Success. The response contains a snapshot of KV metadata.
           content:
             application/octet-stream:
               schema:
@@ -2199,10 +2203,14 @@ paths:
           description: The shard ID.
         - in: query
           name: since
-          description: Earliest time to include in the snapshot. RFC3339 format.
+          description: 'The earliest time [RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp) to include in the snapshot.'
           schema:
             type: string
             format: date-time
+          examples:
+            RFC3339:
+              summary: RFC3339 date/time format
+              value: '2006-01-02T15:04:05Z07:00'
       responses:
         '200':
           description: TSM snapshot.
@@ -2227,7 +2235,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
         default:
           description: Unexpected error
           $ref: '#/paths/~1config/get/responses/401'
@@ -2468,7 +2476,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
         default:
           $ref: '#/paths/~1config/get/responses/401'
   /remotes:
@@ -3621,7 +3629,7 @@ paths:
                                                               type: string
                                                             latestCompleted:
                                                               type: string
-                                                              description: 'Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.'
+                                                              description: 'A timestamp ([RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp)) of the latest scheduled and completed run.'
                                                               format: date-time
                                                               readOnly: true
                                                             lastRunStatus:
@@ -4479,7 +4487,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
     get:
       operationId: GetDashboards
       tags:
@@ -4554,7 +4562,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
   /tasks:
     get:
       operationId: GetTasks
@@ -4718,7 +4726,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
               examples:
                 tokenNotAuthorized:
                   summary: Token is not authorized to access a resource
@@ -4732,9 +4740,16 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
         default:
           $ref: '#/paths/~1config/get/responses/401'
+      x-codeSamples:
+        - lang: Shell
+          label: 'cURL: all tasks, basic output'
+          source: |
+            curl https://localhost:8086/api/v2/tasks/?limit=-1&type=basic \
+              --header 'Content-Type: application/json' \
+              --header 'Authorization: Token INFLUX_API_TOKEN'
     post:
       operationId: PostTasks
       tags:
@@ -4746,7 +4761,8 @@ paths:
 
         #### Related guides
 
-        - [Create a task]({{% INFLUXDB_DOCS_URL %}}/process-data/manage-tasks/create-task/).
+        - [Get started with tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/get-started/)
+        - [Create a task]({{% INFLUXDB_DOCS_URL %}}/process-data/manage-tasks/create-task/)
         - [Common tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/common-tasks/)
         - [Task configuration options]({{% INFLUXDB_DOCS_URL %}}/process-data/task-options/)
       parameters:
@@ -4766,20 +4782,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/Task'
         '400':
-          description: Bad request
-          $ref: '#/paths/~1tasks~1%7BtaskID%7D/get/responses/400'
-          examples:
-            missingFluxError:
-              summary: Task in request body is missing Flux query
-              value:
-                code: invalid
-                message: 'failed to decode request: missing flux'
-        '401':
-          $ref: '#/paths/~1tasks/get/responses/401'
-        '500':
-          $ref: '#/paths/~1tasks/get/responses/500'
-        default:
-          description: Unexpected error
+          description: |
+            Bad request.
+            The response body contains detail about the error.
+
+            #### InfluxDB OSS
+
+            - Returns this error if an incorrect value is passed for `org` or `orgID`.
           content:
             application/json:
               schema:
@@ -4816,24 +4825,44 @@ paths:
                     type: string
                 required:
                   - code
+              examples:
+                orgProvidedNotFound:
+                  summary: The org or orgID passed doesn't own the token passed in the header
+                  value:
+                    code: invalid
+                    message: 'failed to decode request body: organization not found'
+                missingFluxError:
+                  summary: Task in request body is missing Flux query
+                  value:
+                    code: invalid
+                    message: 'failed to decode request: missing flux'
+        '401':
+          $ref: '#/paths/~1tasks/get/responses/401'
+        '500':
+          $ref: '#/paths/~1tasks/get/responses/500'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
       x-codeSamples:
         - lang: Shell
           label: 'cURL: create a task'
           source: |
-            curl -v --request POST \
-            http://localhost:8086/api/v2/tasks \
-            --header "Content-type: application/json" \
-            --header "Authorization: Token INFLUX_TOKEN" \
-            --data-binary @- << EOF
-              {
-              "orgID": "INFLUX_ORG_ID",
-              "description": "IoT Center 30d environment average.",
-              "flux": "option task = {name: \"iot-center-task-1\", every: 30m}\
-                      from(bucket: \"iot_center\")\
-                        |> range(start: -30d)\
-                        |> filter(fn: (r) => r._measurement == \"environment\")\
-                        |> aggregateWindow(every: 1h, fn: mean)"
-              }
+            curl http://localhost:8086/api/v2/tasks \
+              --header "Content-type: application/json" \
+              --header "Authorization: Token INFLUX_TOKEN" \
+              --data-binary @- << EOF
+                {
+                "orgID": "INFLUX_ORG_ID",
+                "description": "IoT Center 30d environment average.",
+                "flux": "option task = {name: \"iot-center-task-1\", every: 30m}\
+                        from(bucket: \"iot_center\")\
+                          |> range(start: -30d)\
+                          |> filter(fn: (r) => r._measurement == \"environment\")\
+                          |> aggregateWindow(every: 1h, fn: mean)"
+                }
             EOF
   '/tasks/{taskID}':
     get:
@@ -4844,7 +4873,7 @@ paths:
       summary: Retrieve a task
       description: |
         Retrieves a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task)
-        by task ID.
+        by ID.
       parameters:
         - $ref: '#/paths/~1ready/get/parameters/0'
         - in: path
@@ -4852,7 +4881,7 @@ paths:
           schema:
             type: string
           required: true
-          description: The task ID.
+          description: The ID of the task to retrieve.
       responses:
         '200':
           description: Success. The response body contains the task.
@@ -4871,7 +4900,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
               examples:
                 orgProvidedNotFound:
                   summary: The org or orgID passed doesn't own the token passed in the header
@@ -4893,7 +4922,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/paths/~1tasks/post/responses/default/content/application~1json/schema'
+                $ref: '#/paths/~1tasks/post/responses/400/content/application~1json/schema'
               examples:
                 org-not-found:
                   summary: Organization name not found
@@ -4923,7 +4952,7 @@ paths:
         Updates a task and then cancels all scheduled runs of the task.
 
         Use this endpoint to modify task properties (for example: `cron`, `name`, `flux`, `status`).
-        Once InfluxDB applies the update, it cancels all scheduled runs of the task.
+        Once InfluxDB applies the update, it cancels all previously scheduled runs of the task.
 
         To update a task, pass an object that contains the updated key-value pairs.
         To activate or inactivate a task, set the `status` property.

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -29,7 +29,7 @@
     },
     {
       "name": "Tasks",
-      "description": "Process and analyze your data with tasks in the InfluxDB task engine.\nWith tasks, you can schedule Flux scripts to query, analyze, modify, and act on data.\n\nUse the `/api/v2/tasks` endpoints to create and manage tasks, retry task runs, and retrieve run logs.\n\n#### Related guides\n\n- [Common data processing tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/common-tasks/)\n"
+      "description": "Process and analyze your data with tasks in the InfluxDB task engine.\nWith tasks, you can schedule Flux scripts to query, analyze, modify, and act on data.\n\nUse the `/api/v2/tasks` endpoints to create and manage tasks, retry task runs, and retrieve run logs.\n\n#### Related guides\n\n- [Get started with tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/get-started/)\n- [Common data processing tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/common-tasks/)\n"
     },
     {
       "name": "Write",
@@ -58,7 +58,7 @@
     {
       "name": "Response codes",
       "x-traitTag": true,
-      "description": "InfluxDB API endpoints use standard HTTP status codes for success and failure responses.\nThe response body may include additional details.\nFor details about a specific operation's response,\nsee **Responses** and **Response Samples** for that operation.\n\nAPI operations may return the following HTTP status codes:\n\n| &nbsp;Code&nbsp; | Status                   | Description      |\n|:-----------:|:------------------------ |:--------------------- |\n| `200`       | Success                  |                       |\n| `204`       | No content               | For a `POST` request, `204` indicates that InfluxDB accepted the request and request data is valid. Asynchronous operations, such as `write`, might not have completed yet. |\n| `400`       | Bad request              | May indicate one of the following: <li>Line protocol is malformed. The response body contains the first malformed line in the data and indicates what was expected. For partial writes, the number of points written and the number of points rejected are also included. For more information, check the `rejected_points` measurement in your `_monitoring` bucket.</li><li>`Authorization` header is missing or malformed or the API token does not have permission for the operation.</li> |\n| `401`       | Unauthorized             | May indicate one of the following: <li>`Authorization: Token` header is missing or malformed</li><li>API token value is missing from the header</li><li>API token does not have permission. For more information about token types and permissions, see [Manage API tokens](https://docs.influxdata.com/influxdb/latest/security/tokens/)</li> |\n| `404`       | Not found                | Requested resource was not found. `message` in the response body provides details about the requested resource. |\n| `413`       | Request entity too large | Request payload exceeds the size limit. |\n| `422`       | Unprocessable entity     | Request data is invalid. `code` and `message` in the response body provide details about the problem. |\n| `429`       | Too many requests        | API token is temporarily over the request quota. The `Retry-After` header describes when to try the request again. |\n| `500`       | Internal server error    |                       |\n| `503`       | Service unavailable      | Server is temporarily unavailable to process the request. The `Retry-After` header describes when to try the request again. |\n"
+      "description": "InfluxDB API endpoints use standard HTTP status codes for success and failure responses.\nThe response body may include additional details.\nFor details about a specific operation's response,\nsee **Responses** and **Response Samples** for that operation.\n\nAPI operations may return the following HTTP status codes:\n\n| &nbsp;Code&nbsp; | Status                   | Description      |\n|:-----------:|:------------------------ |:--------------------- |\n| `200`       | Success                  |                       |\n| `204`       | No content               | For a `POST` request, `204` indicates that InfluxDB accepted the request and request data is valid. Asynchronous operations, such as `write`, might not have completed yet. |\n| `400`       | Bad request              | May indicate one of the following: <ul><li>Line protocol is malformed. The response body contains the first malformed line in the data and indicates what was expected. For partial writes, the number of points written and the number of points rejected are also included. For more information, check the `rejected_points` measurement in your `_monitoring` bucket.</li><li>`Authorization` header is missing or malformed or the API token does not have permission for the operation.</li></ul> |\n| `401`       | Unauthorized             | May indicate one of the following: <ul><li>`Authorization: Token` header is missing or malformed</li><li>API token value is missing from the header</li><li>API token does not have permission. For more information about token types and permissions, see [Manage API tokens](https://docs.influxdata.com/influxdb/latest/security/tokens/)</li></ul> |\n| `404`       | Not found                | Requested resource was not found. `message` in the response body provides details about the requested resource. |\n| `413`       | Request entity too large | Request payload exceeds the size limit. |\n| `422`       | Unprocessable entity     | Request data is invalid. `code` and `message` in the response body provide details about the problem. |\n| `429`       | Too many requests        | API token is temporarily over the request quota. The `Retry-After` header describes when to try the request again. |\n| `500`       | Internal server error    |                       |\n| `503`       | Service unavailable      | Server is temporarily unavailable to process the request. The `Retry-After` header describes when to try the request again. |\n"
     }
   ],
   "x-tagGroups": [
@@ -3140,7 +3140,7 @@
           "Query"
         ],
         "summary": "Generate a query Abstract Syntax Tree (AST)",
-        "description": "Analyzes a Flux query and returns a complete package source [Abstract Syntax\nTree (AST)](https://https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#abstract-syntax-tree)\nfor the query.\n\nUse this endpoint for deep query analysis such as debugging unexpected query\nresults.\n\nA Flux query AST provides a semantic, tree-like representation with contextual\ninformation about the query. The AST illustrates how the query is distributed\ninto different components for execution.\n\n\n#### Limitations\n\n-  The endpoint doesn't validate values in the query--for example:\n\n    The following query has correct syntax, but contains an incorrect `from()` property key:\n    ```json\n    { \"query\": \"from(foo: \\\"iot_center\\\")\\\n                |> range(start: -90d)\\\n                |> filter(fn: (r) => r._measurement == \\\"environment\\\")\"\n    }\n    ```\n    Passing this to `/api/v2/query/ast` will return a successful response\n    with a generated AST.\n",
+        "description": "Analyzes a Flux query and returns a complete package source [Abstract Syntax\nTree (AST)]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#abstract-syntax-tree-ast)\nfor the query.\n\nUse this endpoint for deep query analysis such as debugging unexpected query\nresults.\n\nA Flux query AST provides a semantic, tree-like representation with contextual\ninformation about the query. The AST illustrates how the query is distributed\ninto different components for execution.\n\n#### Limitations\n\n-  The endpoint doesn't validate values in the query--for example:\n\n    The following query has correct syntax, but contains an incorrect `from()` property key:\n\n    ```json\n    { \"query\": \"from(foo: \\\"iot_center\\\")\\\n                |> range(start: -90d)\\\n                |> filter(fn: (r) => r._measurement == \\\"environment\\\")\"\n    }\n    ```\n\n    Passing this to `/api/v2/query/ast` will return a successful response\n    with a generated AST.\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -3170,7 +3170,7 @@
           {
             "lang": "Shell",
             "label": "cURL",
-            "source": "curl --request POST 'INFLUX_URL/api/v2/query/ast' \\\n  --header 'Content-Type: application/json' \\\n  --header 'Accept: application/json \\\n  --header 'Authorization: Token INFLUX_TOKEN' \\\n  --data 'from(bucket: \"example-bucket\")\n            |> range(start: -5m)\n            |> filter(fn: (r) => r._measurement == \"example-measurement\")'\n"
+            "source": "curl --request POST 'http://localhost:8086/api/v2/query/ast' \\\n--header 'Content-Type: application/json' \\\n--header 'Accept: application/json' \\\n--header 'Authorization: Token INFLUX_TOKEN' \\\n--data 'from(bucket: \"example-bucket\")\n          |> range(start: -5m)\n          |> filter(fn: (r) => r._measurement == \"example-measurement\")'\n"
           }
         ],
         "responses": {
@@ -4770,7 +4770,7 @@
           "Query"
         ],
         "summary": "Analyze a Flux query",
-        "description": "Analyzes a [Flux query](https://docs.influxdata.com/flux/v0.x/) for syntax\nerrors and returns the list of errors.\n\nIn the following example `Query` object, `query` is missing a `from()` property key:\n\n    ```json\n    { \"query\": \"from(: \\\"iot_center\\\")\\\n                |> range(start: -90d)\\\n                |> filter(fn: (r) => r._measurement == \\\"environment\\\")\",\n      \"type\": \"flux\"\n    }\n    ```\n\nPassing this to `/api/v2/analyze` returns an `errors` list that contains an error object for the missing key.\n\n#### Limitations\n\n-  The endpoint doesn't validate values in the query--for example:\n\n  - The following query has correct syntax, but contains an incorrect `from()` property key:\n\n    ```json\n    { \"query\": \"from(foo: \\\"iot_center\\\")\\\n                |> range(start: -90d)\\\n                |> filter(fn: (r) => r._measurement == \\\"environment\\\")\",\n      \"type\": \"flux\"\n    }\n    ```\n\n    Passing this to `/api/v2/analyze` returns an empty `errors` list.\n",
+        "description": "Analyzes a [Flux query](https://docs.influxdata.com/flux/v0.x/) for syntax\nerrors and returns the list of errors.\n\nIn the following sample query, `from()` is missing the property key.\n\n    ```json\n    { \"query\": \"from(: \\\"iot_center\\\")\\\n                |> range(start: -90d)\\\n                |> filter(fn: (r) => r._measurement == \\\"environment\\\")\",\n      \"type\": \"flux\"\n    }\n    ```\n\nIf you pass this in a request to the `/api/v2/analyze` endpoint,\nInfluxDB returns an `errors` list that contains an error object for the missing key.\n\n#### Limitations\n\n-  The endpoint doesn't validate values in the query--for example:\n\n  - The following sample query has correct syntax, but contains an incorrect `from()` property key:\n\n    ```json\n    { \"query\": \"from(foo: \\\"iot_center\\\")\\\n                |> range(start: -90d)\\\n                |> filter(fn: (r) => r._measurement == \\\"environment\\\")\",\n      \"type\": \"flux\"\n    }\n    ```\n\n    If you pass this in a request to the `/api/v2/analyze` endpoint,\n    InfluxDB returns an empty `errors` list.\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -4807,7 +4807,7 @@
                 "examples": {
                   "missingQueryPropertyKey": {
                     "summary": "Missing property key error",
-                    "description": "Returns an error object if the Flux query is missing a property key.\n\nThe following example is missing the `bucket` property key:\n\n  ```json\n  {\n    \"query\": \"from(: \\\"iot_center\\\")\\\n\n    ...\n\n  }\n  ```\n",
+                    "description": "Returns an error object if the Flux query is missing a property key.\n\nThe following sample query is missing the _`bucket`_ property key:\n\n  ```json\n  {\n    \"query\": \"from(: \\\"iot_center\\\")\\\n\n    ...\n\n  }\n  ```\n",
                     "value": {
                       "errors": [
                         {
@@ -7080,6 +7080,7 @@
           "Tasks"
         ],
         "summary": "List runs for a task",
+        "description": "Retrieves a list of runs for a [task]({{% INFLUXDB_DOCS_URL %}}/process-data/).\n\nTo limit which task runs are returned, pass query parameters in your request.\nIf no query parameters are passed, InfluxDB returns all task runs up to the default `limit`.\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -7091,7 +7092,7 @@
               "type": "string"
             },
             "required": true,
-            "description": "The ID of the task to get runs for."
+            "description": "The ID of the task to get runs for.\nOnly returns runs for this task.\n"
           },
           {
             "in": "query",
@@ -7099,7 +7100,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Returns runs after a specific ID."
+            "description": "A task run ID. Only returns runs created after this run."
           },
           {
             "in": "query",
@@ -7110,7 +7111,7 @@
               "maximum": 500,
               "default": 100
             },
-            "description": "The number of runs to return"
+            "description": "Limits the number of task runs returned. Default is `100`.\n"
           },
           {
             "in": "query",
@@ -7119,7 +7120,7 @@
               "type": "string",
               "format": "date-time"
             },
-            "description": "Filter runs to those scheduled after this time, RFC3339"
+            "description": "A timestamp ([RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp)).\nOnly returns runs scheduled after this time.\n"
           },
           {
             "in": "query",
@@ -7128,12 +7129,12 @@
               "type": "string",
               "format": "date-time"
             },
-            "description": "Filter runs to those scheduled before this time, RFC3339"
+            "description": "A timestamp ([RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp)).\nOnly returns runs scheduled before this time.\n"
           }
         ],
         "responses": {
           "200": {
-            "description": "A list of task runs",
+            "description": "Success. The response body contains the list of task runs.",
             "content": {
               "application/json": {
                 "schema": {
@@ -7142,15 +7143,14 @@
               }
             }
           },
+          "401": {
+            "$ref": "#/components/responses/AuthorizationError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          },
           "default": {
-            "description": "Unexpected error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
+            "$ref": "#/components/responses/GeneralServerError"
           }
         }
       },
@@ -7160,7 +7160,8 @@
           "Data I/O endpoints",
           "Tasks"
         ],
-        "summary": "Manually start a task run, overriding the current schedule",
+        "summary": "Start a task run, overriding the schedule",
+        "description": "Schedules a task run to start immediately, ignoring scheduled runs.\n\nUse this endpoint to manually start a task run.\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -7185,7 +7186,7 @@
         },
         "responses": {
           "201": {
-            "description": "Run scheduled to start",
+            "description": "Success. The run is scheduled to start.",
             "content": {
               "application/json": {
                 "schema": {
@@ -7194,15 +7195,14 @@
               }
             }
           },
+          "401": {
+            "$ref": "#/components/responses/AuthorizationError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          },
           "default": {
-            "description": "Unexpected error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
+            "$ref": "#/components/responses/GeneralServerError"
           }
         }
       }
@@ -7455,7 +7455,7 @@
                 },
                 "examples": {
                   "taskSuccess": {
-                    "summary": "Events for successful task.",
+                    "summary": "Events for a successful task run.",
                     "value": {
                       "events": [
                         {
@@ -7472,7 +7472,7 @@
                     }
                   },
                   "taskFailure": {
-                    "summary": "Events for a failed task.",
+                    "summary": "Events for a failed task run.",
                     "value": {
                       "events": [
                         {
@@ -7533,7 +7533,7 @@
               "type": "string"
             },
             "required": true,
-            "description": "ID of task to get logs for."
+            "description": "The ID of the task to get logs for."
           },
           {
             "in": "path",
@@ -7542,29 +7542,75 @@
               "type": "string"
             },
             "required": true,
-            "description": "ID of run to get logs for."
+            "description": "The ID of the run to get logs for."
           }
         ],
         "responses": {
           "200": {
-            "description": "All logs for a run",
+            "description": "Success. The response body contains an `events` list with logs for the task run.\nEach log event `message` contains detail about the event.\nIf a run fails, InfluxDB logs an event with the reason for the failure.\n",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Logs"
+                },
+                "examples": {
+                  "taskSuccess": {
+                    "summary": "Events for a successful task run.",
+                    "value": {
+                      "events": [
+                        {
+                          "runID": "09b070dadaa7d000",
+                          "time": "2022-07-18T14:46:07.101231Z",
+                          "message": "Started task from script: \"option task = {name: \\\"task1\\\", every: 30m} from(bucket: \\\"iot_center\\\") |> range(start: -90d) |> filter(fn: (r) => r._measurement == \\\"environment\\\") |> aggregateWindow(every: 1h, fn: mean)\""
+                        },
+                        {
+                          "runID": "09b070dadaa7d000",
+                          "time": "2022-07-18T14:46:07.242859Z",
+                          "message": "Completed(success)"
+                        }
+                      ]
+                    }
+                  },
+                  "taskFailure": {
+                    "summary": "Events for a failed task.",
+                    "value": {
+                      "events": [
+                        {
+                          "runID": "09a946fc3167d000",
+                          "time": "2022-07-13T07:06:54.198167Z",
+                          "message": "Started task from script: \"option task = {name: \\\"test task\\\", every: 3d, offset: 0s}\""
+                        },
+                        {
+                          "runID": "09a946fc3167d000",
+                          "time": "2022-07-13T07:07:13.104037Z",
+                          "message": "Completed(failed)"
+                        },
+                        {
+                          "runID": "09a946fc3167d000",
+                          "time": "2022-07-13T08:24:37.115323Z",
+                          "message": "error exhausting result iterator: error in query specification while starting program: this Flux script returns no streaming data. Consider adding a \"yield\" or invoking streaming functions directly, without performing an assignment"
+                        }
+                      ]
+                    }
+                  }
                 }
               }
             }
           },
+          "400": {
+            "$ref": "#/components/responses/BadRequestError"
+          },
+          "401": {
+            "$ref": "#/components/responses/AuthorizationError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ResourceNotFoundError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          },
           "default": {
-            "description": "Unexpected error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
+            "$ref": "#/components/responses/GeneralServerError"
           }
         }
       }
@@ -12455,7 +12501,8 @@
         "tags": [
           "Backup"
         ],
-        "summary": "Download snapshot of metadata stored in the server's embedded KV store. Should not be used in versions greater than 2.1.x, as it doesn't include metadata stored in embedded SQL.",
+        "summary": "Download snapshot of metadata stored in the server's embedded KV store. Don't use with InfluxDB versions greater than InfluxDB 2.1.x.",
+        "description": "Retrieves a snapshot of metadata stored in the server's embedded KV store.\nInfluxDB versions greater than 2.1.x don't include metadata stored in embedded SQL;\navoid using this endpoint with versions greater than 2.1.x.\n",
         "deprecated": true,
         "parameters": [
           {
@@ -12464,7 +12511,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Snapshot of KV metadata",
+            "description": "Success. The response contains a snapshot of KV metadata.",
             "content": {
               "application/octet-stream": {
                 "schema": {
@@ -12577,10 +12624,16 @@
           {
             "in": "query",
             "name": "since",
-            "description": "Earliest time to include in the snapshot. RFC3339 format.",
+            "description": "The earliest time [RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp) to include in the snapshot.",
             "schema": {
               "type": "string",
               "format": "date-time"
+            },
+            "examples": {
+              "RFC3339": {
+                "summary": "RFC3339 date/time format",
+                "value": "2006-01-02T15:04:05Z07:00"
+              }
             }
           }
         ],
@@ -13791,7 +13844,14 @@
           "default": {
             "$ref": "#/components/responses/GeneralServerError"
           }
-        }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "Shell",
+            "label": "cURL: all tasks, basic output",
+            "source": "curl https://localhost:8086/api/v2/tasks/?limit=-1&type=basic \\\n  --header 'Content-Type: application/json' \\\n  --header 'Authorization: Token INFLUX_API_TOKEN'\n"
+          }
+        ]
       },
       "post": {
         "operationId": "PostTasks",
@@ -13800,7 +13860,7 @@
           "Tasks"
         ],
         "summary": "Create a task",
-        "description": "Creates a [task]({{% INFLUXDB_DOCS_URL %}}/process-data/) and returns the created task.\n\n#### Related guides\n\n- [Create a task]({{% INFLUXDB_DOCS_URL %}}/process-data/manage-tasks/create-task/).\n- [Common tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/common-tasks/)\n- [Task configuration options]({{% INFLUXDB_DOCS_URL %}}/process-data/task-options/)\n",
+        "description": "Creates a [task]({{% INFLUXDB_DOCS_URL %}}/process-data/) and returns the created task.\n\n#### Related guides\n\n- [Get started with tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/get-started/)\n- [Create a task]({{% INFLUXDB_DOCS_URL %}}/process-data/manage-tasks/create-task/)\n- [Common tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/common-tasks/)\n- [Task configuration options]({{% INFLUXDB_DOCS_URL %}}/process-data/task-options/)\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -13829,14 +13889,27 @@
             }
           },
           "400": {
-            "description": "Bad request",
-            "$ref": "#/components/responses/BadRequestError",
-            "examples": {
-              "missingFluxError": {
-                "summary": "Task in request body is missing Flux query",
-                "value": {
-                  "code": "invalid",
-                  "message": "failed to decode request: missing flux"
+            "description": "Bad request.\nThe response body contains detail about the error.\n\n#### InfluxDB OSS\n\n- Returns this error if an incorrect value is passed for `org` or `orgID`.\n",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "orgProvidedNotFound": {
+                    "summary": "The org or orgID passed doesn't own the token passed in the header",
+                    "value": {
+                      "code": "invalid",
+                      "message": "failed to decode request body: organization not found"
+                    }
+                  },
+                  "missingFluxError": {
+                    "summary": "Task in request body is missing Flux query",
+                    "value": {
+                      "code": "invalid",
+                      "message": "failed to decode request: missing flux"
+                    }
+                  }
                 }
               }
             }
@@ -13862,7 +13935,7 @@
           {
             "lang": "Shell",
             "label": "cURL: create a task",
-            "source": "curl -v --request POST \\\nhttp://localhost:8086/api/v2/tasks \\\n--header \"Content-type: application/json\" \\\n--header \"Authorization: Token INFLUX_TOKEN\" \\\n--data-binary @- << EOF\n  {\n  \"orgID\": \"INFLUX_ORG_ID\",\n  \"description\": \"IoT Center 30d environment average.\",\n  \"flux\": \"option task = {name: \\\"iot-center-task-1\\\", every: 30m}\\\n          from(bucket: \\\"iot_center\\\")\\\n            |> range(start: -30d)\\\n            |> filter(fn: (r) => r._measurement == \\\"environment\\\")\\\n            |> aggregateWindow(every: 1h, fn: mean)\"\n  }\nEOF\n"
+            "source": "curl http://localhost:8086/api/v2/tasks \\\n  --header \"Content-type: application/json\" \\\n  --header \"Authorization: Token INFLUX_TOKEN\" \\\n  --data-binary @- << EOF\n    {\n    \"orgID\": \"INFLUX_ORG_ID\",\n    \"description\": \"IoT Center 30d environment average.\",\n    \"flux\": \"option task = {name: \\\"iot-center-task-1\\\", every: 30m}\\\n            from(bucket: \\\"iot_center\\\")\\\n              |> range(start: -30d)\\\n              |> filter(fn: (r) => r._measurement == \\\"environment\\\")\\\n              |> aggregateWindow(every: 1h, fn: mean)\"\n    }\nEOF\n"
           }
         ]
       }
@@ -13875,7 +13948,7 @@
           "Tasks"
         ],
         "summary": "Retrieve a task",
-        "description": "Retrieves a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task)\nby task ID.\n",
+        "description": "Retrieves a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task)\nby ID.\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -13887,7 +13960,7 @@
               "type": "string"
             },
             "required": true,
-            "description": "The task ID."
+            "description": "The ID of the task to retrieve."
           }
         ],
         "responses": {
@@ -13924,7 +13997,7 @@
           "Tasks"
         ],
         "summary": "Update a task",
-        "description": "Updates a task and then cancels all scheduled runs of the task.\n\nUse this endpoint to modify task properties (for example: `cron`, `name`, `flux`, `status`).\nOnce InfluxDB applies the update, it cancels all scheduled runs of the task.\n\nTo update a task, pass an object that contains the updated key-value pairs.\nTo activate or inactivate a task, set the `status` property.\n_`\"status\": \"inactive\"`_ cancels scheduled runs and prevents manual runs of the task.\n",
+        "description": "Updates a task and then cancels all scheduled runs of the task.\n\nUse this endpoint to modify task properties (for example: `cron`, `name`, `flux`, `status`).\nOnce InfluxDB applies the update, it cancels all previously scheduled runs of the task.\n\nTo update a task, pass an object that contains the updated key-value pairs.\nTo activate or inactivate a task, set the `status` property.\n_`\"status\": \"inactive\"`_ cancels scheduled runs and prevents manual runs of the task.\n",
         "requestBody": {
           "description": "An object that contains updated task properties to apply.",
           "required": true,
@@ -14227,12 +14300,12 @@
         ],
         "properties": {
           "start": {
-            "description": "A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/flux/v0.x/data-types/basic/time/#time-syntax)).",
+            "description": "A timestamp ([RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp)).\nThe earliest time to delete from.\n",
             "type": "string",
             "format": "date-time"
           },
           "stop": {
-            "description": "A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/flux/v0.x/data-types/basic/time/#time-syntax)).",
+            "description": "A timestamp ([RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp)).\nThe latest time to delete from.\n",
             "type": "string",
             "format": "date-time"
           },
@@ -14724,7 +14797,7 @@
         }
       },
       "DateTimeLiteral": {
-        "description": "Represents an instant in time with nanosecond precision using the syntax of golang's RFC3339 Nanosecond variant",
+        "description": "Represents an instant in time with nanosecond precision in [RFC3339Nano date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339nano-timestamp).",
         "type": "object",
         "properties": {
           "type": {
@@ -14874,23 +14947,23 @@
         }
       },
       "Dialect": {
-        "description": "Dialect are options to change the default CSV output format; https://www.w3.org/TR/2015/REC-tabular-metadata-20151217/#dialect-descriptions",
+        "description": "Options for tabular data output.\nDefault output is [annotated CSV]({{% INFLUXDB_DOCS_URL %}}/reference/syntax/annotated-csv/#csv-response-format) with headers.\n\nFor more information about tabular data **dialect**,\nsee [W3 metadata vocabulary for tabular data](https://www.w3.org/TR/2015/REC-tabular-metadata-20151217/#dialect-descriptions).\n",
         "type": "object",
         "properties": {
           "header": {
-            "description": "If true, the results will contain a header row",
+            "description": "If true, the results contain a header row.",
             "type": "boolean",
             "default": true
           },
           "delimiter": {
-            "description": "Separator between cells; the default is ,",
+            "description": "The separator used between cells. Default is a comma (`,`).",
             "type": "string",
             "default": ",",
             "maxLength": 1,
             "minLength": 1
           },
           "annotations": {
-            "description": "https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/#columns",
+            "description": "Annotation rows to include in the results.\nAn _annotation_ is metadata associated with an object (column) in the data model.\n\n#### Related guides\n\n- See [Annotated CSV annotations]({{% INFLUXDB_DOCS_URL %}}/reference/syntax/annotated-csv/#annotations) for examples and more information.\n\nFor more information about **annotations** in tabular data,\nsee [W3 metadata vocabulary for tabular data](https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/#columns).\n",
             "type": "array",
             "uniqueItems": true,
             "items": {
@@ -14903,14 +14976,14 @@
             }
           },
           "commentPrefix": {
-            "description": "Character prefixed to comment strings",
+            "description": "The character prefixed to comment strings. Default is a number sign (`#`).",
             "type": "string",
             "default": "#",
             "maxLength": 1,
             "minLength": 0
           },
           "dateTimeFormat": {
-            "description": "Format of timestamps",
+            "description": "The format for timestamps in results.\nDefault is [`RFC3339` date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp).\nTo include nanoseconds in timestamps, use `RFC3339Nano`.\n\n#### Example formatted date/time values\n\n| Format      | Value                       |\n|:------------|:----------------------------|\n| `RFC3339`    | `\"2006-01-02T15:04:05Z07:00\"` |\n| `RFC3339Nano` | `\"2006-01-02T15:04:05.999999999Z07:00\"` |\n",
             "type": "string",
             "default": "RFC3339",
             "enum": [
@@ -15196,9 +15269,10 @@
         "properties": {
           "time": {
             "readOnly": true,
-            "description": "Time event occurred, RFC3339Nano.",
+            "description": "The time ([RFC3339Nano date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339nano-timestamp)) that the event occurred.",
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "example": "2006-01-02T15:04:05.999999999Z07:00"
           },
           "message": {
             "readOnly": true,
@@ -15208,7 +15282,7 @@
           },
           "runID": {
             "readOnly": true,
-            "description": "the ID of the task that logged",
+            "description": "The ID of the task run that generated the event.",
             "type": "string"
           }
         }
@@ -16827,7 +16901,7 @@
             ]
           },
           "scheduledFor": {
-            "description": "Time used for run's \"now\" option, RFC3339.",
+            "description": "The time [RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp) used for the run's `now` option.",
             "type": "string",
             "format": "date-time"
           },
@@ -16846,21 +16920,24 @@
           },
           "startedAt": {
             "readOnly": true,
-            "description": "Time run started executing, RFC3339Nano.",
+            "description": "The time ([RFC3339Nano date/time format](https://go.dev/src/time/format.go)) the run started executing.",
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "example": "2006-01-02T15:04:05.999999999Z07:00"
           },
           "finishedAt": {
             "readOnly": true,
-            "description": "Time run finished executing, RFC3339Nano.",
+            "description": "The time ([RFC3339Nano date/time format](https://go.dev/src/time/format.go)) the run finished executing.",
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "example": "2006-01-02T15:04:05.999999999Z07:00"
           },
           "requestedAt": {
             "readOnly": true,
-            "description": "Time run was manually requested, RFC3339Nano.",
+            "description": "The time ([RFC3339Nano date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339nano-timestamp)) the run was manually requested.",
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "example": "2006-01-02T15:04:05.999999999Z07:00"
           },
           "links": {
             "type": "object",
@@ -16891,7 +16968,7 @@
         "properties": {
           "scheduledFor": {
             "nullable": true,
-            "description": "Time used for run's \"now\" option, RFC3339.  Default is the server's now time.",
+            "description": "The time [RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp)\nused for the run's `now` option.\nDefault is the server _now_ time.\n",
             "type": "string",
             "format": "date-time"
           }
@@ -20230,7 +20307,7 @@
           },
           "latestCompleted": {
             "type": "string",
-            "description": "Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.",
+            "description": "A timestamp ([RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp)) of the latest scheduled and completed run.",
             "format": "date-time",
             "readOnly": true
           },
@@ -20655,7 +20732,7 @@
         ],
         "properties": {
           "latestCompleted": {
-            "description": "Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.",
+            "description": "A timestamp ([RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp)) of the latest scheduled and completed run.",
             "type": "string",
             "format": "date-time",
             "readOnly": true

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -48,6 +48,7 @@ tags:
 
       #### Related guides
 
+      - [Get started with tasks](https://docs.influxdata.com/influxdb/v2.3/process-data/get-started/)
       - [Common data processing tasks](https://docs.influxdata.com/influxdb/v2.3/process-data/common-tasks/)
   - name: Write
     description: |
@@ -113,8 +114,8 @@ tags:
       |:-----------:|:------------------------ |:--------------------- |
       | `200`       | Success                  |                       |
       | `204`       | No content               | For a `POST` request, `204` indicates that InfluxDB accepted the request and request data is valid. Asynchronous operations, such as `write`, might not have completed yet. |
-      | `400`       | Bad request              | May indicate one of the following: <li>Line protocol is malformed. The response body contains the first malformed line in the data and indicates what was expected. For partial writes, the number of points written and the number of points rejected are also included. For more information, check the `rejected_points` measurement in your `_monitoring` bucket.</li><li>`Authorization` header is missing or malformed or the API token does not have permission for the operation.</li> |
-      | `401`       | Unauthorized             | May indicate one of the following: <li>`Authorization: Token` header is missing or malformed</li><li>API token value is missing from the header</li><li>API token does not have permission. For more information about token types and permissions, see [Manage API tokens](https://docs.influxdata.com/influxdb/latest/security/tokens/)</li> |
+      | `400`       | Bad request              | May indicate one of the following: <ul><li>Line protocol is malformed. The response body contains the first malformed line in the data and indicates what was expected. For partial writes, the number of points written and the number of points rejected are also included. For more information, check the `rejected_points` measurement in your `_monitoring` bucket.</li><li>`Authorization` header is missing or malformed or the API token does not have permission for the operation.</li></ul> |
+      | `401`       | Unauthorized             | May indicate one of the following: <ul><li>`Authorization: Token` header is missing or malformed</li><li>API token value is missing from the header</li><li>API token does not have permission. For more information about token types and permissions, see [Manage API tokens](https://docs.influxdata.com/influxdb/latest/security/tokens/)</li></ul> |
       | `404`       | Not found                | Requested resource was not found. `message` in the response body provides details about the requested resource. |
       | `413`       | Request entity too large | Request payload exceeds the size limit. |
       | `422`       | Unprocessable entity     | Request data is invalid. `code` and `message` in the response body provide details about the problem. |
@@ -2307,7 +2308,7 @@ paths:
       summary: Generate a query Abstract Syntax Tree (AST)
       description: |
         Analyzes a Flux query and returns a complete package source [Abstract Syntax
-        Tree (AST)](https://https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#abstract-syntax-tree)
+        Tree (AST)](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#abstract-syntax-tree-ast)
         for the query.
 
         Use this endpoint for deep query analysis such as debugging unexpected query
@@ -2317,18 +2318,19 @@ paths:
         information about the query. The AST illustrates how the query is distributed
         into different components for execution.
 
-
         #### Limitations
 
         -  The endpoint doesn't validate values in the query--for example:
 
             The following query has correct syntax, but contains an incorrect `from()` property key:
+
             ```json
             { "query": "from(foo: \"iot_center\")\
                         |> range(start: -90d)\
                         |> filter(fn: (r) => r._measurement == \"environment\")"
             }
             ```
+
             Passing this to `/api/v2/query/ast` will return a successful response
             with a generated AST.
       parameters:
@@ -2349,13 +2351,13 @@ paths:
         - lang: Shell
           label: cURL
           source: |
-            curl --request POST 'INFLUX_URL/api/v2/query/ast' \
-              --header 'Content-Type: application/json' \
-              --header 'Accept: application/json \
-              --header 'Authorization: Token INFLUX_TOKEN' \
-              --data 'from(bucket: "example-bucket")
-                        |> range(start: -5m)
-                        |> filter(fn: (r) => r._measurement == "example-measurement")'
+            curl --request POST 'http://localhost:8086/api/v2/query/ast' \
+            --header 'Content-Type: application/json' \
+            --header 'Accept: application/json' \
+            --header 'Authorization: Token INFLUX_TOKEN' \
+            --data 'from(bucket: "example-bucket")
+                      |> range(start: -5m)
+                      |> filter(fn: (r) => r._measurement == "example-measurement")'
       responses:
         '200':
           description: |
@@ -3465,7 +3467,7 @@ paths:
         Analyzes a [Flux query](https://docs.influxdata.com/flux/v0.x/) for syntax
         errors and returns the list of errors.
 
-        In the following example `Query` object, `query` is missing a `from()` property key:
+        In the following sample query, `from()` is missing the property key.
 
             ```json
             { "query": "from(: \"iot_center\")\
@@ -3475,13 +3477,14 @@ paths:
             }
             ```
 
-        Passing this to `/api/v2/analyze` returns an `errors` list that contains an error object for the missing key.
+        If you pass this in a request to the `/api/v2/analyze` endpoint,
+        InfluxDB returns an `errors` list that contains an error object for the missing key.
 
         #### Limitations
 
         -  The endpoint doesn't validate values in the query--for example:
 
-          - The following query has correct syntax, but contains an incorrect `from()` property key:
+          - The following sample query has correct syntax, but contains an incorrect `from()` property key:
 
             ```json
             { "query": "from(foo: \"iot_center\")\
@@ -3491,7 +3494,8 @@ paths:
             }
             ```
 
-            Passing this to `/api/v2/analyze` returns an empty `errors` list.
+            If you pass this in a request to the `/api/v2/analyze` endpoint,
+            InfluxDB returns an empty `errors` list.
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: header
@@ -3522,7 +3526,7 @@ paths:
                   description: |
                     Returns an error object if the Flux query is missing a property key.
 
-                    The following example is missing the `bucket` property key:
+                    The following sample query is missing the _`bucket`_ property key:
 
                       ```json
                       {
@@ -5007,6 +5011,11 @@ paths:
       tags:
         - Tasks
       summary: List runs for a task
+      description: |
+        Retrieves a list of runs for a [task](https://docs.influxdata.com/influxdb/v2.3/process-data/).
+
+        To limit which task runs are returned, pass query parameters in your request.
+        If no query parameters are passed, InfluxDB returns all task runs up to the default `limit`.
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -5014,12 +5023,14 @@ paths:
           schema:
             type: string
           required: true
-          description: The ID of the task to get runs for.
+          description: |
+            The ID of the task to get runs for.
+            Only returns runs for this task.
         - in: query
           name: after
           schema:
             type: string
-          description: Returns runs after a specific ID.
+          description: A task run ID. Only returns runs created after this run.
         - in: query
           name: limit
           schema:
@@ -5027,38 +5038,47 @@ paths:
             minimum: 1
             maximum: 500
             default: 100
-          description: The number of runs to return
+          description: |
+            Limits the number of task runs returned. Default is `100`.
         - in: query
           name: afterTime
           schema:
             type: string
             format: date-time
-          description: 'Filter runs to those scheduled after this time, RFC3339'
+          description: |
+            A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339-timestamp)).
+            Only returns runs scheduled after this time.
         - in: query
           name: beforeTime
           schema:
             type: string
             format: date-time
-          description: 'Filter runs to those scheduled before this time, RFC3339'
+          description: |
+            A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339-timestamp)).
+            Only returns runs scheduled before this time.
       responses:
         '200':
-          description: A list of task runs
+          description: Success. The response body contains the list of task runs.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Runs'
+        '401':
+          $ref: '#/components/responses/AuthorizationError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
         default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/GeneralServerError'
     post:
       operationId: PostTasksIDRuns
       tags:
         - Data I/O endpoints
         - Tasks
-      summary: 'Manually start a task run, overriding the current schedule'
+      summary: 'Start a task run, overriding the schedule'
+      description: |
+        Schedules a task run to start immediately, ignoring scheduled runs.
+
+        Use this endpoint to manually start a task run.
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -5073,17 +5093,17 @@ paths:
               $ref: '#/components/schemas/RunManually'
       responses:
         '201':
-          description: Run scheduled to start
+          description: Success. The run is scheduled to start.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Run'
+        '401':
+          $ref: '#/components/responses/AuthorizationError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
         default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/GeneralServerError'
   '/tasks/{taskID}/runs/{runID}':
     get:
       operationId: GetTasksIDRunsID
@@ -5280,7 +5300,7 @@ paths:
                 $ref: '#/components/schemas/Logs'
               examples:
                 taskSuccess:
-                  summary: Events for successful task.
+                  summary: Events for a successful task run.
                   value:
                     events:
                       - runID: 09b070dadaa7d000
@@ -5290,7 +5310,7 @@ paths:
                         time: '2022-07-18T14:46:07.242859Z'
                         message: Completed(success)
                 taskFailure:
-                  summary: Events for a failed task.
+                  summary: Events for a failed task run.
                   value:
                     events:
                       - runID: 09a946fc3167d000
@@ -5325,26 +5345,57 @@ paths:
           schema:
             type: string
           required: true
-          description: ID of task to get logs for.
+          description: The ID of the task to get logs for.
         - in: path
           name: runID
           schema:
             type: string
           required: true
-          description: ID of run to get logs for.
+          description: The ID of the run to get logs for.
       responses:
         '200':
-          description: All logs for a run
+          description: |
+            Success. The response body contains an `events` list with logs for the task run.
+            Each log event `message` contains detail about the event.
+            If a run fails, InfluxDB logs an event with the reason for the failure.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Logs'
+              examples:
+                taskSuccess:
+                  summary: Events for a successful task run.
+                  value:
+                    events:
+                      - runID: 09b070dadaa7d000
+                        time: '2022-07-18T14:46:07.101231Z'
+                        message: 'Started task from script: "option task = {name: \"task1\", every: 30m} from(bucket: \"iot_center\") |> range(start: -90d) |> filter(fn: (r) => r._measurement == \"environment\") |> aggregateWindow(every: 1h, fn: mean)"'
+                      - runID: 09b070dadaa7d000
+                        time: '2022-07-18T14:46:07.242859Z'
+                        message: Completed(success)
+                taskFailure:
+                  summary: Events for a failed task.
+                  value:
+                    events:
+                      - runID: 09a946fc3167d000
+                        time: '2022-07-13T07:06:54.198167Z'
+                        message: 'Started task from script: "option task = {name: \"test task\", every: 3d, offset: 0s}"'
+                      - runID: 09a946fc3167d000
+                        time: '2022-07-13T07:07:13.104037Z'
+                        message: Completed(failed)
+                      - runID: 09a946fc3167d000
+                        time: '2022-07-13T08:24:37.115323Z'
+                        message: 'error exhausting result iterator: error in query specification while starting program: this Flux script returns no streaming data. Consider adding a "yield" or invoking streaming functions directly, without performing an assignment'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/AuthorizationError'
+        '404':
+          $ref: '#/components/responses/ResourceNotFoundError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
         default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/GeneralServerError'
   '/tasks/{taskID}/labels':
     get:
       operationId: GetTasksIDLabels
@@ -8650,13 +8701,17 @@ paths:
       operationId: GetBackupKV
       tags:
         - Backup
-      summary: 'Download snapshot of metadata stored in the server''s embedded KV store. Should not be used in versions greater than 2.1.x, as it doesn''t include metadata stored in embedded SQL.'
+      summary: Download snapshot of metadata stored in the server's embedded KV store. Don't use with InfluxDB versions greater than InfluxDB 2.1.x.
+      description: |
+        Retrieves a snapshot of metadata stored in the server's embedded KV store.
+        InfluxDB versions greater than 2.1.x don't include metadata stored in embedded SQL;
+        avoid using this endpoint with versions greater than 2.1.x.
       deprecated: true
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
       responses:
         '200':
-          description: Snapshot of KV metadata
+          description: Success. The response contains a snapshot of KV metadata.
           content:
             application/octet-stream:
               schema:
@@ -8731,10 +8786,14 @@ paths:
           description: The shard ID.
         - in: query
           name: since
-          description: Earliest time to include in the snapshot. RFC3339 format.
+          description: 'The earliest time [RFC3339 date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339-timestamp) to include in the snapshot.'
           schema:
             type: string
             format: date-time
+          examples:
+            RFC3339:
+              summary: RFC3339 date/time format
+              value: '2006-01-02T15:04:05Z07:00'
       responses:
         '200':
           description: TSM snapshot.
@@ -9544,6 +9603,13 @@ paths:
           $ref: '#/components/responses/InternalServerError'
         default:
           $ref: '#/components/responses/GeneralServerError'
+      x-codeSamples:
+        - lang: Shell
+          label: 'cURL: all tasks, basic output'
+          source: |
+            curl https://localhost:8086/api/v2/tasks/?limit=-1&type=basic \
+              --header 'Content-Type: application/json' \
+              --header 'Authorization: Token INFLUX_API_TOKEN'
     post:
       operationId: PostTasks
       tags:
@@ -9555,7 +9621,8 @@ paths:
 
         #### Related guides
 
-        - [Create a task](https://docs.influxdata.com/influxdb/v2.3/process-data/manage-tasks/create-task/).
+        - [Get started with tasks](https://docs.influxdata.com/influxdb/v2.3/process-data/get-started/)
+        - [Create a task](https://docs.influxdata.com/influxdb/v2.3/process-data/manage-tasks/create-task/)
         - [Common tasks](https://docs.influxdata.com/influxdb/v2.3/process-data/common-tasks/)
         - [Task configuration options](https://docs.influxdata.com/influxdb/v2.3/process-data/task-options/)
       parameters:
@@ -9575,14 +9642,28 @@ paths:
               schema:
                 $ref: '#/components/schemas/Task'
         '400':
-          description: Bad request
-          $ref: '#/components/responses/BadRequestError'
-          examples:
-            missingFluxError:
-              summary: Task in request body is missing Flux query
-              value:
-                code: invalid
-                message: 'failed to decode request: missing flux'
+          description: |
+            Bad request.
+            The response body contains detail about the error.
+
+            #### InfluxDB OSS
+
+            - Returns this error if an incorrect value is passed for `org` or `orgID`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                orgProvidedNotFound:
+                  summary: The org or orgID passed doesn't own the token passed in the header
+                  value:
+                    code: invalid
+                    message: 'failed to decode request body: organization not found'
+                missingFluxError:
+                  summary: Task in request body is missing Flux query
+                  value:
+                    code: invalid
+                    message: 'failed to decode request: missing flux'
         '401':
           $ref: '#/components/responses/AuthorizationError'
         '500':
@@ -9597,20 +9678,19 @@ paths:
         - lang: Shell
           label: 'cURL: create a task'
           source: |
-            curl -v --request POST \
-            http://localhost:8086/api/v2/tasks \
-            --header "Content-type: application/json" \
-            --header "Authorization: Token INFLUX_TOKEN" \
-            --data-binary @- << EOF
-              {
-              "orgID": "INFLUX_ORG_ID",
-              "description": "IoT Center 30d environment average.",
-              "flux": "option task = {name: \"iot-center-task-1\", every: 30m}\
-                      from(bucket: \"iot_center\")\
-                        |> range(start: -30d)\
-                        |> filter(fn: (r) => r._measurement == \"environment\")\
-                        |> aggregateWindow(every: 1h, fn: mean)"
-              }
+            curl http://localhost:8086/api/v2/tasks \
+              --header "Content-type: application/json" \
+              --header "Authorization: Token INFLUX_TOKEN" \
+              --data-binary @- << EOF
+                {
+                "orgID": "INFLUX_ORG_ID",
+                "description": "IoT Center 30d environment average.",
+                "flux": "option task = {name: \"iot-center-task-1\", every: 30m}\
+                        from(bucket: \"iot_center\")\
+                          |> range(start: -30d)\
+                          |> filter(fn: (r) => r._measurement == \"environment\")\
+                          |> aggregateWindow(every: 1h, fn: mean)"
+                }
             EOF
   '/tasks/{taskID}':
     get:
@@ -9621,7 +9701,7 @@ paths:
       summary: Retrieve a task
       description: |
         Retrieves a [task](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#task)
-        by task ID.
+        by ID.
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -9629,7 +9709,7 @@ paths:
           schema:
             type: string
           required: true
-          description: The task ID.
+          description: The ID of the task to retrieve.
       responses:
         '200':
           description: Success. The response body contains the task.
@@ -9656,7 +9736,7 @@ paths:
         Updates a task and then cancels all scheduled runs of the task.
 
         Use this endpoint to modify task properties (for example: `cron`, `name`, `flux`, `status`).
-        Once InfluxDB applies the update, it cancels all scheduled runs of the task.
+        Once InfluxDB applies the update, it cancels all previously scheduled runs of the task.
 
         To update a task, pass an object that contains the updated key-value pairs.
         To activate or inactivate a task, set the `status` property.
@@ -9902,11 +9982,15 @@ components:
         - stop
       properties:
         start:
-          description: 'A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/flux/v0.x/data-types/basic/time/#time-syntax)).'
+          description: |
+            A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339-timestamp)).
+            The earliest time to delete from.
           type: string
           format: date-time
         stop:
-          description: 'A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/flux/v0.x/data-types/basic/time/#time-syntax)).'
+          description: |
+            A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339-timestamp)).
+            The latest time to delete from.
           type: string
           format: date-time
         predicate:
@@ -10200,7 +10284,7 @@ components:
         value:
           type: boolean
     DateTimeLiteral:
-      description: Represents an instant in time with nanosecond precision using the syntax of golang's RFC3339 Nanosecond variant
+      description: 'Represents an instant in time with nanosecond precision in [RFC3339Nano date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339nano-timestamp).'
       type: object
       properties:
         type:
@@ -10298,21 +10382,35 @@ components:
         name:
           type: string
     Dialect:
-      description: 'Dialect are options to change the default CSV output format; https://www.w3.org/TR/2015/REC-tabular-metadata-20151217/#dialect-descriptions'
+      description: |
+        Options for tabular data output.
+        Default output is [annotated CSV](https://docs.influxdata.com/influxdb/v2.3/reference/syntax/annotated-csv/#csv-response-format) with headers.
+
+        For more information about tabular data **dialect**,
+        see [W3 metadata vocabulary for tabular data](https://www.w3.org/TR/2015/REC-tabular-metadata-20151217/#dialect-descriptions).
       type: object
       properties:
         header:
-          description: 'If true, the results will contain a header row'
+          description: 'If true, the results contain a header row.'
           type: boolean
           default: true
         delimiter:
-          description: 'Separator between cells; the default is ,'
+          description: 'The separator used between cells. Default is a comma (`,`).'
           type: string
           default: ','
           maxLength: 1
           minLength: 1
         annotations:
-          description: 'https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/#columns'
+          description: |
+            Annotation rows to include in the results.
+            An _annotation_ is metadata associated with an object (column) in the data model.
+
+            #### Related guides
+
+            - See [Annotated CSV annotations](https://docs.influxdata.com/influxdb/v2.3/reference/syntax/annotated-csv/#annotations) for examples and more information.
+
+            For more information about **annotations** in tabular data,
+            see [W3 metadata vocabulary for tabular data](https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/#columns).
           type: array
           uniqueItems: true
           items:
@@ -10322,13 +10420,23 @@ components:
               - datatype
               - default
         commentPrefix:
-          description: Character prefixed to comment strings
+          description: The character prefixed to comment strings. Default is a number sign (`#`).
           type: string
           default: '#'
           maxLength: 1
           minLength: 0
         dateTimeFormat:
-          description: Format of timestamps
+          description: |
+            The format for timestamps in results.
+            Default is [`RFC3339` date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339-timestamp).
+            To include nanoseconds in timestamps, use `RFC3339Nano`.
+
+            #### Example formatted date/time values
+
+            | Format      | Value                       |
+            |:------------|:----------------------------|
+            | `RFC3339`    | `"2006-01-02T15:04:05Z07:00"` |
+            | `RFC3339Nano` | `"2006-01-02T15:04:05.999999999Z07:00"` |
           type: string
           default: RFC3339
           enum:
@@ -10533,9 +10641,10 @@ components:
       properties:
         time:
           readOnly: true
-          description: 'Time event occurred, RFC3339Nano.'
+          description: 'The time ([RFC3339Nano date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339nano-timestamp)) that the event occurred.'
           type: string
           format: date-time
+          example: '2006-01-02T15:04:05.999999999Z07:00'
         message:
           readOnly: true
           description: A description of the event that occurred.
@@ -10543,7 +10652,7 @@ components:
           example: Halt and catch fire
         runID:
           readOnly: true
-          description: the ID of the task that logged
+          description: The ID of the task run that generated the event.
           type: string
     Organization:
       properties:
@@ -11590,7 +11699,7 @@ components:
             - success
             - canceled
         scheduledFor:
-          description: 'Time used for run''s "now" option, RFC3339.'
+          description: 'The time [RFC3339 date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339-timestamp) used for the run''s `now` option.'
           type: string
           format: date-time
         log:
@@ -11605,19 +11714,22 @@ components:
           readOnly: true
         startedAt:
           readOnly: true
-          description: 'Time run started executing, RFC3339Nano.'
+          description: 'The time ([RFC3339Nano date/time format](https://go.dev/src/time/format.go)) the run started executing.'
           type: string
           format: date-time
+          example: '2006-01-02T15:04:05.999999999Z07:00'
         finishedAt:
           readOnly: true
-          description: 'Time run finished executing, RFC3339Nano.'
+          description: 'The time ([RFC3339Nano date/time format](https://go.dev/src/time/format.go)) the run finished executing.'
           type: string
           format: date-time
+          example: '2006-01-02T15:04:05.999999999Z07:00'
         requestedAt:
           readOnly: true
-          description: 'Time run was manually requested, RFC3339Nano.'
+          description: 'The time ([RFC3339Nano date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339nano-timestamp)) the run was manually requested.'
           type: string
           format: date-time
+          example: '2006-01-02T15:04:05.999999999Z07:00'
         links:
           type: object
           readOnly: true
@@ -11639,7 +11751,10 @@ components:
       properties:
         scheduledFor:
           nullable: true
-          description: 'Time used for run''s "now" option, RFC3339.  Default is the server''s now time.'
+          description: |
+            The time [RFC3339 date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339-timestamp)
+            used for the run's `now` option.
+            Default is the server _now_ time.
           type: string
           format: date-time
     TaskStatusType:
@@ -13942,7 +14057,7 @@ components:
           type: string
         latestCompleted:
           type: string
-          description: 'Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.'
+          description: 'A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339-timestamp)) of the latest scheduled and completed run.'
           format: date-time
           readOnly: true
         lastRunStatus:
@@ -14212,7 +14327,7 @@ components:
         - endpointID
       properties:
         latestCompleted:
-          description: 'Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.'
+          description: 'A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339-timestamp)) of the latest scheduled and completed run.'
           type: string
           format: date-time
           readOnly: true

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -670,7 +670,7 @@ components:
           readOnly: true
           type: string
         latestCompleted:
-          description: Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339))
+          description: A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#rfc3339-timestamp))
             of the latest scheduled and completed run.
           format: date-time
           readOnly: true
@@ -1119,8 +1119,8 @@ components:
           $ref: '#/components/schemas/Links'
       type: object
     DateTimeLiteral:
-      description: Represents an instant in time with nanosecond precision using the
-        syntax of golang's RFC3339 Nanosecond variant
+      description: Represents an instant in time with nanosecond precision in [RFC3339Nano
+        date/time format](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#rfc3339nano-timestamp).
       properties:
         type:
           $ref: '#/components/schemas/NodeType'
@@ -1191,11 +1191,15 @@ components:
           example: tag1="value1" and (tag2="value2" and tag3!="value3")
           type: string
         start:
-          description: A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/flux/v0.x/data-types/basic/time/#time-syntax)).
+          description: |
+            A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#rfc3339-timestamp)).
+            The earliest time to delete from.
           format: date-time
           type: string
         stop:
-          description: A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/flux/v0.x/data-types/basic/time/#time-syntax)).
+          description: |
+            A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#rfc3339-timestamp)).
+            The latest time to delete from.
           format: date-time
           type: string
       required:
@@ -1203,10 +1207,24 @@ components:
       - stop
       type: object
     Dialect:
-      description: Dialect are options to change the default CSV output format; https://www.w3.org/TR/2015/REC-tabular-metadata-20151217/#dialect-descriptions
+      description: |
+        Options for tabular data output.
+        Default output is [annotated CSV](https://docs.influxdata.com/influxdb/cloud/reference/syntax/annotated-csv/#csv-response-format) with headers.
+
+        For more information about tabular data **dialect**,
+        see [W3 metadata vocabulary for tabular data](https://www.w3.org/TR/2015/REC-tabular-metadata-20151217/#dialect-descriptions).
       properties:
         annotations:
-          description: https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/#columns
+          description: |
+            Annotation rows to include in the results.
+            An _annotation_ is metadata associated with an object (column) in the data model.
+
+            #### Related guides
+
+            - See [Annotated CSV annotations](https://docs.influxdata.com/influxdb/cloud/reference/syntax/annotated-csv/#annotations) for examples and more information.
+
+            For more information about **annotations** in tabular data,
+            see [W3 metadata vocabulary for tabular data](https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/#columns).
           items:
             enum:
             - group
@@ -1217,26 +1235,37 @@ components:
           uniqueItems: true
         commentPrefix:
           default: '#'
-          description: Character prefixed to comment strings
+          description: The character prefixed to comment strings. Default is a number
+            sign (`#`).
           maxLength: 1
           minLength: 0
           type: string
         dateTimeFormat:
           default: RFC3339
-          description: Format of timestamps
+          description: |
+            The format for timestamps in results.
+            Default is [`RFC3339` date/time format](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#rfc3339-timestamp).
+            To include nanoseconds in timestamps, use `RFC3339Nano`.
+
+            #### Example formatted date/time values
+
+            | Format      | Value                       |
+            |:------------|:----------------------------|
+            | `RFC3339`    | `"2006-01-02T15:04:05Z07:00"` |
+            | `RFC3339Nano` | `"2006-01-02T15:04:05.999999999Z07:00"` |
           enum:
           - RFC3339
           - RFC3339Nano
           type: string
         delimiter:
           default: ','
-          description: Separator between cells; the default is ,
+          description: The separator used between cells. Default is a comma (`,`).
           maxLength: 1
           minLength: 1
           type: string
         header:
           default: true
-          description: If true, the results will contain a header row
+          description: If true, the results contain a header row.
           type: boolean
       type: object
     DictExpression:
@@ -2505,11 +2534,13 @@ components:
           readOnly: true
           type: string
         runID:
-          description: the ID of the task that logged
+          description: The ID of the task run that generated the event.
           readOnly: true
           type: string
         time:
-          description: Time event occurred, RFC3339Nano.
+          description: The time ([RFC3339Nano date/time format](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#rfc3339nano-timestamp))
+            that the event occurred.
+          example: 2006-01-02T15:04:05.999999999Z07:00
           format: date-time
           readOnly: true
           type: string
@@ -2994,7 +3025,7 @@ components:
           readOnly: true
           type: string
         latestCompleted:
-          description: Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339))
+          description: A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#rfc3339-timestamp))
             of the latest scheduled and completed run.
           format: date-time
           readOnly: true
@@ -3818,7 +3849,9 @@ components:
     Run:
       properties:
         finishedAt:
-          description: Time run finished executing, RFC3339Nano.
+          description: The time ([RFC3339Nano date/time format](https://go.dev/src/time/format.go))
+            the run finished executing.
+          example: 2006-01-02T15:04:05.999999999Z07:00
           format: date-time
           readOnly: true
           type: string
@@ -3853,16 +3886,21 @@ components:
           readOnly: true
           type: array
         requestedAt:
-          description: Time run was manually requested, RFC3339Nano.
+          description: The time ([RFC3339Nano date/time format](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#rfc3339nano-timestamp))
+            the run was manually requested.
+          example: 2006-01-02T15:04:05.999999999Z07:00
           format: date-time
           readOnly: true
           type: string
         scheduledFor:
-          description: Time used for run's "now" option, RFC3339.
+          description: The time [RFC3339 date/time format](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#rfc3339-timestamp)
+            used for the run's `now` option.
           format: date-time
           type: string
         startedAt:
-          description: Time run started executing, RFC3339Nano.
+          description: The time ([RFC3339Nano date/time format](https://go.dev/src/time/format.go))
+            the run started executing.
+          example: 2006-01-02T15:04:05.999999999Z07:00
           format: date-time
           readOnly: true
           type: string
@@ -3881,8 +3919,10 @@ components:
     RunManually:
       properties:
         scheduledFor:
-          description: Time used for run's "now" option, RFC3339.  Default is the
-            server's now time.
+          description: |
+            The time [RFC3339 date/time format](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#rfc3339-timestamp)
+            used for the run's `now` option.
+            Default is the server _now_ time.
           format: date-time
           nullable: true
           type: string
@@ -4456,14 +4496,14 @@ components:
           type: string
         cron:
           description: A [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview)
-            that defines the schedule on which the task runs. InfluxDB bases cron
-            runs on the system time.
+            that defines the schedule on which the task runs. InfluxDB uses the system
+            time when evaluating Cron expressions.
           type: string
         description:
           description: The description of the task.
           type: string
         every:
-          description: The interval ([duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals)))
+          description: The interval ([duration literal](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#rfc3339-timestamp))
             at which the task runs. `every` also determines when the task first runs,
             depending on the specified time.
           format: duration
@@ -4492,7 +4532,7 @@ components:
           readOnly: true
           type: string
         latestCompleted:
-          description: A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/flux/v0.x/data-types/basic/time/#time-syntax))
+          description: A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#rfc3339-timestamp))
             of the latest scheduled and completed run.
           format: date-time
           readOnly: true
@@ -10068,7 +10108,7 @@ paths:
         Analyzes a [Flux query](https://docs.influxdata.com/flux/v0.x/) for syntax
         errors and returns the list of errors.
 
-        In the following example `Query` object, `query` is missing a `from()` property key:
+        In the following sample query, `from()` is missing the property key.
 
             ```json
             { "query": "from(: \"iot_center\")\
@@ -10078,13 +10118,14 @@ paths:
             }
             ```
 
-        Passing this to `/api/v2/analyze` returns an `errors` list that contains an error object for the missing key.
+        If you pass this in a request to the `/api/v2/analyze` endpoint,
+        InfluxDB returns an `errors` list that contains an error object for the missing key.
 
         #### Limitations
 
         -  The endpoint doesn't validate values in the query--for example:
 
-          - The following query has correct syntax, but contains an incorrect `from()` property key:
+          - The following sample query has correct syntax, but contains an incorrect `from()` property key:
 
             ```json
             { "query": "from(foo: \"iot_center\")\
@@ -10094,7 +10135,8 @@ paths:
             }
             ```
 
-            Passing this to `/api/v2/analyze` returns an empty `errors` list.
+            If you pass this in a request to the `/api/v2/analyze` endpoint,
+            InfluxDB returns an empty `errors` list.
       operationId: PostQueryAnalyze
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
@@ -10119,7 +10161,7 @@ paths:
                   description: |
                     Returns an error object if the Flux query is missing a property key.
 
-                    The following example is missing the `bucket` property key:
+                    The following sample query is missing the _`bucket`_ property key:
 
                       ```json
                       {
@@ -10218,7 +10260,7 @@ paths:
     post:
       description: |
         Analyzes a Flux query and returns a complete package source [Abstract Syntax
-        Tree (AST)](https://https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#abstract-syntax-tree)
+        Tree (AST)](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#abstract-syntax-tree-ast)
         for the query.
 
         Use this endpoint for deep query analysis such as debugging unexpected query
@@ -10228,18 +10270,19 @@ paths:
         information about the query. The AST illustrates how the query is distributed
         into different components for execution.
 
-
         #### Limitations
 
         -  The endpoint doesn't validate values in the query--for example:
 
             The following query has correct syntax, but contains an incorrect `from()` property key:
+
             ```json
             { "query": "from(foo: \"iot_center\")\
                         |> range(start: -90d)\
                         |> filter(fn: (r) => r._measurement == \"environment\")"
             }
             ```
+
             Passing this to `/api/v2/query/ast` will return a successful response
             with a generated AST.
       operationId: PostQueryAst
@@ -10634,13 +10677,13 @@ paths:
       - label: cURL
         lang: Shell
         source: |
-          curl --request POST 'INFLUX_URL/api/v2/query/ast' \
-            --header 'Content-Type: application/json' \
-            --header 'Accept: application/json \
-            --header 'Authorization: Token INFLUX_TOKEN' \
-            --data 'from(bucket: "example-bucket")
-                      |> range(start: -5m)
-                      |> filter(fn: (r) => r._measurement == "example-measurement")'
+          curl --request POST 'http://localhost:8086/api/v2/query/ast' \
+          --header 'Content-Type: application/json' \
+          --header 'Accept: application/json' \
+          --header 'Authorization: Token INFLUX_TOKEN' \
+          --data 'from(bucket: "example-bucket")
+                    |> range(start: -5m)
+                    |> filter(fn: (r) => r._measurement == "example-measurement")'
   /api/v2/query/suggestions:
     get:
       description: |
@@ -12123,7 +12166,7 @@ paths:
           maximum: 500
           minimum: -1
           type: integer
-      - description: The number of records to skip
+      - description: The number of records to skip.
         in: query
         name: offset
         required: false
@@ -12131,7 +12174,9 @@ paths:
           default: 0
           minimum: 0
           type: integer
-      - description: Field that records should be sorted by
+      - description: |
+          The field used for sorting records in the list.
+          Only `name` is supported.
         in: query
         name: sortBy
         required: false
@@ -12173,7 +12218,7 @@ paths:
       - Data I/O endpoints
       - Tasks
       x-codeSamples:
-      - label: 'cURL: all tasks, `basic` output'
+      - label: 'cURL: all tasks, basic output'
         lang: Shell
         source: |
           curl https://cloud2.influxdata.com/api/v2/tasks/?limit=-1&type=basic \
@@ -12195,7 +12240,8 @@ paths:
 
         #### Related guides
 
-        - [Create a task](https://docs.influxdata.com/influxdb/cloud/process-data/manage-tasks/create-task/).
+        - [Get started with tasks](https://docs.influxdata.com/influxdb/cloud/process-data/get-started/)
+        - [Create a task](https://docs.influxdata.com/influxdb/cloud/process-data/manage-tasks/create-task/)
         - [Common tasks](https://docs.influxdata.com/influxdb/cloud/process-data/common-tasks/)
         - [Task configuration options](https://docs.influxdata.com/influxdb/cloud/process-data/task-options/)
       operationId: PostTasks
@@ -12217,26 +12263,31 @@ paths:
           description: Success. The response body contains a `tasks` list with the
             new task.
         "400":
-          $ref: '#/components/responses/BadRequestError'
+          content:
+            application/json:
+              examples:
+                fluxAndScriptError:
+                  summary: The request body can't contain both flux and scriptID
+                  value:
+                    code: invalid
+                    message: 'failed to decode request: can not provide both scriptID
+                      and flux'
+                missingFluxError:
+                  summary: The request body requires either a flux parameter or scriptID
+                    parameter
+                  value:
+                    code: invalid
+                    message: 'failed to decode request: flux required'
+              schema:
+                $ref: '#/components/schemas/Error'
           description: |
-            Bad request
+            Bad request.
+            The response body contains detail about the error.
 
             #### InfluxDB Cloud
 
               - Returns this error if the task doesn't contain one of _`flux`_ or _`scriptID`_.
               - Returns this error if the task contains _`flux`_ _and_ _`scriptID`_.
-          examples:
-            fluxAndScriptError:
-              summary: The request body can't contain both flux and scriptID
-              value:
-                code: invalid
-                message: 'failed to decode request: can not provide both scriptID
-                  and flux'
-            missingFluxError:
-              summary: The request body requires either flux or scriptID
-              value:
-                code: invalid
-                message: 'failed to decode request: flux required'
         "401":
           $ref: '#/components/responses/AuthorizationError'
         "500":
@@ -12252,43 +12303,41 @@ paths:
       - Data I/O endpoints
       - Tasks
       x-codeSamples:
-      - label: 'cURL: create a flux query task'
+      - label: 'cURL: create a Flux script task'
         lang: Shell
         source: |
-          curl -v --request POST \
-          https://cloud2.influxdata.com/api/v2/tasks \
+          curl https://cloud2.influxdata.com/api/v2/tasks \
           --header "Content-type: application/json" \
           --header "Authorization: Token INFLUX_TOKEN" \
           --data-binary @- << EOF
             {
-            "orgID": "INFLUX_ORG_ID",
-            "description": "IoT Center 30d environment average.",
-            "flux": "option task = {name: \"iot-center-task-1\", every: 30m}\
-                    from(bucket: \"iot_center\")\
-                      |> range(start: -30d)\
-                      |> filter(fn: (r) => r._measurement == \"environment\")\
-                      |> aggregateWindow(every: 1h, fn: mean)"
+              "orgID": "INFLUX_ORG_ID",
+              "description": "IoT Center 30d environment average.",
+              "flux": "option task = {name: \"iot-center-task-1\", every: 30m}\
+                      from(bucket: \"iot_center\")\
+                        |> range(start: -30d)\
+                        |> filter(fn: (r) => r._measurement == \"environment\")\
+                        |> aggregateWindow(every: 1h, fn: mean)"
             }
           EOF
-      - label: 'cURL: create a script task'
+      - label: 'cURL: create a Flux script reference task'
         lang: Shell
         source: |
-          curl -v --request POST \
-          https://cloud2.influxdata.com/api/v2/tasks \
+          curl https://cloud2.influxdata.com/api/v2/tasks \
           --header "Content-type: application/json" \
           --header "Authorization: Token INFLUX_TOKEN" \
           --data-binary @- << EOF
             {
-            "orgID": "INFLUX_ORG_ID",
-            "description": "IoT Center 30d environment average.",
-            "scriptID": "085138a111448000",
-            "scriptParameters":
-              {
-                "rangeStart": "-30d",
-                "bucket": "air_sensor",
-                "filterField": "temperature",
-                "groupColumn": "_time"
-              }
+              "orgID": "INFLUX_ORG_ID",
+              "description": "IoT Center 30d environment average.",
+              "scriptID": "085138a111448000",
+              "scriptParameters":
+                {
+                  "rangeStart": "-30d",
+                  "bucket": "air_sensor",
+                  "filterField": "temperature",
+                  "groupColumn": "_time"
+                }
             }
           EOF
   /api/v2/tasks/{taskID}:
@@ -12328,11 +12377,11 @@ paths:
     get:
       description: |
         Retrieves a [task](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#task)
-        by task ID.
+        by ID.
       operationId: GetTasksID
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
-      - description: The task ID.
+      - description: The ID of the task to retrieve.
         in: path
         name: taskID
         required: true
@@ -12364,7 +12413,7 @@ paths:
         Updates a task and then cancels all scheduled runs of the task.
 
         Use this endpoint to modify task properties (for example: `cron`, `name`, `flux`, `status`).
-        Once InfluxDB applies the update, it cancels all scheduled runs of the task.
+        Once InfluxDB applies the update, it cancels all previously scheduled runs of the task.
 
         To update a task, pass an object that contains the updated key-value pairs.
         To activate or inactivate a task, set the `status` property.
@@ -12543,7 +12592,7 @@ paths:
             application/json:
               examples:
                 taskFailure:
-                  summary: Events for a failed task.
+                  summary: Events for a failed task run.
                   value:
                     events:
                     - message: 'Started task from script: "option task = {name: \"test
@@ -12560,7 +12609,7 @@ paths:
                       runID: 09a946fc3167d000
                       time: "2022-07-13T08:24:37.115323Z"
                 taskSuccess:
-                  summary: Events for successful task.
+                  summary: Events for a successful task run.
                   value:
                     events:
                     - message: 'Started task from script: "option task = {name: \"task1\",
@@ -12771,21 +12820,29 @@ paths:
       - Tasks
   /api/v2/tasks/{taskID}/runs:
     get:
+      description: |
+        Retrieves a list of runs for a [task](https://docs.influxdata.com/influxdb/cloud/process-data/).
+
+        To limit which task runs are returned, pass query parameters in your request.
+        If no query parameters are passed, InfluxDB returns all task runs up to the default `limit`.
       operationId: GetTasksIDRuns
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
-      - description: The ID of the task to get runs for.
+      - description: |
+          The ID of the task to get runs for.
+          Only returns runs for this task.
         in: path
         name: taskID
         required: true
         schema:
           type: string
-      - description: Returns runs after a specific ID.
+      - description: A task run ID. Only returns runs created after this run.
         in: query
         name: after
         schema:
           type: string
-      - description: The number of runs to return
+      - description: |
+          Limits the number of task runs returned. Default is `100`.
         in: query
         name: limit
         schema:
@@ -12793,13 +12850,17 @@ paths:
           maximum: 500
           minimum: 1
           type: integer
-      - description: Filter runs to those scheduled after this time, RFC3339
+      - description: |
+          A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#rfc3339-timestamp)).
+          Only returns runs scheduled after this time.
         in: query
         name: afterTime
         schema:
           format: date-time
           type: string
-      - description: Filter runs to those scheduled before this time, RFC3339
+      - description: |
+          A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#rfc3339-timestamp)).
+          Only returns runs scheduled before this time.
         in: query
         name: beforeTime
         schema:
@@ -12811,17 +12872,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Runs'
-          description: A list of task runs
+          description: Success. The response body contains the list of task runs.
+        "401":
+          $ref: '#/components/responses/AuthorizationError'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
         default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Unexpected error
+          $ref: '#/components/responses/GeneralServerError'
       summary: List runs for a task
       tags:
       - Tasks
     post:
+      description: |
+        Schedules a task run to start immediately, ignoring scheduled runs.
+
+        Use this endpoint to manually start a task run.
       operationId: PostTasksIDRuns
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
@@ -12841,14 +12906,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Run'
-          description: Run scheduled to start
+          description: Success. The run is scheduled to start.
+        "401":
+          $ref: '#/components/responses/AuthorizationError'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
         default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Unexpected error
-      summary: Manually start a task run, overriding the current schedule
+          $ref: '#/components/responses/GeneralServerError'
+      summary: Start a task run, overriding the schedule
       tags:
       - Data I/O endpoints
       - Tasks
@@ -12984,13 +13049,13 @@ paths:
       operationId: GetTasksIDRunsIDLogs
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
-      - description: ID of task to get logs for.
+      - description: The ID of the task to get logs for.
         in: path
         name: taskID
         required: true
         schema:
           type: string
-      - description: ID of run to get logs for.
+      - description: The ID of the run to get logs for.
         in: path
         name: runID
         required: true
@@ -13000,15 +13065,53 @@ paths:
         "200":
           content:
             application/json:
+              examples:
+                taskFailure:
+                  summary: Events for a failed task.
+                  value:
+                    events:
+                    - message: 'Started task from script: "option task = {name: \"test
+                        task\", every: 3d, offset: 0s}"'
+                      runID: 09a946fc3167d000
+                      time: "2022-07-13T07:06:54.198167Z"
+                    - message: Completed(failed)
+                      runID: 09a946fc3167d000
+                      time: "2022-07-13T07:07:13.104037Z"
+                    - message: 'error exhausting result iterator: error in query specification
+                        while starting program: this Flux script returns no streaming
+                        data. Consider adding a "yield" or invoking streaming functions
+                        directly, without performing an assignment'
+                      runID: 09a946fc3167d000
+                      time: "2022-07-13T08:24:37.115323Z"
+                taskSuccess:
+                  summary: Events for a successful task run.
+                  value:
+                    events:
+                    - message: 'Started task from script: "option task = {name: \"task1\",
+                        every: 30m} from(bucket: \"iot_center\") |> range(start: -90d)
+                        |> filter(fn: (r) => r._measurement == \"environment\") |>
+                        aggregateWindow(every: 1h, fn: mean)"'
+                      runID: 09b070dadaa7d000
+                      time: "2022-07-18T14:46:07.101231Z"
+                    - message: Completed(success)
+                      runID: 09b070dadaa7d000
+                      time: "2022-07-18T14:46:07.242859Z"
               schema:
                 $ref: '#/components/schemas/Logs'
-          description: All logs for a run
+          description: |
+            Success. The response body contains an `events` list with logs for the task run.
+            Each log event `message` contains detail about the event.
+            If a run fails, InfluxDB logs an event with the reason for the failure.
+        "400":
+          $ref: '#/components/responses/BadRequestError'
+        "401":
+          $ref: '#/components/responses/AuthorizationError'
+        "404":
+          $ref: '#/components/responses/ResourceNotFoundError'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
         default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Unexpected error
+          $ref: '#/components/responses/GeneralServerError'
       summary: Retrieve all logs for a run
       tags:
       - Tasks
@@ -14541,7 +14644,7 @@ paths:
           description: |
             Media type that the client can understand.
 
-            **Note**: With `application/csv`, query results include [unix timestamps]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#unix-timestamp) instead of RFC3339 timestamps.
+            **Note**: With `application/csv`, query results include [**unix timestamps**]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#unix-timestamp) instead of [RFC3339 timestamps]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp).
           enum:
           - application/json
           - application/csv
@@ -14600,9 +14703,10 @@ paths:
         required: true
         schema:
           type: string
-      - description: Return results with [unix (epoch) timestamps]({{% INFLUXDB_DOCS_URL
-          %}}/reference/glossary/#unix-timestamp) in the specified precision instead
-          of RFC3339 timestamps with nanosecond precision.
+      - description: |
+          A unix timestamp precision.
+          Formats timestamps as [unix (epoch) timestamps]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#unix-timestamp) the specified precision
+          instead of [RFC3339 timestamps]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp) with nanosecond precision.
         in: query
         name: epoch
         schema:
@@ -14840,8 +14944,9 @@ tags:
 
     #### Related guides
 
+    - [Get started with tasks](https://docs.influxdata.com/influxdb/cloud/process-data/get-started/)
     - [Common data processing tasks](https://docs.influxdata.com/influxdb/cloud/process-data/common-tasks/)
-    - [Invoke custom scripts as API endpoints](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/)
+    - [Create a script](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/#create-an-invokable-script).
   name: Tasks
 - description: |
     Write time series data to buckets.
@@ -14901,8 +15006,8 @@ tags:
     |:-----------:|:------------------------ |:--------------------- |
     | `200`       | Success                  |                       |
     | `204`       | No content               | For a `POST` request, `204` indicates that InfluxDB accepted the request and request data is valid. Asynchronous operations, such as `write`, might not have completed yet. |
-    | `400`       | Bad request              | May indicate one of the following: <li>Line protocol is malformed. The response body contains the first malformed line in the data and indicates what was expected. For partial writes, the number of points written and the number of points rejected are also included. For more information, check the `rejected_points` measurement in your `_monitoring` bucket.</li><li>`Authorization` header is missing or malformed or the API token does not have permission for the operation.</li> |
-    | `401`       | Unauthorized             | May indicate one of the following: <li>`Authorization: Token` header is missing or malformed</li><li>API token value is missing from the header</li><li>API token does not have permission. For more information about token types and permissions, see [Manage API tokens](https://docs.influxdata.com/influxdb/cloud/security/tokens/)</li> |
+    | `400`       | Bad request              | May indicate one of the following: <ul><li>Line protocol is malformed. The response body contains the first malformed line in the data and indicates what was expected. For partial writes, the number of points written and the number of points rejected are also included. For more information, check the `rejected_points` measurement in your `_monitoring` bucket.</li><li>`Authorization` header is missing or malformed or the API token does not have permission for the operation.</li></ul> |
+    | `401`       | Unauthorized             | May indicate one of the following: <ul><li>`Authorization: Token` header is missing or malformed</li><li>API token value is missing from the header</li><li>API token does not have permission. For more information about token types and permissions, see [Manage API tokens](https://docs.influxdata.com/influxdb/cloud/security/tokens/)</li></ul> |
     | `404`       | Not found                | Requested resource was not found. `message` in the response body provides details about the requested resource. |
     | `413`       | Request entity too large | Request payload exceeds the size limit. |
     | `422`       | Unprocessable entity     | Request data is invalid. `code` and `message` in the response body provide details about the problem. |

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -735,7 +735,7 @@ components:
           readOnly: true
           type: string
         latestCompleted:
-          description: Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339))
+          description: A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339-timestamp))
             of the latest scheduled and completed run.
           format: date-time
           readOnly: true
@@ -1174,8 +1174,8 @@ components:
           $ref: '#/components/schemas/Links'
       type: object
     DateTimeLiteral:
-      description: Represents an instant in time with nanosecond precision using the
-        syntax of golang's RFC3339 Nanosecond variant
+      description: Represents an instant in time with nanosecond precision in [RFC3339Nano
+        date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339nano-timestamp).
       properties:
         type:
           $ref: '#/components/schemas/NodeType'
@@ -1246,11 +1246,15 @@ components:
           example: tag1="value1" and (tag2="value2" and tag3!="value3")
           type: string
         start:
-          description: A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/flux/v0.x/data-types/basic/time/#time-syntax)).
+          description: |
+            A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339-timestamp)).
+            The earliest time to delete from.
           format: date-time
           type: string
         stop:
-          description: A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/flux/v0.x/data-types/basic/time/#time-syntax)).
+          description: |
+            A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339-timestamp)).
+            The latest time to delete from.
           format: date-time
           type: string
       required:
@@ -1258,10 +1262,24 @@ components:
       - stop
       type: object
     Dialect:
-      description: Dialect are options to change the default CSV output format; https://www.w3.org/TR/2015/REC-tabular-metadata-20151217/#dialect-descriptions
+      description: |
+        Options for tabular data output.
+        Default output is [annotated CSV](https://docs.influxdata.com/influxdb/v2.3/reference/syntax/annotated-csv/#csv-response-format) with headers.
+
+        For more information about tabular data **dialect**,
+        see [W3 metadata vocabulary for tabular data](https://www.w3.org/TR/2015/REC-tabular-metadata-20151217/#dialect-descriptions).
       properties:
         annotations:
-          description: https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/#columns
+          description: |
+            Annotation rows to include in the results.
+            An _annotation_ is metadata associated with an object (column) in the data model.
+
+            #### Related guides
+
+            - See [Annotated CSV annotations](https://docs.influxdata.com/influxdb/v2.3/reference/syntax/annotated-csv/#annotations) for examples and more information.
+
+            For more information about **annotations** in tabular data,
+            see [W3 metadata vocabulary for tabular data](https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/#columns).
           items:
             enum:
             - group
@@ -1272,26 +1290,37 @@ components:
           uniqueItems: true
         commentPrefix:
           default: '#'
-          description: Character prefixed to comment strings
+          description: The character prefixed to comment strings. Default is a number
+            sign (`#`).
           maxLength: 1
           minLength: 0
           type: string
         dateTimeFormat:
           default: RFC3339
-          description: Format of timestamps
+          description: |
+            The format for timestamps in results.
+            Default is [`RFC3339` date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339-timestamp).
+            To include nanoseconds in timestamps, use `RFC3339Nano`.
+
+            #### Example formatted date/time values
+
+            | Format      | Value                       |
+            |:------------|:----------------------------|
+            | `RFC3339`    | `"2006-01-02T15:04:05Z07:00"` |
+            | `RFC3339Nano` | `"2006-01-02T15:04:05.999999999Z07:00"` |
           enum:
           - RFC3339
           - RFC3339Nano
           type: string
         delimiter:
           default: ','
-          description: Separator between cells; the default is ,
+          description: The separator used between cells. Default is a comma (`,`).
           maxLength: 1
           minLength: 1
           type: string
         header:
           default: true
-          description: If true, the results will contain a header row
+          description: If true, the results contain a header row.
           type: boolean
       type: object
     DictExpression:
@@ -2453,11 +2482,13 @@ components:
           readOnly: true
           type: string
         runID:
-          description: the ID of the task that logged
+          description: The ID of the task run that generated the event.
           readOnly: true
           type: string
         time:
-          description: Time event occurred, RFC3339Nano.
+          description: The time ([RFC3339Nano date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339nano-timestamp))
+            that the event occurred.
+          example: 2006-01-02T15:04:05.999999999Z07:00
           format: date-time
           readOnly: true
           type: string
@@ -2796,7 +2827,7 @@ components:
           readOnly: true
           type: string
         latestCompleted:
-          description: Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339))
+          description: A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339-timestamp))
             of the latest scheduled and completed run.
           format: date-time
           readOnly: true
@@ -3844,7 +3875,9 @@ components:
     Run:
       properties:
         finishedAt:
-          description: Time run finished executing, RFC3339Nano.
+          description: The time ([RFC3339Nano date/time format](https://go.dev/src/time/format.go))
+            the run finished executing.
+          example: 2006-01-02T15:04:05.999999999Z07:00
           format: date-time
           readOnly: true
           type: string
@@ -3879,16 +3912,21 @@ components:
           readOnly: true
           type: array
         requestedAt:
-          description: Time run was manually requested, RFC3339Nano.
+          description: The time ([RFC3339Nano date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339nano-timestamp))
+            the run was manually requested.
+          example: 2006-01-02T15:04:05.999999999Z07:00
           format: date-time
           readOnly: true
           type: string
         scheduledFor:
-          description: Time used for run's "now" option, RFC3339.
+          description: The time [RFC3339 date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339-timestamp)
+            used for the run's `now` option.
           format: date-time
           type: string
         startedAt:
-          description: Time run started executing, RFC3339Nano.
+          description: The time ([RFC3339Nano date/time format](https://go.dev/src/time/format.go))
+            the run started executing.
+          example: 2006-01-02T15:04:05.999999999Z07:00
           format: date-time
           readOnly: true
           type: string
@@ -3907,8 +3945,10 @@ components:
     RunManually:
       properties:
         scheduledFor:
-          description: Time used for run's "now" option, RFC3339.  Default is the
-            server's now time.
+          description: |
+            The time [RFC3339 date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339-timestamp)
+            used for the run's `now` option.
+            Default is the server _now_ time.
           format: date-time
           nullable: true
           type: string
@@ -6392,6 +6432,10 @@ paths:
   /api/v2/backup/kv:
     get:
       deprecated: true
+      description: |
+        Retrieves a snapshot of metadata stored in the server's embedded KV store.
+        InfluxDB versions greater than 2.1.x don't include metadata stored in embedded SQL;
+        avoid using this endpoint with versions greater than 2.1.x.
       operationId: GetBackupKV
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
@@ -6402,13 +6446,12 @@ paths:
               schema:
                 format: binary
                 type: string
-          description: Snapshot of KV metadata
+          description: Success. The response contains a snapshot of KV metadata.
         default:
           $ref: '#/components/responses/GeneralServerError'
           description: Unexpected error
       summary: Download snapshot of metadata stored in the server's embedded KV store.
-        Should not be used in versions greater than 2.1.x, as it doesn't include metadata
-        stored in embedded SQL.
+        Don't use with InfluxDB versions greater than InfluxDB 2.1.x.
       tags:
       - Backup
   /api/v2/backup/metadata:
@@ -6477,7 +6520,12 @@ paths:
         schema:
           format: int64
           type: integer
-      - description: Earliest time to include in the snapshot. RFC3339 format.
+      - description: The earliest time [RFC3339 date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339-timestamp)
+          to include in the snapshot.
+        examples:
+          RFC3339:
+            summary: RFC3339 date/time format
+            value: 2006-01-02T15:04:05Z07:00
         in: query
         name: since
         schema:
@@ -10797,7 +10845,7 @@ paths:
         Analyzes a [Flux query](https://docs.influxdata.com/flux/v0.x/) for syntax
         errors and returns the list of errors.
 
-        In the following example `Query` object, `query` is missing a `from()` property key:
+        In the following sample query, `from()` is missing the property key.
 
             ```json
             { "query": "from(: \"iot_center\")\
@@ -10807,13 +10855,14 @@ paths:
             }
             ```
 
-        Passing this to `/api/v2/analyze` returns an `errors` list that contains an error object for the missing key.
+        If you pass this in a request to the `/api/v2/analyze` endpoint,
+        InfluxDB returns an `errors` list that contains an error object for the missing key.
 
         #### Limitations
 
         -  The endpoint doesn't validate values in the query--for example:
 
-          - The following query has correct syntax, but contains an incorrect `from()` property key:
+          - The following sample query has correct syntax, but contains an incorrect `from()` property key:
 
             ```json
             { "query": "from(foo: \"iot_center\")\
@@ -10823,7 +10872,8 @@ paths:
             }
             ```
 
-            Passing this to `/api/v2/analyze` returns an empty `errors` list.
+            If you pass this in a request to the `/api/v2/analyze` endpoint,
+            InfluxDB returns an empty `errors` list.
       operationId: PostQueryAnalyze
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
@@ -10848,7 +10898,7 @@ paths:
                   description: |
                     Returns an error object if the Flux query is missing a property key.
 
-                    The following example is missing the `bucket` property key:
+                    The following sample query is missing the _`bucket`_ property key:
 
                       ```json
                       {
@@ -10947,7 +10997,7 @@ paths:
     post:
       description: |
         Analyzes a Flux query and returns a complete package source [Abstract Syntax
-        Tree (AST)](https://https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#abstract-syntax-tree)
+        Tree (AST)](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#abstract-syntax-tree-ast)
         for the query.
 
         Use this endpoint for deep query analysis such as debugging unexpected query
@@ -10957,18 +11007,19 @@ paths:
         information about the query. The AST illustrates how the query is distributed
         into different components for execution.
 
-
         #### Limitations
 
         -  The endpoint doesn't validate values in the query--for example:
 
             The following query has correct syntax, but contains an incorrect `from()` property key:
+
             ```json
             { "query": "from(foo: \"iot_center\")\
                         |> range(start: -90d)\
                         |> filter(fn: (r) => r._measurement == \"environment\")"
             }
             ```
+
             Passing this to `/api/v2/query/ast` will return a successful response
             with a generated AST.
       operationId: PostQueryAst
@@ -11363,13 +11414,13 @@ paths:
       - label: cURL
         lang: Shell
         source: |
-          curl --request POST 'INFLUX_URL/api/v2/query/ast' \
-            --header 'Content-Type: application/json' \
-            --header 'Accept: application/json \
-            --header 'Authorization: Token INFLUX_TOKEN' \
-            --data 'from(bucket: "example-bucket")
-                      |> range(start: -5m)
-                      |> filter(fn: (r) => r._measurement == "example-measurement")'
+          curl --request POST 'http://localhost:8086/api/v2/query/ast' \
+          --header 'Content-Type: application/json' \
+          --header 'Accept: application/json' \
+          --header 'Authorization: Token INFLUX_TOKEN' \
+          --data 'from(bucket: "example-bucket")
+                    |> range(start: -5m)
+                    |> filter(fn: (r) => r._measurement == "example-measurement")'
   /api/v2/query/suggestions:
     get:
       description: |
@@ -13778,13 +13829,21 @@ paths:
       tags:
       - Data I/O endpoints
       - Tasks
+      x-codeSamples:
+      - label: 'cURL: all tasks, basic output'
+        lang: Shell
+        source: |
+          curl https://localhost:8086/api/v2/tasks/?limit=-1&type=basic \
+            --header 'Content-Type: application/json' \
+            --header 'Authorization: Token INFLUX_API_TOKEN'
     post:
       description: |
         Creates a [task](https://docs.influxdata.com/influxdb/v2.3/process-data/) and returns the created task.
 
         #### Related guides
 
-        - [Create a task](https://docs.influxdata.com/influxdb/v2.3/process-data/manage-tasks/create-task/).
+        - [Get started with tasks](https://docs.influxdata.com/influxdb/v2.3/process-data/get-started/)
+        - [Create a task](https://docs.influxdata.com/influxdb/v2.3/process-data/manage-tasks/create-task/)
         - [Common tasks](https://docs.influxdata.com/influxdb/v2.3/process-data/common-tasks/)
         - [Task configuration options](https://docs.influxdata.com/influxdb/v2.3/process-data/task-options/)
       operationId: PostTasks
@@ -13806,14 +13865,29 @@ paths:
           description: Success. The response body contains a `tasks` list with the
             new task.
         "400":
-          $ref: '#/components/responses/BadRequestError'
-          description: Bad request
-          examples:
-            missingFluxError:
-              summary: Task in request body is missing Flux query
-              value:
-                code: invalid
-                message: 'failed to decode request: missing flux'
+          content:
+            application/json:
+              examples:
+                missingFluxError:
+                  summary: Task in request body is missing Flux query
+                  value:
+                    code: invalid
+                    message: 'failed to decode request: missing flux'
+                orgProvidedNotFound:
+                  summary: The org or orgID passed doesn't own the token passed in
+                    the header
+                  value:
+                    code: invalid
+                    message: 'failed to decode request body: organization not found'
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            Bad request.
+            The response body contains detail about the error.
+
+            #### InfluxDB OSS
+
+            - Returns this error if an incorrect value is passed for `org` or `orgID`.
         "401":
           $ref: '#/components/responses/AuthorizationError'
         "500":
@@ -13832,20 +13906,19 @@ paths:
       - label: 'cURL: create a task'
         lang: Shell
         source: |
-          curl -v --request POST \
-          http://localhost:8086/api/v2/tasks \
-          --header "Content-type: application/json" \
-          --header "Authorization: Token INFLUX_TOKEN" \
-          --data-binary @- << EOF
-            {
-            "orgID": "INFLUX_ORG_ID",
-            "description": "IoT Center 30d environment average.",
-            "flux": "option task = {name: \"iot-center-task-1\", every: 30m}\
-                    from(bucket: \"iot_center\")\
-                      |> range(start: -30d)\
-                      |> filter(fn: (r) => r._measurement == \"environment\")\
-                      |> aggregateWindow(every: 1h, fn: mean)"
-            }
+          curl http://localhost:8086/api/v2/tasks \
+            --header "Content-type: application/json" \
+            --header "Authorization: Token INFLUX_TOKEN" \
+            --data-binary @- << EOF
+              {
+              "orgID": "INFLUX_ORG_ID",
+              "description": "IoT Center 30d environment average.",
+              "flux": "option task = {name: \"iot-center-task-1\", every: 30m}\
+                      from(bucket: \"iot_center\")\
+                        |> range(start: -30d)\
+                        |> filter(fn: (r) => r._measurement == \"environment\")\
+                        |> aggregateWindow(every: 1h, fn: mean)"
+              }
           EOF
   /api/v2/tasks/{taskID}:
     delete:
@@ -13884,11 +13957,11 @@ paths:
     get:
       description: |
         Retrieves a [task](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#task)
-        by task ID.
+        by ID.
       operationId: GetTasksID
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
-      - description: The task ID.
+      - description: The ID of the task to retrieve.
         in: path
         name: taskID
         required: true
@@ -13920,7 +13993,7 @@ paths:
         Updates a task and then cancels all scheduled runs of the task.
 
         Use this endpoint to modify task properties (for example: `cron`, `name`, `flux`, `status`).
-        Once InfluxDB applies the update, it cancels all scheduled runs of the task.
+        Once InfluxDB applies the update, it cancels all previously scheduled runs of the task.
 
         To update a task, pass an object that contains the updated key-value pairs.
         To activate or inactivate a task, set the `status` property.
@@ -14099,7 +14172,7 @@ paths:
             application/json:
               examples:
                 taskFailure:
-                  summary: Events for a failed task.
+                  summary: Events for a failed task run.
                   value:
                     events:
                     - message: 'Started task from script: "option task = {name: \"test
@@ -14116,7 +14189,7 @@ paths:
                       runID: 09a946fc3167d000
                       time: "2022-07-13T08:24:37.115323Z"
                 taskSuccess:
-                  summary: Events for successful task.
+                  summary: Events for a successful task run.
                   value:
                     events:
                     - message: 'Started task from script: "option task = {name: \"task1\",
@@ -14327,21 +14400,29 @@ paths:
       - Tasks
   /api/v2/tasks/{taskID}/runs:
     get:
+      description: |
+        Retrieves a list of runs for a [task](https://docs.influxdata.com/influxdb/v2.3/process-data/).
+
+        To limit which task runs are returned, pass query parameters in your request.
+        If no query parameters are passed, InfluxDB returns all task runs up to the default `limit`.
       operationId: GetTasksIDRuns
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
-      - description: The ID of the task to get runs for.
+      - description: |
+          The ID of the task to get runs for.
+          Only returns runs for this task.
         in: path
         name: taskID
         required: true
         schema:
           type: string
-      - description: Returns runs after a specific ID.
+      - description: A task run ID. Only returns runs created after this run.
         in: query
         name: after
         schema:
           type: string
-      - description: The number of runs to return
+      - description: |
+          Limits the number of task runs returned. Default is `100`.
         in: query
         name: limit
         schema:
@@ -14349,13 +14430,17 @@ paths:
           maximum: 500
           minimum: 1
           type: integer
-      - description: Filter runs to those scheduled after this time, RFC3339
+      - description: |
+          A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339-timestamp)).
+          Only returns runs scheduled after this time.
         in: query
         name: afterTime
         schema:
           format: date-time
           type: string
-      - description: Filter runs to those scheduled before this time, RFC3339
+      - description: |
+          A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#rfc3339-timestamp)).
+          Only returns runs scheduled before this time.
         in: query
         name: beforeTime
         schema:
@@ -14367,17 +14452,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Runs'
-          description: A list of task runs
+          description: Success. The response body contains the list of task runs.
+        "401":
+          $ref: '#/components/responses/AuthorizationError'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
         default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Unexpected error
+          $ref: '#/components/responses/GeneralServerError'
       summary: List runs for a task
       tags:
       - Tasks
     post:
+      description: |
+        Schedules a task run to start immediately, ignoring scheduled runs.
+
+        Use this endpoint to manually start a task run.
       operationId: PostTasksIDRuns
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
@@ -14397,14 +14486,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Run'
-          description: Run scheduled to start
+          description: Success. The run is scheduled to start.
+        "401":
+          $ref: '#/components/responses/AuthorizationError'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
         default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Unexpected error
-      summary: Manually start a task run, overriding the current schedule
+          $ref: '#/components/responses/GeneralServerError'
+      summary: Start a task run, overriding the schedule
       tags:
       - Data I/O endpoints
       - Tasks
@@ -14540,13 +14629,13 @@ paths:
       operationId: GetTasksIDRunsIDLogs
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
-      - description: ID of task to get logs for.
+      - description: The ID of the task to get logs for.
         in: path
         name: taskID
         required: true
         schema:
           type: string
-      - description: ID of run to get logs for.
+      - description: The ID of the run to get logs for.
         in: path
         name: runID
         required: true
@@ -14556,15 +14645,53 @@ paths:
         "200":
           content:
             application/json:
+              examples:
+                taskFailure:
+                  summary: Events for a failed task.
+                  value:
+                    events:
+                    - message: 'Started task from script: "option task = {name: \"test
+                        task\", every: 3d, offset: 0s}"'
+                      runID: 09a946fc3167d000
+                      time: "2022-07-13T07:06:54.198167Z"
+                    - message: Completed(failed)
+                      runID: 09a946fc3167d000
+                      time: "2022-07-13T07:07:13.104037Z"
+                    - message: 'error exhausting result iterator: error in query specification
+                        while starting program: this Flux script returns no streaming
+                        data. Consider adding a "yield" or invoking streaming functions
+                        directly, without performing an assignment'
+                      runID: 09a946fc3167d000
+                      time: "2022-07-13T08:24:37.115323Z"
+                taskSuccess:
+                  summary: Events for a successful task run.
+                  value:
+                    events:
+                    - message: 'Started task from script: "option task = {name: \"task1\",
+                        every: 30m} from(bucket: \"iot_center\") |> range(start: -90d)
+                        |> filter(fn: (r) => r._measurement == \"environment\") |>
+                        aggregateWindow(every: 1h, fn: mean)"'
+                      runID: 09b070dadaa7d000
+                      time: "2022-07-18T14:46:07.101231Z"
+                    - message: Completed(success)
+                      runID: 09b070dadaa7d000
+                      time: "2022-07-18T14:46:07.242859Z"
               schema:
                 $ref: '#/components/schemas/Logs'
-          description: All logs for a run
+          description: |
+            Success. The response body contains an `events` list with logs for the task run.
+            Each log event `message` contains detail about the event.
+            If a run fails, InfluxDB logs an event with the reason for the failure.
+        "400":
+          $ref: '#/components/responses/BadRequestError'
+        "401":
+          $ref: '#/components/responses/AuthorizationError'
+        "404":
+          $ref: '#/components/responses/ResourceNotFoundError'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
         default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Unexpected error
+          $ref: '#/components/responses/GeneralServerError'
       summary: Retrieve all logs for a run
       tags:
       - Tasks
@@ -16110,7 +16237,7 @@ paths:
           description: |
             Media type that the client can understand.
 
-            **Note**: With `application/csv`, query results include [unix timestamps]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#unix-timestamp) instead of RFC3339 timestamps.
+            **Note**: With `application/csv`, query results include [**unix timestamps**]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#unix-timestamp) instead of [RFC3339 timestamps]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp).
           enum:
           - application/json
           - application/csv
@@ -16169,9 +16296,10 @@ paths:
         required: true
         schema:
           type: string
-      - description: Return results with [unix (epoch) timestamps]({{% INFLUXDB_DOCS_URL
-          %}}/reference/glossary/#unix-timestamp) in the specified precision instead
-          of RFC3339 timestamps with nanosecond precision.
+      - description: |
+          A unix timestamp precision.
+          Formats timestamps as [unix (epoch) timestamps]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#unix-timestamp) the specified precision
+          instead of [RFC3339 timestamps]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp) with nanosecond precision.
         in: query
         name: epoch
         schema:
@@ -16405,6 +16533,7 @@ tags:
 
     #### Related guides
 
+    - [Get started with tasks](https://docs.influxdata.com/influxdb/v2.3/process-data/get-started/)
     - [Common data processing tasks](https://docs.influxdata.com/influxdb/v2.3/process-data/common-tasks/)
   name: Tasks
 - description: |
@@ -16469,8 +16598,8 @@ tags:
     |:-----------:|:------------------------ |:--------------------- |
     | `200`       | Success                  |                       |
     | `204`       | No content               | For a `POST` request, `204` indicates that InfluxDB accepted the request and request data is valid. Asynchronous operations, such as `write`, might not have completed yet. |
-    | `400`       | Bad request              | May indicate one of the following: <li>Line protocol is malformed. The response body contains the first malformed line in the data and indicates what was expected. For partial writes, the number of points written and the number of points rejected are also included. For more information, check the `rejected_points` measurement in your `_monitoring` bucket.</li><li>`Authorization` header is missing or malformed or the API token does not have permission for the operation.</li> |
-    | `401`       | Unauthorized             | May indicate one of the following: <li>`Authorization: Token` header is missing or malformed</li><li>API token value is missing from the header</li><li>API token does not have permission. For more information about token types and permissions, see [Manage API tokens](https://docs.influxdata.com/influxdb/latest/security/tokens/)</li> |
+    | `400`       | Bad request              | May indicate one of the following: <ul><li>Line protocol is malformed. The response body contains the first malformed line in the data and indicates what was expected. For partial writes, the number of points written and the number of points rejected are also included. For more information, check the `rejected_points` measurement in your `_monitoring` bucket.</li><li>`Authorization` header is missing or malformed or the API token does not have permission for the operation.</li></ul> |
+    | `401`       | Unauthorized             | May indicate one of the following: <ul><li>`Authorization: Token` header is missing or malformed</li><li>API token value is missing from the header</li><li>API token does not have permission. For more information about token types and permissions, see [Manage API tokens](https://docs.influxdata.com/influxdb/latest/security/tokens/)</li></ul> |
     | `404`       | Not found                | Requested resource was not found. `message` in the response body provides details about the requested resource. |
     | `413`       | Request entity too large | Request payload exceeds the size limit. |
     | `422`       | Unprocessable entity     | Request data is invalid. `code` and `message` in the response body provide details about the problem. |

--- a/src/cloud/paths/tasks.yml
+++ b/src/cloud/paths/tasks.yml
@@ -83,10 +83,12 @@ get:
         type: integer
         minimum: 0
         default: 0
-      description: The number of records to skip
+      description: The number of records to skip.
     - in: query
       name: sortBy
-      description: Field that records should be sorted by
+      description: |
+        The field used for sorting records in the list.
+        Only `name` is supported.
       required: false
       schema:
         type: string
@@ -123,7 +125,7 @@ get:
       $ref: "../../common/responses/ServerError.yml"
   x-codeSamples:
     - lang: Shell
-      label: "cURL: all tasks, `basic` output"
+      label: "cURL: all tasks, basic output"
       source: |
         curl https://cloud2.influxdata.com/api/v2/tasks/?limit=-1&type=basic \
           --header 'Content-Type: application/json' \
@@ -149,7 +151,8 @@ post:
 
     #### Related guides
 
-    - [Create a task]({{% INFLUXDB_DOCS_URL %}}/process-data/manage-tasks/create-task/).
+    - [Get started with tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/get-started/)
+    - [Create a task]({{% INFLUXDB_DOCS_URL %}}/process-data/manage-tasks/create-task/)
     - [Common tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/common-tasks/)
     - [Task configuration options]({{% INFLUXDB_DOCS_URL %}}/process-data/task-options/)
   parameters:
@@ -170,28 +173,32 @@ post:
             $ref: "../schemas/Task.yml"
     "400":
       description: |
-        Bad request
+        Bad request.
+        The response body contains detail about the error.
 
         #### InfluxDB Cloud
 
           - Returns this error if the task doesn't contain one of _`flux`_ or _`scriptID`_.
           - Returns this error if the task contains _`flux`_ _and_ _`scriptID`_.
-      $ref: "../../common/responses/BadRequestError.yml"
-      examples:
-        fluxAndScriptError:
-          summary: The request body can't contain both flux and scriptID
-          value:
-            {
-              "code": "invalid",
-              "message": "failed to decode request: can not provide both scriptID and flux"
-            }
-        missingFluxError:
-          summary: The request body requires either flux or scriptID
-          value:
-            {
-              "code": "invalid",
-              "message": "failed to decode request: flux required"
-            }
+      content:
+        application/json:
+          schema:
+            $ref: "../../common/schemas/Error.yml"
+          examples:
+            fluxAndScriptError:
+              summary: The request body can't contain both flux and scriptID
+              value:
+                {
+                  "code": "invalid",
+                  "message": "failed to decode request: can not provide both scriptID and flux"
+                }
+            missingFluxError:
+              summary: The request body requires either a flux parameter or scriptID parameter
+              value:
+                {
+                  "code": "invalid",
+                  "message": "failed to decode request: flux required"
+                }
     "401":
       $ref: "../../common/responses/AuthorizationError.yml"
     "500":
@@ -204,41 +211,39 @@ post:
             $ref: "../../common/schemas/Error.yml"
   x-codeSamples:
     - lang: Shell
-      label: "cURL: create a flux query task"
+      label: "cURL: create a Flux script task"
       source: |
-        curl -v --request POST \
-        https://cloud2.influxdata.com/api/v2/tasks \
+        curl https://cloud2.influxdata.com/api/v2/tasks \
         --header "Content-type: application/json" \
         --header "Authorization: Token INFLUX_TOKEN" \
         --data-binary @- << EOF
           {
-          "orgID": "INFLUX_ORG_ID",
-          "description": "IoT Center 30d environment average.",
-          "flux": "option task = {name: \"iot-center-task-1\", every: 30m}\
-                  from(bucket: \"iot_center\")\
-                    |> range(start: -30d)\
-                    |> filter(fn: (r) => r._measurement == \"environment\")\
-                    |> aggregateWindow(every: 1h, fn: mean)"
+            "orgID": "INFLUX_ORG_ID",
+            "description": "IoT Center 30d environment average.",
+            "flux": "option task = {name: \"iot-center-task-1\", every: 30m}\
+                    from(bucket: \"iot_center\")\
+                      |> range(start: -30d)\
+                      |> filter(fn: (r) => r._measurement == \"environment\")\
+                      |> aggregateWindow(every: 1h, fn: mean)"
           }
         EOF
     - lang: Shell
-      label: "cURL: create a script task"
+      label: "cURL: create a Flux script reference task"
       source: |
-        curl -v --request POST \
-        https://cloud2.influxdata.com/api/v2/tasks \
+        curl https://cloud2.influxdata.com/api/v2/tasks \
         --header "Content-type: application/json" \
         --header "Authorization: Token INFLUX_TOKEN" \
         --data-binary @- << EOF
           {
-          "orgID": "INFLUX_ORG_ID",
-          "description": "IoT Center 30d environment average.",
-          "scriptID": "085138a111448000",
-          "scriptParameters":
-            {
-              "rangeStart": "-30d",
-              "bucket": "air_sensor",
-              "filterField": "temperature",
-              "groupColumn": "_time"
-            }
+            "orgID": "INFLUX_ORG_ID",
+            "description": "IoT Center 30d environment average.",
+            "scriptID": "085138a111448000",
+            "scriptParameters":
+              {
+                "rangeStart": "-30d",
+                "bucket": "air_sensor",
+                "filterField": "temperature",
+                "groupColumn": "_time"
+              }
           }
         EOF

--- a/src/cloud/paths/tasks_taskID.yml
+++ b/src/cloud/paths/tasks_taskID.yml
@@ -6,7 +6,7 @@ get:
   summary: Retrieve a task
   description: |
     Retrieves a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task)
-    by task ID.
+    by ID.
   parameters:
     - $ref: "../../common/parameters/TraceSpan.yml"
     - in: path
@@ -14,7 +14,7 @@ get:
       schema:
         type: string
       required: true
-      description: The task ID.
+      description: The ID of the task to retrieve.
   responses:
     "200":
       description: Success. The response body contains the task.
@@ -41,7 +41,7 @@ patch:
     Updates a task and then cancels all scheduled runs of the task.
 
     Use this endpoint to modify task properties (for example: `cron`, `name`, `flux`, `status`).
-    Once InfluxDB applies the update, it cancels all scheduled runs of the task.
+    Once InfluxDB applies the update, it cancels all previously scheduled runs of the task.
 
     To update a task, pass an object that contains the updated key-value pairs.
     To activate or inactivate a task, set the `status` property.

--- a/src/cloud/schemas/Task.yml
+++ b/src/cloud/schemas/Task.yml
@@ -35,14 +35,14 @@
       type: string
     every:
       description: >-
-        The interval ([duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals))) at which the task runs.
+        The interval ([duration literal]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp)) at which the task runs.
         `every` also determines when the task first runs, depending on the specified time.
       type: string
       format: duration
     cron:
       description: >-
         A [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview) that defines the schedule on which the task runs.
-        InfluxDB bases cron runs on the system time.
+        InfluxDB uses the system time when evaluating Cron expressions.
       type: string
     offset:
       description: >-
@@ -52,7 +52,7 @@
       format: duration
     latestCompleted:
       description: >-
-        A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/flux/v0.x/data-types/basic/time/#time-syntax)) of the latest scheduled and completed run.
+        A timestamp ([RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp)) of the latest scheduled and completed run.
       type: string
       format: date-time
       readOnly: true

--- a/src/cloud/tags.yml
+++ b/src/cloud/tags.yml
@@ -44,8 +44,9 @@ tags:
 
       #### Related guides
 
+      - [Get started with tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/get-started/)
       - [Common data processing tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/common-tasks/)
-      - [Invoke custom scripts as API endpoints](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/)
+      - [Create a script](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/#create-an-invokable-script).
   - name: Write
     description: |
       Write time series data to buckets.
@@ -108,8 +109,8 @@ tags:
       |:-----------:|:------------------------ |:--------------------- |
       | `200`       | Success                  |                       |
       | `204`       | No content               | For a `POST` request, `204` indicates that InfluxDB accepted the request and request data is valid. Asynchronous operations, such as `write`, might not have completed yet. |
-      | `400`       | Bad request              | May indicate one of the following: <li>Line protocol is malformed. The response body contains the first malformed line in the data and indicates what was expected. For partial writes, the number of points written and the number of points rejected are also included. For more information, check the `rejected_points` measurement in your `_monitoring` bucket.</li><li>`Authorization` header is missing or malformed or the API token does not have permission for the operation.</li> |
-      | `401`       | Unauthorized             | May indicate one of the following: <li>`Authorization: Token` header is missing or malformed</li><li>API token value is missing from the header</li><li>API token does not have permission. For more information about token types and permissions, see [Manage API tokens](https://docs.influxdata.com/influxdb/cloud/security/tokens/)</li> |
+      | `400`       | Bad request              | May indicate one of the following: <ul><li>Line protocol is malformed. The response body contains the first malformed line in the data and indicates what was expected. For partial writes, the number of points written and the number of points rejected are also included. For more information, check the `rejected_points` measurement in your `_monitoring` bucket.</li><li>`Authorization` header is missing or malformed or the API token does not have permission for the operation.</li></ul> |
+      | `401`       | Unauthorized             | May indicate one of the following: <ul><li>`Authorization: Token` header is missing or malformed</li><li>API token value is missing from the header</li><li>API token does not have permission. For more information about token types and permissions, see [Manage API tokens](https://docs.influxdata.com/influxdb/cloud/security/tokens/)</li></ul> |
       | `404`       | Not found                | Requested resource was not found. `message` in the response body provides details about the requested resource. |
       | `413`       | Request entity too large | Request payload exceeds the size limit. |
       | `422`       | Unprocessable entity     | Request data is invalid. `code` and `message` in the response body provide details about the problem. |

--- a/src/common/paths/query_analyze.yml
+++ b/src/common/paths/query_analyze.yml
@@ -7,7 +7,7 @@ post:
     Analyzes a [Flux query](https://docs.influxdata.com/flux/v0.x/) for syntax
     errors and returns the list of errors.
 
-    In the following example `Query` object, `query` is missing a `from()` property key:
+    In the following sample query, `from()` is missing the property key.
 
         ```json
         { "query": "from(: \"iot_center\")\
@@ -17,13 +17,14 @@ post:
         }
         ```
 
-    Passing this to `/api/v2/analyze` returns an `errors` list that contains an error object for the missing key.
+    If you pass this in a request to the `/api/v2/analyze` endpoint,
+    InfluxDB returns an `errors` list that contains an error object for the missing key.
 
     #### Limitations
 
     -  The endpoint doesn't validate values in the query--for example:
 
-      - The following query has correct syntax, but contains an incorrect `from()` property key:
+      - The following sample query has correct syntax, but contains an incorrect `from()` property key:
 
         ```json
         { "query": "from(foo: \"iot_center\")\
@@ -33,7 +34,8 @@ post:
         }
         ```
 
-        Passing this to `/api/v2/analyze` returns an empty `errors` list.
+        If you pass this in a request to the `/api/v2/analyze` endpoint,
+        InfluxDB returns an empty `errors` list.
 
   parameters:
     - $ref: "../parameters/TraceSpan.yml"
@@ -65,7 +67,7 @@ post:
               description: |
                 Returns an error object if the Flux query is missing a property key.
 
-                The following example is missing the `bucket` property key:
+                The following sample query is missing the _`bucket`_ property key:
 
                   ```json
                   {

--- a/src/common/paths/query_ast.yml
+++ b/src/common/paths/query_ast.yml
@@ -5,7 +5,7 @@ post:
   summary: Generate a query Abstract Syntax Tree (AST)
   description: |
     Analyzes a Flux query and returns a complete package source [Abstract Syntax
-    Tree (AST)](https://https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#abstract-syntax-tree)
+    Tree (AST)]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#abstract-syntax-tree-ast)
     for the query.
 
     Use this endpoint for deep query analysis such as debugging unexpected query
@@ -15,18 +15,19 @@ post:
     information about the query. The AST illustrates how the query is distributed
     into different components for execution.
 
-
     #### Limitations
 
     -  The endpoint doesn't validate values in the query--for example:
 
         The following query has correct syntax, but contains an incorrect `from()` property key:
+
         ```json
         { "query": "from(foo: \"iot_center\")\
                     |> range(start: -90d)\
                     |> filter(fn: (r) => r._measurement == \"environment\")"
         }
         ```
+
         Passing this to `/api/v2/query/ast` will return a successful response
         with a generated AST.
 
@@ -48,13 +49,13 @@ post:
     - lang: Shell
       label: cURL
       source: |
-        curl --request POST 'INFLUX_URL/api/v2/query/ast' \
-          --header 'Content-Type: application/json' \
-          --header 'Accept: application/json \
-          --header 'Authorization: Token INFLUX_TOKEN' \
-          --data 'from(bucket: "example-bucket")
-                    |> range(start: -5m)
-                    |> filter(fn: (r) => r._measurement == "example-measurement")'
+        curl --request POST 'http://localhost:8086/api/v2/query/ast' \
+        --header 'Content-Type: application/json' \
+        --header 'Accept: application/json' \
+        --header 'Authorization: Token INFLUX_TOKEN' \
+        --data 'from(bucket: "example-bucket")
+                  |> range(start: -5m)
+                  |> filter(fn: (r) => r._measurement == "example-measurement")'
   responses:
     "200":
       description: |

--- a/src/common/paths/tasks.yml
+++ b/src/common/paths/tasks.yml
@@ -165,6 +165,13 @@ get:
       $ref: "../responses/InternalServerError.yml"
     default:
       $ref: "../responses/ServerError.yml"
+  x-codeSamples:
+    - lang: Shell
+      label: "cURL: all tasks, basic output"
+      source: |
+        curl https://localhost:8086/api/v2/tasks/?limit=-1&type=basic \
+          --header 'Content-Type: application/json' \
+          --header 'Authorization: Token INFLUX_API_TOKEN'
 post:
   operationId: PostTasks
   tags:
@@ -176,7 +183,8 @@ post:
 
     #### Related guides
 
-    - [Create a task]({{% INFLUXDB_DOCS_URL %}}/process-data/manage-tasks/create-task/).
+    - [Get started with tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/get-started/)
+    - [Create a task]({{% INFLUXDB_DOCS_URL %}}/process-data/manage-tasks/create-task/)
     - [Common tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/common-tasks/)
     - [Task configuration options]({{% INFLUXDB_DOCS_URL %}}/process-data/task-options/)
   parameters:
@@ -196,15 +204,31 @@ post:
           schema:
             $ref: "../schemas/Task.yml"
     "400":
-      description: Bad request
-      $ref: "../responses/BadRequestError.yml"
-      examples:
-        missingFluxError:
-          summary: Task in request body is missing Flux query
-          value: {
-            "code":"invalid",
-            "message": "failed to decode request: missing flux"
-            }
+      description: |
+        Bad request.
+        The response body contains detail about the error.
+
+        #### InfluxDB OSS
+
+        - Returns this error if an incorrect value is passed for `org` or `orgID`.
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/Error.yml"
+          examples:
+            orgProvidedNotFound:
+              summary: The org or orgID passed doesn't own the token passed in the header
+              value:
+                {
+                  "code":"invalid",
+                  "message":"failed to decode request body: organization not found"
+                }
+            missingFluxError:
+              summary: Task in request body is missing Flux query
+              value: {
+                  "code":"invalid",
+                  "message": "failed to decode request: missing flux"
+                }
     "401":
       $ref: "../responses/AuthorizationError.yml"
     "500":
@@ -219,18 +243,17 @@ post:
     - lang: Shell
       label: "cURL: create a task"
       source: |
-        curl -v --request POST \
-        http://localhost:8086/api/v2/tasks \
-        --header "Content-type: application/json" \
-        --header "Authorization: Token INFLUX_TOKEN" \
-        --data-binary @- << EOF
-          {
-          "orgID": "INFLUX_ORG_ID",
-          "description": "IoT Center 30d environment average.",
-          "flux": "option task = {name: \"iot-center-task-1\", every: 30m}\
-                  from(bucket: \"iot_center\")\
-                    |> range(start: -30d)\
-                    |> filter(fn: (r) => r._measurement == \"environment\")\
-                    |> aggregateWindow(every: 1h, fn: mean)"
-          }
+        curl http://localhost:8086/api/v2/tasks \
+          --header "Content-type: application/json" \
+          --header "Authorization: Token INFLUX_TOKEN" \
+          --data-binary @- << EOF
+            {
+            "orgID": "INFLUX_ORG_ID",
+            "description": "IoT Center 30d environment average.",
+            "flux": "option task = {name: \"iot-center-task-1\", every: 30m}\
+                    from(bucket: \"iot_center\")\
+                      |> range(start: -30d)\
+                      |> filter(fn: (r) => r._measurement == \"environment\")\
+                      |> aggregateWindow(every: 1h, fn: mean)"
+            }
         EOF

--- a/src/common/paths/tasks_taskID.yml
+++ b/src/common/paths/tasks_taskID.yml
@@ -6,7 +6,7 @@ get:
   summary: Retrieve a task
   description: |
     Retrieves a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task)
-    by task ID.
+    by ID.
   parameters:
     - $ref: "../parameters/TraceSpan.yml"
     - in: path
@@ -14,7 +14,7 @@ get:
       schema:
         type: string
       required: true
-      description: The task ID.
+      description: The ID of the task to retrieve.
   responses:
     "200":
       description: Success. The response body contains the task.
@@ -41,7 +41,7 @@ patch:
     Updates a task and then cancels all scheduled runs of the task.
 
     Use this endpoint to modify task properties (for example: `cron`, `name`, `flux`, `status`).
-    Once InfluxDB applies the update, it cancels all scheduled runs of the task.
+    Once InfluxDB applies the update, it cancels all previously scheduled runs of the task.
 
     To update a task, pass an object that contains the updated key-value pairs.
     To activate or inactivate a task, set the `status` property.

--- a/src/common/paths/tasks_taskID_logs.yml
+++ b/src/common/paths/tasks_taskID_logs.yml
@@ -31,7 +31,7 @@ get:
             $ref: "../schemas/Logs.yml"
           examples:
             taskSuccess:
-              summary: Events for successful task.
+              summary: Events for a successful task run.
               value:
                 "events": [
                   {
@@ -46,7 +46,7 @@ get:
                   }
                 ]
             taskFailure:
-              summary: Events for a failed task.
+              summary: Events for a failed task run.
               value: {
                 "events": [
                   {

--- a/src/common/paths/tasks_taskID_runs.yml
+++ b/src/common/paths/tasks_taskID_runs.yml
@@ -3,6 +3,11 @@ get:
   tags:
     - Tasks
   summary: List runs for a task
+  description: |
+    Retrieves a list of runs for a [task]({{% INFLUXDB_DOCS_URL %}}/process-data/).
+
+    To limit which task runs are returned, pass query parameters in your request.
+    If no query parameters are passed, InfluxDB returns all task runs up to the default `limit`.
   parameters:
     - $ref: "../parameters/TraceSpan.yml"
     - in: path
@@ -10,12 +15,16 @@ get:
       schema:
         type: string
       required: true
-      description: The ID of the task to get runs for.
+      description: |
+        The ID of the task to get runs for.
+        Only returns runs for this task.
     - in: query
       name: after
       schema:
         type: string
-      description: Returns runs after a specific ID.
+      description:
+        A task run ID.
+        Only returns runs created after this run.
     - in: query
       name: limit
       schema:
@@ -23,38 +32,47 @@ get:
         minimum: 1
         maximum: 500
         default: 100
-      description: The number of runs to return
+      description: |
+        Limits the number of task runs returned. Default is `100`.
     - in: query
       name: afterTime
       schema:
         type: string
         format: date-time
-      description: Filter runs to those scheduled after this time, RFC3339
+      description: |
+        A timestamp ([RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp)).
+        Only returns runs scheduled after this time.
     - in: query
       name: beforeTime
       schema:
         type: string
         format: date-time
-      description: Filter runs to those scheduled before this time, RFC3339
+      description: |
+        A timestamp ([RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp)).
+        Only returns runs scheduled before this time.
   responses:
     "200":
-      description: A list of task runs
+      description: Success. The response body contains the list of task runs.
       content:
         application/json:
           schema:
             $ref: "../schemas/Runs.yml"
+    "401":
+      $ref: "../responses/AuthorizationError.yml"
+    "500":
+      $ref: "../responses/InternalServerError.yml"
     default:
-      description: Unexpected error
-      content:
-        application/json:
-          schema:
-            $ref: "../schemas/Error.yml"
+      $ref: "../responses/ServerError.yml"
 post:
   operationId: PostTasksIDRuns
   tags:
     - Data I/O endpoints
     - Tasks
-  summary: Manually start a task run, overriding the current schedule
+  summary: Start a task run, overriding the schedule
+  description: |
+    Schedules a task run to start immediately, ignoring scheduled runs.
+
+    Use this endpoint to manually start a task run.
   parameters:
     - $ref: "../parameters/TraceSpan.yml"
     - in: path
@@ -69,14 +87,14 @@ post:
           $ref: "../schemas/RunManually.yml"
   responses:
     "201":
-      description: Run scheduled to start
+      description: Success. The run is scheduled to start.
       content:
         application/json:
           schema:
             $ref: "../schemas/Run.yml"
+    "401":
+      $ref: "../responses/AuthorizationError.yml"
+    "500":
+      $ref: "../responses/InternalServerError.yml"
     default:
-      description: Unexpected error
-      content:
-        application/json:
-          schema:
-            $ref: "../schemas/Error.yml"
+      $ref: "../responses/ServerError.yml"

--- a/src/common/paths/tasks_taskID_runs_runID_logs.yml
+++ b/src/common/paths/tasks_taskID_runs_runID_logs.yml
@@ -10,23 +10,67 @@ get:
       schema:
         type: string
       required: true
-      description: ID of task to get logs for.
+      description: The ID of the task to get logs for.
     - in: path
       name: runID
       schema:
         type: string
       required: true
-      description: ID of run to get logs for.
+      description: The ID of the run to get logs for.
   responses:
     "200":
-      description: All logs for a run
+      description: |
+        Success. The response body contains an `events` list with logs for the task run.
+        Each log event `message` contains detail about the event.
+        If a run fails, InfluxDB logs an event with the reason for the failure.
       content:
         application/json:
           schema:
             $ref: "../schemas/Logs.yml"
+          examples:
+            taskSuccess:
+              summary: Events for a successful task run.
+              value:
+                "events": [
+                  {
+                    "runID": "09b070dadaa7d000",
+                    "time": "2022-07-18T14:46:07.101231Z",
+                    "message": "Started task from script: \"option task = {name: \\\"task1\\\", every: 30m} from(bucket: \\\"iot_center\\\") |> range(start: -90d) |> filter(fn: (r) => r._measurement == \\\"environment\\\") |> aggregateWindow(every: 1h, fn: mean)\""
+                  },
+                  {
+                    "runID": "09b070dadaa7d000",
+                    "time": "2022-07-18T14:46:07.242859Z",
+                    "message": "Completed(success)"
+                  }
+                ]
+            taskFailure:
+              summary: Events for a failed task.
+              value: {
+                "events": [
+                  {
+                    "runID": "09a946fc3167d000",
+                    "time": "2022-07-13T07:06:54.198167Z",
+                    "message": "Started task from script: \"option task = {name: \\\"test task\\\", every: 3d, offset: 0s}\""
+                  },
+                  {
+                    "runID": "09a946fc3167d000",
+                    "time": "2022-07-13T07:07:13.104037Z",
+                    "message": "Completed(failed)"
+                  },
+                  {
+                    "runID": "09a946fc3167d000",
+                    "time": "2022-07-13T08:24:37.115323Z",
+                    "message": "error exhausting result iterator: error in query specification while starting program: this Flux script returns no streaming data. Consider adding a \"yield\" or invoking streaming functions directly, without performing an assignment"
+                  }
+                ]
+              }
+    "400":
+      $ref: "../responses/BadRequestError.yml"
+    "401":
+      $ref: "../responses/AuthorizationError.yml"
+    "404":
+      $ref: "../responses/ResourceNotFoundError.yml"
+    "500":
+      $ref: "../responses/InternalServerError.yml"
     default:
-      description: Unexpected error
-      content:
-        application/json:
-          schema:
-            $ref: "../schemas/Error.yml"
+      $ref: "../responses/ServerError.yml"

--- a/src/common/responses/BadRequestError.yml
+++ b/src/common/responses/BadRequestError.yml
@@ -13,7 +13,8 @@
       examples:
         orgProvidedNotFound:
           summary: The org or orgID passed doesn't own the token passed in the header
-          value: {
-            "code":"invalid",
-            "message":"failed to decode request body: organization not found"
-          }
+          value:
+            {
+              "code":"invalid",
+              "message":"failed to decode request body: organization not found"
+            }

--- a/src/common/schemas/CheckBase.yml
+++ b/src/common/schemas/CheckBase.yml
@@ -31,7 +31,7 @@
       type: string
     latestCompleted:
       type: string
-      description: Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.
+      description: A timestamp ([RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp)) of the latest scheduled and completed run.
       format: date-time
       readOnly: true
     lastRunStatus:

--- a/src/common/schemas/DateTimeLiteral.yml
+++ b/src/common/schemas/DateTimeLiteral.yml
@@ -1,4 +1,4 @@
-  description: Represents an instant in time with nanosecond precision using the syntax of golang's RFC3339 Nanosecond variant
+  description: Represents an instant in time with nanosecond precision in [RFC3339Nano date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339nano-timestamp).
   type: object
   properties:
     type:

--- a/src/common/schemas/DeletePredicateRequest.yml
+++ b/src/common/schemas/DeletePredicateRequest.yml
@@ -3,11 +3,15 @@
   required: [start, stop]
   properties:
     start:
-      description: A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/flux/v0.x/data-types/basic/time/#time-syntax)).
+      description: |
+        A timestamp ([RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp)).
+        The earliest time to delete from.
       type: string
       format: date-time
     stop:
-      description: A timestamp ([RFC3339 date/time format](https://docs.influxdata.com/flux/v0.x/data-types/basic/time/#time-syntax)).
+      description: |
+        A timestamp ([RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp)).
+        The latest time to delete from.
       type: string
       format: date-time
     predicate:

--- a/src/common/schemas/Dialect.yml
+++ b/src/common/schemas/Dialect.yml
@@ -1,18 +1,32 @@
-  description: Dialect are options to change the default CSV output format; https://www.w3.org/TR/2015/REC-tabular-metadata-20151217/#dialect-descriptions
+  description: |
+    Options for tabular data output.
+    Default output is [annotated CSV]({{% INFLUXDB_DOCS_URL %}}/reference/syntax/annotated-csv/#csv-response-format) with headers.
+
+    For more information about tabular data **dialect**,
+    see [W3 metadata vocabulary for tabular data](https://www.w3.org/TR/2015/REC-tabular-metadata-20151217/#dialect-descriptions).
   type: object
   properties:
     header:
-      description: If true, the results will contain a header row
+      description: If true, the results contain a header row.
       type: boolean
       default: true
     delimiter:
-      description: Separator between cells; the default is ,
+      description: The separator used between cells. Default is a comma (`,`).
       type: string
       default: ","
       maxLength: 1
       minLength: 1
     annotations:
-      description: https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/#columns
+      description: |
+        Annotation rows to include in the results.
+        An _annotation_ is metadata associated with an object (column) in the data model.
+
+        #### Related guides
+
+        - See [Annotated CSV annotations]({{% INFLUXDB_DOCS_URL %}}/reference/syntax/annotated-csv/#annotations) for examples and more information.
+
+        For more information about **annotations** in tabular data,
+        see [W3 metadata vocabulary for tabular data](https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/#columns).
       type: array
       uniqueItems: true
       items:
@@ -22,13 +36,23 @@
           - "datatype"
           - "default"
     commentPrefix:
-      description: Character prefixed to comment strings
+      description: The character prefixed to comment strings. Default is a number sign (`#`).
       type: string
       default: "#"
       maxLength: 1
       minLength: 0
     dateTimeFormat:
-      description: Format of timestamps
+      description: |
+        The format for timestamps in results.
+        Default is [`RFC3339` date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp).
+        To include nanoseconds in timestamps, use `RFC3339Nano`.
+
+        #### Example formatted date/time values
+
+        | Format      | Value                       |
+        |:------------|:----------------------------|
+        | `RFC3339`    | `"2006-01-02T15:04:05Z07:00"` |
+        | `RFC3339Nano` | `"2006-01-02T15:04:05.999999999Z07:00"` |
       type: string
       default: "RFC3339"
       enum:

--- a/src/common/schemas/LogEvent.yml
+++ b/src/common/schemas/LogEvent.yml
@@ -2,9 +2,10 @@
   properties:
     time:
       readOnly: true
-      description: Time event occurred, RFC3339Nano.
+      description: The time ([RFC3339Nano date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339nano-timestamp)) that the event occurred.
       type: string
       format: date-time
+      example: "2006-01-02T15:04:05.999999999Z07:00"
     message:
       readOnly: true
       description: A description of the event that occurred.
@@ -12,5 +13,5 @@
       example: Halt and catch fire
     runID:
       readOnly: true
-      description: the ID of the task that logged
+      description: The ID of the task run that generated the event.
       type: string

--- a/src/common/schemas/NotificationRuleBase.yml
+++ b/src/common/schemas/NotificationRuleBase.yml
@@ -7,7 +7,7 @@
     - endpointID
   properties:
     latestCompleted:
-      description: Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.
+      description: A timestamp ([RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp)) of the latest scheduled and completed run.
       type: string
       format: date-time
       readOnly: true

--- a/src/common/schemas/Run.yml
+++ b/src/common/schemas/Run.yml
@@ -15,7 +15,7 @@
         - success
         - canceled
     scheduledFor:
-      description: Time used for run's "now" option, RFC3339.
+      description: The time [RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp) used for the run's `now` option.
       type: string
       format: date-time
     log:
@@ -30,19 +30,22 @@
       readOnly: true
     startedAt:
       readOnly: true
-      description: Time run started executing, RFC3339Nano.
+      description: The time ([RFC3339Nano date/time format](https://go.dev/src/time/format.go)) the run started executing.
       type: string
       format: date-time
+      example: "2006-01-02T15:04:05.999999999Z07:00"
     finishedAt:
       readOnly: true
-      description: Time run finished executing, RFC3339Nano.
+      description: The time ([RFC3339Nano date/time format](https://go.dev/src/time/format.go)) the run finished executing.
       type: string
       format: date-time
+      example: "2006-01-02T15:04:05.999999999Z07:00"
     requestedAt:
       readOnly: true
-      description: Time run was manually requested, RFC3339Nano.
+      description: The time ([RFC3339Nano date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339nano-timestamp)) the run was manually requested.
       type: string
       format: date-time
+      example: "2006-01-02T15:04:05.999999999Z07:00"
     links:
       type: object
       readOnly: true

--- a/src/common/schemas/RunManually.yml
+++ b/src/common/schemas/RunManually.yml
@@ -1,6 +1,9 @@
   properties:
     scheduledFor:
       nullable: true
-      description: Time used for run's "now" option, RFC3339.  Default is the server's now time.
+      description: |
+        The time [RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp)
+        used for the run's `now` option.
+        Default is the server _now_ time.
       type: string
       format: date-time

--- a/src/legacy/paths/query.yml
+++ b/src/legacy/paths/query.yml
@@ -13,7 +13,7 @@ get:
         description: |
           Media type that the client can understand.
 
-          **Note**: With `application/csv`, query results include [unix timestamps]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#unix-timestamp) instead of RFC3339 timestamps.
+          **Note**: With `application/csv`, query results include [**unix timestamps**]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#unix-timestamp) instead of [RFC3339 timestamps]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp).
         default: application/json
         enum:
           - application/json
@@ -71,7 +71,10 @@ get:
         type: string
     - in: query
       name: epoch
-      description: Return results with [unix (epoch) timestamps]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#unix-timestamp) in the specified precision instead of RFC3339 timestamps with nanosecond precision.
+      description: |
+        A unix timestamp precision.
+        Formats timestamps as [unix (epoch) timestamps]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#unix-timestamp) the specified precision
+        instead of [RFC3339 timestamps]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp) with nanosecond precision.
       schema:
         type: string
         enum: [ns, u, µ, ms, s, m, h]

--- a/src/oss/paths/backup_kv.yml
+++ b/src/oss/paths/backup_kv.yml
@@ -3,14 +3,18 @@ get:
   tags:
     - Backup
   summary: >-
-    Download snapshot of metadata stored in the server's embedded KV store. Should not be
-    used in versions greater than 2.1.x, as it doesn't include metadata stored in embedded SQL.
+    Download snapshot of metadata stored in the server's embedded KV store.
+    Don't use with InfluxDB versions greater than InfluxDB 2.1.x.
+  description: |
+    Retrieves a snapshot of metadata stored in the server's embedded KV store.
+    InfluxDB versions greater than 2.1.x don't include metadata stored in embedded SQL;
+    avoid using this endpoint with versions greater than 2.1.x.
   deprecated: true
   parameters:
     - $ref: "../../common/parameters/TraceSpan.yml"
   responses:
     "200":
-      description: Snapshot of KV metadata
+      description: Success. The response contains a snapshot of KV metadata.
       content:
         application/octet-stream:
           schema:

--- a/src/oss/paths/backup_shards_shardID.yml
+++ b/src/oss/paths/backup_shards_shardID.yml
@@ -24,10 +24,14 @@ get:
       description: The shard ID.
     - in: query
       name: since
-      description: Earliest time to include in the snapshot. RFC3339 format.
+      description: The earliest time [RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp) to include in the snapshot.
       schema:
         type: string
         format: date-time
+      examples:
+        RFC3339:
+          summary: RFC3339 date/time format
+          value: "2006-01-02T15:04:05Z07:00"
   responses:
     "200":
       description: TSM snapshot.

--- a/src/oss/tags.yml
+++ b/src/oss/tags.yml
@@ -40,6 +40,7 @@ tags:
 
       #### Related guides
 
+      - [Get started with tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/get-started/)
       - [Common data processing tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/common-tasks/)
   - name: Write
     description: |
@@ -107,8 +108,8 @@ tags:
       |:-----------:|:------------------------ |:--------------------- |
       | `200`       | Success                  |                       |
       | `204`       | No content               | For a `POST` request, `204` indicates that InfluxDB accepted the request and request data is valid. Asynchronous operations, such as `write`, might not have completed yet. |
-      | `400`       | Bad request              | May indicate one of the following: <li>Line protocol is malformed. The response body contains the first malformed line in the data and indicates what was expected. For partial writes, the number of points written and the number of points rejected are also included. For more information, check the `rejected_points` measurement in your `_monitoring` bucket.</li><li>`Authorization` header is missing or malformed or the API token does not have permission for the operation.</li> |
-      | `401`       | Unauthorized             | May indicate one of the following: <li>`Authorization: Token` header is missing or malformed</li><li>API token value is missing from the header</li><li>API token does not have permission. For more information about token types and permissions, see [Manage API tokens](https://docs.influxdata.com/influxdb/latest/security/tokens/)</li> |
+      | `400`       | Bad request              | May indicate one of the following: <ul><li>Line protocol is malformed. The response body contains the first malformed line in the data and indicates what was expected. For partial writes, the number of points written and the number of points rejected are also included. For more information, check the `rejected_points` measurement in your `_monitoring` bucket.</li><li>`Authorization` header is missing or malformed or the API token does not have permission for the operation.</li></ul> |
+      | `401`       | Unauthorized             | May indicate one of the following: <ul><li>`Authorization: Token` header is missing or malformed</li><li>API token value is missing from the header</li><li>API token does not have permission. For more information about token types and permissions, see [Manage API tokens](https://docs.influxdata.com/influxdb/latest/security/tokens/)</li></ul> |
       | `404`       | Not found                | Requested resource was not found. `message` in the response body provides details about the requested resource. |
       | `413`       | Request entity too large | Request payload exceeds the size limit. |
       | `422`       | Unprocessable entity     | Request data is invalid. `code` and `message` in the response body provide details about the problem. |


### PR DESCRIPTION
- fix script link title in tag.
- use valid HTML in description.
- fix tasks sortby description.
- fix query AST link and whitespace.
- fixes task run descriptions (part of https://github.com/influxdata/openapi/issues/418).
- update timestamp descriptions in all endpoints.
- cleanup create task (closes #404).
- cleanup retrieve and update tasks (closes #406, #407).
- Cleanup timestamp description for LogEvent, Dialect, DateTimeLiteral schema.
- Cleanup deprecated backup endpoint.
- Add examples and response details to task run logs.