### PR TITLE
feat: add replication-bucket-name to replication

### DIFF
--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -5966,6 +5966,8 @@ components:
           type: string
         remoteBucketID:
           type: string
+        remoteBucketName:
+          type: string
         maxQueueSizeBytes:
           type: integer
           format: int64
@@ -5984,7 +5986,6 @@ components:
         - remoteID
         - orgID
         - localBucketID
-        - remoteBucketID
         - maxQueueSizeBytes
         - currentQueueSizeBytes
     Replications:
@@ -6009,6 +6010,8 @@ components:
           type: string
         remoteBucketID:
           type: string
+        remoteBucketName:
+          type: string
         maxQueueSizeBytes:
           type: integer
           format: int64
@@ -6027,7 +6030,6 @@ components:
         - orgID
         - remoteID
         - localBucketID
-        - remoteBucketID
         - maxQueueSizeBytes
         - maxAgeSeconds
     ReplicationUpdateRequest:
@@ -6040,6 +6042,8 @@ components:
         remoteID:
           type: string
         remoteBucketID:
+          type: string
+        remoteBucketName:
           type: string
         maxQueueSizeBytes:
           type: integer

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -22959,6 +22959,9 @@
           "remoteBucketID": {
             "type": "string"
           },
+          "remoteBucketName": {
+            "type": "string"
+          },
           "maxQueueSizeBytes": {
             "type": "integer",
             "format": "int64"
@@ -22983,7 +22986,6 @@
           "remoteID",
           "orgID",
           "localBucketID",
-          "remoteBucketID",
           "maxQueueSizeBytes",
           "currentQueueSizeBytes"
         ]
@@ -23020,6 +23022,9 @@
           "remoteBucketID": {
             "type": "string"
           },
+          "remoteBucketName": {
+            "type": "string"
+          },
           "maxQueueSizeBytes": {
             "type": "integer",
             "format": "int64",
@@ -23042,7 +23047,6 @@
           "orgID",
           "remoteID",
           "localBucketID",
-          "remoteBucketID",
           "maxQueueSizeBytes",
           "maxAgeSeconds"
         ]
@@ -23060,6 +23064,9 @@
             "type": "string"
           },
           "remoteBucketID": {
+            "type": "string"
+          },
+          "remoteBucketName": {
             "type": "string"
           },
           "maxQueueSizeBytes": {

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -16424,6 +16424,8 @@ components:
           type: string
         remoteBucketID:
           type: string
+        remoteBucketName:
+          type: string
         maxQueueSizeBytes:
           type: integer
           format: int64
@@ -16442,7 +16444,6 @@ components:
         - remoteID
         - orgID
         - localBucketID
-        - remoteBucketID
         - maxQueueSizeBytes
         - currentQueueSizeBytes
     Replications:
@@ -16467,6 +16468,8 @@ components:
           type: string
         remoteBucketID:
           type: string
+        remoteBucketName:
+          type: string
         maxQueueSizeBytes:
           type: integer
           format: int64
@@ -16485,7 +16488,6 @@ components:
         - orgID
         - remoteID
         - localBucketID
-        - remoteBucketID
         - maxQueueSizeBytes
         - maxAgeSeconds
     ReplicationUpdateRequest:
@@ -16498,6 +16500,8 @@ components:
         remoteID:
           type: string
         remoteBucketID:
+          type: string
+        remoteBucketName:
           type: string
         maxQueueSizeBytes:
           type: integer

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -3577,6 +3577,8 @@ components:
           type: string
         remoteBucketID:
           type: string
+        remoteBucketName:
+          type: string
         remoteID:
           type: string
       required:
@@ -3585,7 +3587,6 @@ components:
       - remoteID
       - orgID
       - localBucketID
-      - remoteBucketID
       - maxQueueSizeBytes
       - currentQueueSizeBytes
       type: object
@@ -3614,6 +3615,8 @@ components:
           type: string
         remoteBucketID:
           type: string
+        remoteBucketName:
+          type: string
         remoteID:
           type: string
       required:
@@ -3621,7 +3624,6 @@ components:
       - orgID
       - remoteID
       - localBucketID
-      - remoteBucketID
       - maxQueueSizeBytes
       - maxAgeSeconds
       type: object
@@ -3642,6 +3644,8 @@ components:
         name:
           type: string
         remoteBucketID:
+          type: string
+        remoteBucketName:
           type: string
         remoteID:
           type: string

--- a/src/oss/schemas/Replication.yml
+++ b/src/oss/schemas/Replication.yml
@@ -14,6 +14,8 @@ properties:
     type: string
   remoteBucketID:
     type: string
+  remoteBucketName:
+    type: string
   maxQueueSizeBytes:
     type: integer
     format: int64
@@ -32,6 +34,5 @@ required:
   - remoteID
   - orgID
   - localBucketID
-  - remoteBucketID
   - maxQueueSizeBytes
   - currentQueueSizeBytes

--- a/src/oss/schemas/ReplicationCreationRequest.yml
+++ b/src/oss/schemas/ReplicationCreationRequest.yml
@@ -12,6 +12,8 @@ properties:
     type: string
   remoteBucketID:
     type: string
+  remoteBucketName:
+    type: string
   maxQueueSizeBytes:
     type: integer
     format: int64
@@ -30,6 +32,5 @@ required:
   - orgID
   - remoteID
   - localBucketID
-  - remoteBucketID
   - maxQueueSizeBytes
   - maxAgeSeconds

--- a/src/oss/schemas/ReplicationUpdateRequest.yml
+++ b/src/oss/schemas/ReplicationUpdateRequest.yml
@@ -8,6 +8,8 @@ properties:
     type: string
   remoteBucketID:
     type: string
+  remoteBucketName:
+    type: string
   maxQueueSizeBytes:
     type: integer
     format: int64


### PR DESCRIPTION
Replications will now support passing a bucket-name as well as a bucket-id. This is to provide full support for replication to 1.x installations. Fixes https://github.com/influxdata/influxdb/issues/23550