### PR TITLE
chore: Cleanup descriptions for `POST v2private/orgs`

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -626,19 +626,24 @@ paths:
               $ref: '#/components/schemas/OrganizationCreateRequest'
       responses:
         '201':
-          description: Organization created
+          description: |
+            Created. The response body contains the newly created organization.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/OrganizationWithToken'
         '401':
-          description: Unauthorized bearer token
+          description: Unauthorized. The token passed doesn't have permissions necessary to complete the request.
           $ref: '#/components/responses/ServerError'
         '409':
-          description: Organization name taken
+          description: Conflict. The organization name is already in use.
           $ref: '#/components/responses/ServerError'
         '422':
-          description: Missing or invalid information
+          description: |
+            Unprocessable entity.
+            The error may indicate one of the following problems:
+            - The request body isn't valid--the request is well-formed, but InfluxDB can't process it due to semantic errors.
+            - You passed a parameter combination that InfluxDB doesn't support
           $ref: '#/components/responses/ServerError'
         default:
           description: Unexpected error

--- a/src/unity/paths/orgs.yml
+++ b/src/unity/paths/orgs.yml
@@ -12,19 +12,24 @@ post:
           $ref: '../schemas/OrganizationCreateRequest.yml'
   responses:
     '201':
-      description: Organization created
+      description: |
+        Created. The response body contains the newly created organization.
       content:
         application/json:
           schema:
             $ref: '../schemas/OrganizationWithToken.yml'
     '401':
-      description: Unauthorized bearer token
+      description: Unauthorized. The token passed doesn't have permissions necessary to complete the request.
       $ref: '../../common/responses/ServerError.yml'
     '409':
-      description: Organization name taken
+      description: Conflict. The organization name is already in use.
       $ref: '../../common/responses/ServerError.yml'
     '422':
-      description: Missing or invalid information
+      description: |
+        Unprocessable entity.
+        The error may indicate one of the following problems:
+        - The request body isn't valid--the request is well-formed, but InfluxDB can't process it due to semantic errors.
+        - You passed a parameter combination that InfluxDB doesn't support
       $ref: '../../common/responses/ServerError.yml'
     default:
       description: Unexpected error


### PR DESCRIPTION
#505 

As requested following [PR 504](https://github.com/influxdata/openapi/pull/504), the descriptions for status returns on `POST /api/v2private/orgs` have been updated. 