### PR TITLE
chore(billing): Remove Region from BillingInfo

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -1815,8 +1815,6 @@ components:
         balance:
           type: number
           description: account balance
-        region:
-          type: string
         paymentMethod:
           $ref: '#/components/schemas/PaymentMethod'
         balanceUpdatedAt:

--- a/src/unity/schemas/BillingInfo.yml
+++ b/src/unity/schemas/BillingInfo.yml
@@ -2,8 +2,6 @@ properties:
   balance:
     type: number
     description: account balance
-  region:
-    type: string
   paymentMethod:
     $ref: './PaymentMethod.yml'
   balanceUpdatedAt:


### PR DESCRIPTION
Removes the `region` from the `BillingInfo` Schema. The region is no longer needed in a multi-org/account world and instead of fetching the region for the active org, we simply removed it.