### PR TITLE
chore(ecommerce): Change `400` to `422` for Create Org `v2private`

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -631,14 +631,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OrganizationWithToken'
-        '400':
-          description: Invalid request
-          $ref: '#/components/responses/ServerError'
         '401':
           description: Unauthorized bearer token
           $ref: '#/components/responses/ServerError'
         '409':
           description: Organization name taken
+          $ref: '#/components/responses/ServerError'
+        '422':
+          description: Missing or invalid information
           $ref: '#/components/responses/ServerError'
         default:
           description: Unexpected error

--- a/src/unity/paths/orgs.yml
+++ b/src/unity/paths/orgs.yml
@@ -9,23 +9,23 @@ post:
     content:
       application/json:
         schema:
-          $ref: "../schemas/OrganizationCreateRequest.yml"
+          $ref: '../schemas/OrganizationCreateRequest.yml'
   responses:
-    "201":
+    '201':
       description: Organization created
       content:
         application/json:
           schema:
-            $ref: "../schemas/OrganizationWithToken.yml"
-    "400":
-      description: Invalid request
-      $ref: "../../common/responses/ServerError.yml"
-    "401":
+            $ref: '../schemas/OrganizationWithToken.yml'
+    '401':
       description: Unauthorized bearer token
-      $ref: "../../common/responses/ServerError.yml"
-    "409":
+      $ref: '../../common/responses/ServerError.yml'
+    '409':
       description: Organization name taken
-      $ref: "../../common/responses/ServerError.yml"
+      $ref: '../../common/responses/ServerError.yml'
+    '422':
+      description: Missing or invalid information
+      $ref: '../../common/responses/ServerError.yml'
     default:
       description: Unexpected error
-      $ref: "../../common/responses/ServerError.yml"
+      $ref: '../../common/responses/ServerError.yml'


### PR DESCRIPTION
We decided to change the `400` response to `422` for the new `POST /api/v2private/orgs` endpoint. This keeps in line with our other `v2private` endpoints.