### PR TITLE
fix(invocable-scripts): `type` is not allowed in example object

### DIFF
--- a/contracts/invocable-scripts.yml
+++ b/contracts/invocable-scripts.yml
@@ -360,7 +360,6 @@ paths:
                 $ref: '#/components/schemas/ScriptHTTPResponseData'
               examples:
                 successResponse:
-                  type: string
                   value: |
                     ,result,table,_start,_stop,_time,_value,_field,_measurement,host
                     ,_result,0,2019-10-30T01:28:02.52716421Z,2022-07-26T01:28:02.52716421Z,2020-01-01T00:00:00Z,72.01,used_percent,mem,host2

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -11793,7 +11793,6 @@ paths:
             text/csv:
               examples:
                 successResponse:
-                  type: string
                   value: |
                     ,result,table,_start,_stop,_time,_value,_field,_measurement,host
                     ,_result,0,2019-10-30T01:28:02.52716421Z,2022-07-26T01:28:02.52716421Z,2020-01-01T00:00:00Z,72.01,used_percent,mem,host2

--- a/contracts/svc/invocable-scripts.yml
+++ b/contracts/svc/invocable-scripts.yml
@@ -360,7 +360,6 @@ paths:
                 $ref: '#/components/schemas/ScriptHTTPResponseData'
               examples:
                 successResponse:
-                  type: string
                   value: |
                     ,result,table,_start,_stop,_time,_value,_field,_measurement,host
                     ,_result,0,2019-10-30T01:28:02.52716421Z,2022-07-26T01:28:02.52716421Z,2020-01-01T00:00:00Z,72.01,used_percent,mem,host2

--- a/src/svc/invocable-scripts/schemas/ScriptInvokeResponse.yml
+++ b/src/svc/invocable-scripts/schemas/ScriptInvokeResponse.yml
@@ -1,5 +1,4 @@
   successResponse:
-    type: string
     value: |
       ,result,table,_start,_stop,_time,_value,_field,_measurement,host
       ,_result,0,2019-10-30T01:28:02.52716421Z,2022-07-26T01:28:02.52716421Z,2020-01-01T00:00:00Z,72.01,used_percent,mem,host2


### PR DESCRIPTION
The `openapi` specification doesn't specify the `type` in the `Example` object:

<img width="703" alt="image" src="https://user-images.githubusercontent.com/455137/183643928-ff236f1c-30d3-4c55-878f-19caaffb8802.png">


https://swagger.io/specification/#example-object

This breaks our generator to build the [influxdb-client-java](http://github.com/influxdata/influxdb-client-java), [influxdb-client-python](http://github.com/influxdata/influxdb-client-python), [influxdb-client-csharp](http://github.com/influxdata/influxdb-client-csharp)...

<img width="1029" alt="image" src="https://user-images.githubusercontent.com/455137/183643829-a232e263-78ab-4657-b928-19b9e3e14d4b.png">

https://app.circleci.com/pipelines/github/bonitoo-io/influxdb-clients-apigen/665/workflows/c4342df9-0b86-4d43-9205-05c7f43b06b5


Caused by https://github.com/influxdata/openapi/pull/451