### PR TITLE
feat: Add `POST /api/v2private/orgs` to unity

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -611,6 +611,38 @@ paths:
         default:
           description: Unexpected error
           $ref: '#/components/responses/ServerError'
+  /orgs:
+    post:
+      operationId: PostOrgs
+      tags:
+        - Organizations
+      summary: Creates an organization
+      requestBody:
+        description: Information for provisioning an organization
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrganizationCreateRequest'
+      responses:
+        '201':
+          description: Organization created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationWithToken'
+        '400':
+          description: Invalid request
+          $ref: '#/components/responses/ServerError'
+        '401':
+          description: Unauthorized bearer token
+          $ref: '#/components/responses/ServerError'
+        '409':
+          description: Organization name taken
+          $ref: '#/components/responses/ServerError'
+        default:
+          description: Unexpected error
+          $ref: '#/components/responses/ServerError'
   '/orgs/{orgId}':
     get:
       operationId: GetOrgsId
@@ -2369,6 +2401,21 @@ components:
         - isRegionBeta
         - regionCode
         - regionName
+    OrganizationWithToken:
+      allOf:
+        - $ref: '#/components/schemas/Organization'
+        - type: object
+          properties:
+            token:
+              description: Authentication token to manage the organization and its resources in IDPE
+              readOnly: true
+              type: string
+            links:
+              description: Links to the IDPE resources for this organization
+              readOnly: true
+              type: object
+              example:
+                resource: path/to/resource
     OrganizationSummaries:
       type: array
       items:
@@ -2391,6 +2438,26 @@ components:
           - name
           - isActive
           - isDefault
+    OrganizationCreateRequest:
+      type: object
+      properties:
+        orgName:
+          description: name of the organization
+          type: string
+        provider:
+          description: name of the cloud provider
+          type: string
+          enum:
+            - AWS
+            - GCP
+            - Azure
+        region:
+          description: name of the region within the cloud provider
+          type: string
+      required:
+        - orgName
+        - provider
+        - region
     OrganizationDefaultRequest:
       properties:
         id:

--- a/src/unity.yml
+++ b/src/unity.yml
@@ -49,6 +49,8 @@ paths:
     $ref: './unity/paths/billing_invoices.yml'
   '/billing/invoices/{invoiceId}':
     $ref: './unity/paths/billing_invoices_invoiceId.yml'
+  '/orgs':
+    $ref: './unity/paths/orgs.yml'
   '/orgs/{orgId}':
     $ref: './unity/paths/orgs_orgId.yml'
   '/orgs/{orgId}/invites':
@@ -196,8 +198,12 @@ components:
       $ref: './unity/schemas/RelatedAccount.yml'
     Organization:
       $ref: './unity/schemas/Organization.yml'
+    OrganizationWithToken:
+      $ref: './unity/schemas/OrganizationWithToken.yml'
     OrganizationSummaries:
       $ref: './unity/schemas/OrganizationSummaries.yml'
+    OrganizationCreateRequest:
+      $ref: './unity/schemas/OrganizationCreateRequest.yml'
     OrganizationDefaultRequest:
       $ref: './unity/schemas/OrganizationDefaultRequest.yml'
     # quartz shared limits

--- a/src/unity/paths/orgs.yml
+++ b/src/unity/paths/orgs.yml
@@ -1,0 +1,31 @@
+post:
+  operationId: PostOrgs
+  tags:
+    - Organizations
+  summary: Creates an organization
+  requestBody:
+    description: Information for provisioning an organization
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: "../schemas/OrganizationCreateRequest.yml"
+  responses:
+    "201":
+      description: Organization created
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/OrganizationWithToken.yml"
+    "400":
+      description: Invalid request
+      $ref: "../../common/responses/ServerError.yml"
+    "401":
+      description: Unauthorized bearer token
+      $ref: "../../common/responses/ServerError.yml"
+    "409":
+      description: Organization name taken
+      $ref: "../../common/responses/ServerError.yml"
+    default:
+      description: Unexpected error
+      $ref: "../../common/responses/ServerError.yml"

--- a/src/unity/schemas/OrganizationCreateRequest.yml
+++ b/src/unity/schemas/OrganizationCreateRequest.yml
@@ -1,0 +1,16 @@
+type: object
+properties:
+  orgName:
+    description: name of the organization
+    type: string
+  provider:
+    description: name of the cloud provider
+    type: string
+    enum:
+      - AWS
+      - GCP
+      - Azure
+  region:
+    description: name of the region within the cloud provider
+    type: string
+required: [orgName, provider, region]

--- a/src/unity/schemas/OrganizationWithToken.yml
+++ b/src/unity/schemas/OrganizationWithToken.yml
@@ -1,0 +1,13 @@
+allOf:
+  - $ref: "./Organization.yml"
+  - type: object
+    properties:
+      token:
+        description: Authentication token to manage the organization and its resources in IDPE
+        readOnly: true
+        type: string
+      links:
+        description: Links to the IDPE resources for this organization
+        readOnly: true
+        type: object
+        example: { "resource": "path/to/resource" }


### PR DESCRIPTION
[Quartz #6659](https://github.com/influxdata/quartz/issues/6659)

In multi-org a user will be able to add an organization to an account in the UI. Due to redirects in the Quartz version of this API, we had to make a separate endpoint for this new feature. This endpoint (`POST /api/v2private`) requires `region`, `provider`, and `orgName` in the request. It will return a `201` with the new organization if successful, otherwise it will return one of the following errors: `400`, `401`, `409`, and `500`. 