### PR TITLE
chore(nifi): add brokerCACert param to subscription params

### DIFF
--- a/contracts/priv/nifid.yml
+++ b/contracts/priv/nifid.yml
@@ -324,7 +324,7 @@ components:
           type: string
         topic:
           type: string
-        certCreatedAt:
+        certProvidedAt:
           type: string
         authType:
           description: auth type for broker security

--- a/contracts/priv/nifid.yml
+++ b/contracts/priv/nifid.yml
@@ -236,10 +236,17 @@ components:
           type: string
         brokerCACert:
           type: string
-        brokerCert:
+        brokerClientCert:
           type: string
-        brokerKey:
+        brokerClientKey:
           type: string
+        authType:
+          description: auth type for broker security
+          type: string
+          enum:
+            - none
+            - user
+            - certificate
         topic:
           type: string
         dataFormat:

--- a/contracts/priv/nifid.yml
+++ b/contracts/priv/nifid.yml
@@ -324,6 +324,15 @@ components:
           type: string
         topic:
           type: string
+        certCreatedAt:
+          type: string
+        authType:
+          description: auth type for broker security
+          type: string
+          enum:
+            - none
+            - user
+            - certificate
         dataFormat:
           type: string
         jsonMeasurementKey:

--- a/contracts/priv/nifid.yml
+++ b/contracts/priv/nifid.yml
@@ -234,6 +234,8 @@ components:
           type: string
         brokerPassword:
           type: string
+        brokerCACert:
+          type: string
         brokerCert:
           type: string
         brokerKey:

--- a/contracts/svc/nifid.yml
+++ b/contracts/svc/nifid.yml
@@ -324,7 +324,7 @@ components:
           type: string
         topic:
           type: string
-        certCreatedAt:
+        certProvidedAt:
           type: string
         authType:
           description: auth type for broker security

--- a/contracts/svc/nifid.yml
+++ b/contracts/svc/nifid.yml
@@ -236,10 +236,17 @@ components:
           type: string
         brokerCACert:
           type: string
-        brokerCert:
+        brokerClientCert:
           type: string
-        brokerKey:
+        brokerClientKey:
           type: string
+        authType:
+          description: auth type for broker security
+          type: string
+          enum:
+            - none
+            - user
+            - certificate
         topic:
           type: string
         dataFormat:

--- a/contracts/svc/nifid.yml
+++ b/contracts/svc/nifid.yml
@@ -324,6 +324,15 @@ components:
           type: string
         topic:
           type: string
+        certCreatedAt:
+          type: string
+        authType:
+          description: auth type for broker security
+          type: string
+          enum:
+            - none
+            - user
+            - certificate
         dataFormat:
           type: string
         jsonMeasurementKey:

--- a/contracts/svc/nifid.yml
+++ b/contracts/svc/nifid.yml
@@ -234,6 +234,8 @@ components:
           type: string
         brokerPassword:
           type: string
+        brokerCACert:
+          type: string
         brokerCert:
           type: string
         brokerKey:

--- a/src/svc/nifid/schemas/Subscription.yml
+++ b/src/svc/nifid/schemas/Subscription.yml
@@ -19,6 +19,15 @@ properties:
     type: string
   topic:
     type: string
+  certCreatedAt:
+    type: string
+  authType:
+    description: auth type for broker security
+    type: string
+    enum:
+      - none
+      - user
+      - certificate
   dataFormat:
     type: string
   jsonMeasurementKey:

--- a/src/svc/nifid/schemas/Subscription.yml
+++ b/src/svc/nifid/schemas/Subscription.yml
@@ -19,7 +19,7 @@ properties:
     type: string
   topic:
     type: string
-  certCreatedAt:
+  certProvidedAt:
     type: string
   authType:
     description: auth type for broker security

--- a/src/svc/nifid/schemas/SubscriptionParams.yml
+++ b/src/svc/nifid/schemas/SubscriptionParams.yml
@@ -17,10 +17,17 @@ properties:
     type: string
   brokerCACert:
     type: string
-  brokerCert:
+  brokerClientCert:
     type: string
-  brokerKey:
+  brokerClientKey:
     type: string
+  authType:
+    description: auth type for broker security
+    type: string
+    enum:
+      - none
+      - user
+      - certificate
   topic:
     type: string
   dataFormat:

--- a/src/svc/nifid/schemas/SubscriptionParams.yml
+++ b/src/svc/nifid/schemas/SubscriptionParams.yml
@@ -15,6 +15,8 @@ properties:
     type: string
   brokerPassword:
     type: string
+  brokerCACert:
+    type: string
   brokerCert:
     type: string
   brokerKey:


### PR DESCRIPTION
Related Issue: https://github.com/influxdata/data-acquisition/issues/441

add `brokerCACert` and `authType` params as we need 4 params
1. `brokerCACert`
2. `brokerClientCert`
3. `brokerClientKey`