### PR TITLE
chore(cloud-tasks): document scriptID in task find parameters

### DIFF
--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -2715,6 +2715,13 @@ paths:
             enum:
               - basic
               - system
+        - in: query
+          name: scriptID
+          description: |
+            Script ID.
+            Only returns tasks using this script.
+          schema:
+            type: string
       responses:
         '200':
           description: |

--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -2719,7 +2719,7 @@ paths:
           name: scriptID
           description: |
             Script ID.
-            Only returns tasks using this script.
+            Only returns tasks that use this script.
           schema:
             type: string
       responses:

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -11310,6 +11310,14 @@
                 "system"
               ]
             }
+          },
+          {
+            "in": "query",
+            "name": "scriptID",
+            "description": "Script ID.\nOnly returns tasks using this script.\n",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -11314,7 +11314,7 @@
           {
             "in": "query",
             "name": "scriptID",
-            "description": "Script ID.\nOnly returns tasks using this script.\n",
+            "description": "Script ID.\nOnly returns tasks that use this script.\n",
             "schema": {
               "type": "string"
             }

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -7736,7 +7736,7 @@ paths:
           name: scriptID
           description: |
             Script ID.
-            Only returns tasks using this script.
+            Only returns tasks that use this script.
           schema:
             type: string
       responses:

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -7732,6 +7732,13 @@ paths:
             enum:
               - basic
               - system
+        - in: query
+          name: scriptID
+          description: |
+            Script ID.
+            Only returns tasks using this script.
+          schema:
+            type: string
       responses:
         '200':
           description: |

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -12327,7 +12327,7 @@ paths:
           type: string
       - description: |
           Script ID.
-          Only returns tasks using this script.
+          Only returns tasks that use this script.
         in: query
         name: scriptID
         schema:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -12325,6 +12325,13 @@ paths:
           - basic
           - system
           type: string
+      - description: |
+          Script ID.
+          Only returns tasks using this script.
+        in: query
+        name: scriptID
+        schema:
+          type: string
       responses:
         "200":
           content:

--- a/src/cloud/paths/tasks.yml
+++ b/src/cloud/paths/tasks.yml
@@ -108,6 +108,13 @@ get:
         enum:
           - "basic"
           - "system"
+    - in: query
+      name: scriptID
+      description: |
+        Script ID.
+        Only returns tasks using this script.
+      schema:
+        type: string
   responses:
     "200":
       description: |

--- a/src/cloud/paths/tasks.yml
+++ b/src/cloud/paths/tasks.yml
@@ -112,7 +112,7 @@ get:
       name: scriptID
       description: |
         Script ID.
-        Only returns tasks using this script.
+        Only returns tasks that use this script.
       schema:
         type: string
   responses:


### PR DESCRIPTION
A recent change to cloud added the ability to search for tasks by their referenced script id, this documents that change.