### PR TITLE
docs(stacks): Stacks POST orgID is required

### DIFF
--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -5142,6 +5142,9 @@
               "schema": {
                 "type": "object",
                 "title": "PostStackRequest",
+                "required": [
+                  "orgID"
+                ],
                 "properties": {
                   "orgID": {
                     "type": "string"

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -3368,6 +3368,8 @@ paths:
             schema:
               type: object
               title: PostStackRequest
+              required:
+                - orgID
               properties:
                 orgID:
                   type: string

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -3250,6 +3250,8 @@ paths:
             schema:
               type: object
               title: PostStackRequest
+              required:
+                - orgID
               properties:
                 orgID:
                   type: string

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -5146,6 +5146,9 @@
               "schema": {
                 "type": "object",
                 "title": "PostStackRequest",
+                "required": [
+                  "orgID"
+                ],
                 "properties": {
                   "orgID": {
                     "type": "string"

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -3374,6 +3374,8 @@ paths:
             schema:
               type: object
               title: PostStackRequest
+              required:
+                - orgID
               properties:
                 orgID:
                   type: string

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -10077,6 +10077,8 @@ paths:
                   items:
                     type: string
                   type: array
+              required:
+              - orgID
               title: PostStackRequest
               type: object
         description: The stack to create.

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -12061,6 +12061,8 @@ paths:
                   items:
                     type: string
                   type: array
+              required:
+              - orgID
               title: PostStackRequest
               type: object
         description: The stack to create.

--- a/src/common/paths/stacks.yml
+++ b/src/common/paths/stacks.yml
@@ -51,6 +51,8 @@ post:
         schema:
           type: object
           title: PostStackRequest
+          required:
+          - orgID
           properties:
             orgID:
               type: string


### PR DESCRIPTION
The following updates the openAPI contract for the creation of stacks,
which the code states orgID is a requirement for cloud and OSS. This
seems to have been an oversight and is now fixed with this change.