### PR TITLE
feat: allow users to set custom prettier ignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 ts/
 .vscode
 .idea/
+.prettierignore


### PR DESCRIPTION
`prettier` is auto-formatting the **.yml** files by updating the indentation of the whole file on every save. That is too opinionated. To stop this from happening and making large diffs, let users set their own prettier ignore rules via **.prettierignore** which does not need to be shared by everyone.