### PR TITLE
chore: correct error return for `POST /api/v2private/orgs`

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -632,18 +632,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OrganizationWithToken'
+        '400':
+          description: |
+            Bad request.
+            The error may indicate one of the following problems:
+            - The request body isn't valid--the request is well-formed, but InfluxDB can't process it due to semantic errors.
+            - You passed a parameter combination that InfluxDB doesn't support
+          $ref: '#/components/responses/ServerError'
         '401':
           description: Unauthorized. The token passed doesn't have permissions necessary to complete the request.
           $ref: '#/components/responses/ServerError'
         '409':
           description: Conflict. The organization name is already in use.
-          $ref: '#/components/responses/ServerError'
-        '422':
-          description: |
-            Unprocessable entity.
-            The error may indicate one of the following problems:
-            - The request body isn't valid--the request is well-formed, but InfluxDB can't process it due to semantic errors.
-            - You passed a parameter combination that InfluxDB doesn't support
           $ref: '#/components/responses/ServerError'
         default:
           description: Unexpected error

--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -637,13 +637,17 @@ paths:
             Bad request.
             The error may indicate one of the following problems:
             - The request body isn't valid--the request is well-formed, but InfluxDB can't process it due to semantic errors.
-            - You passed a parameter combination that InfluxDB doesn't support
+            - You passed a parameter combination that InfluxDB doesn't support.
           $ref: '#/components/responses/ServerError'
         '401':
           description: Unauthorized. The token passed doesn't have permissions necessary to complete the request.
           $ref: '#/components/responses/ServerError'
         '409':
           description: Conflict. The organization name is already in use.
+          $ref: '#/components/responses/ServerError'
+        '422':
+          description: |
+            Unprocessable entity. The request contains missing or invalid information.
           $ref: '#/components/responses/ServerError'
         default:
           description: Unexpected error

--- a/src/unity/paths/orgs.yml
+++ b/src/unity/paths/orgs.yml
@@ -23,13 +23,17 @@ post:
         Bad request.
         The error may indicate one of the following problems:
         - The request body isn't valid--the request is well-formed, but InfluxDB can't process it due to semantic errors.
-        - You passed a parameter combination that InfluxDB doesn't support
+        - You passed a parameter combination that InfluxDB doesn't support.
       $ref: "../../common/responses/ServerError.yml"
     '401':
       description: Unauthorized. The token passed doesn't have permissions necessary to complete the request.
       $ref: '../../common/responses/ServerError.yml'
     '409':
       description: Conflict. The organization name is already in use.
+      $ref: '../../common/responses/ServerError.yml'
+    '422':
+      description: |
+        Unprocessable entity. The request contains missing or invalid information.
       $ref: '../../common/responses/ServerError.yml'
     default:
       description: Unexpected error

--- a/src/unity/paths/orgs.yml
+++ b/src/unity/paths/orgs.yml
@@ -18,18 +18,18 @@ post:
         application/json:
           schema:
             $ref: '../schemas/OrganizationWithToken.yml'
+    '400':
+      description: |
+        Bad request.
+        The error may indicate one of the following problems:
+        - The request body isn't valid--the request is well-formed, but InfluxDB can't process it due to semantic errors.
+        - You passed a parameter combination that InfluxDB doesn't support
+      $ref: "../../common/responses/ServerError.yml"
     '401':
       description: Unauthorized. The token passed doesn't have permissions necessary to complete the request.
       $ref: '../../common/responses/ServerError.yml'
     '409':
       description: Conflict. The organization name is already in use.
-      $ref: '../../common/responses/ServerError.yml'
-    '422':
-      description: |
-        Unprocessable entity.
-        The error may indicate one of the following problems:
-        - The request body isn't valid--the request is well-formed, but InfluxDB can't process it due to semantic errors.
-        - You passed a parameter combination that InfluxDB doesn't support
       $ref: '../../common/responses/ServerError.yml'
     default:
       description: Unexpected error


### PR DESCRIPTION
After additional testing for the new `POST /api/v2private/orgs` was completed, it was noted that Quartz returns `400` when a required parameter is missing, rather than `422`, so the `unity` swagger has been updated to reflect that. 