### PR TITLE
feat(scripts): bulk update/remove internal API endpoints

### DIFF
--- a/contracts/svc/invocable-scripts-internal.yml
+++ b/contracts/svc/invocable-scripts-internal.yml
@@ -1,0 +1,178 @@
+openapi: 3.0.0
+info:
+  title: InfluxData Invokable Scripts Internal API
+  version: 0.1.0
+  description: |
+    Internal API endpoints for Invokable Scripts.
+    These operations can only be called internally from other services.
+servers:
+  - url: /
+paths:
+  /scripts/labels/update:
+    patch:
+      operationId: PatchScriptsBulkUpdateLabel
+      tags:
+        - Data I/O endpoints
+        - Invokable Scripts
+      summary: Updates a label name in all scripts in the organization.
+      description: |
+        Updates a label name in all scripts in the organization.
+        This is a global operation and can only be called
+        internally between services. Global (not org-scoped)
+        access needed for `labels` and `functions`.
+      requestBody:
+        description: The org ID and the label name to update.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScriptBulkUpdateLabelRequest'
+      responses:
+        '204':
+          description: |
+            Success. 
+            The label name is updated in all scripts of the organization.
+        '400':
+          description: Bad request.
+          $ref: '#/components/responses/ServerError'
+        '401':
+          $ref: '#/components/responses/AuthorizationError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        default:
+          description: Unexpected error.
+          $ref: '#/components/responses/ServerError'
+  /scripts/labels/remove:
+    patch:
+      operationId: PatchScriptsBulkRemoveLabel
+      tags:
+        - Data I/O endpoints
+        - Invokable Scripts
+      summary: Removes a label from all scripts in the organization.
+      description: |
+        Removes a label from all scripts in the organization.
+        This is a global operation and can only be called
+        internally between services. Global (not org-scoped)
+        access needed for `labels` and `functions`.
+      requestBody:
+        description: The org ID and the label names to remove.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScriptBulkRemoveLabelRequest'
+      responses:
+        '204':
+          description: |
+            Success. 
+            The label is removed from all scripts of the organization.
+        '400':
+          description: Bad request.
+          $ref: '#/components/responses/ServerError'
+        '401':
+          $ref: '#/components/responses/AuthorizationError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        default:
+          description: Unexpected error.
+          $ref: '#/components/responses/ServerError'
+components:
+  responses:
+    ServerError:
+      description: Non 2XX error response from server.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    AuthorizationError:
+      description: |
+        Unauthorized. The error may indicate one of the following:
+
+          * The `Authorization: Token` header is missing or malformed.
+          * The API token value is missing from the header.
+          * The token doesn't have sufficient permissions to write to this organization and bucket.
+      content:
+        application/json:
+          schema:
+            properties:
+              code:
+                description: |
+                  The HTTP status code description. Default is `unauthorized`.
+                readOnly: true
+                type: string
+                enum:
+                  - unauthorized
+              message:
+                readOnly: true
+                description: A human-readable message that may contain detail about the error.
+                type: string
+          examples:
+            tokenNotAuthorized:
+              summary: Token is not authorized to access a resource
+              value:
+                code: unauthorized
+                message: unauthorized access
+    InternalServerError:
+      description: |
+        Internal server error.
+        The server encountered an unexpected situation.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+  schemas:
+    Error:
+      properties:
+        code:
+          description: code is the machine-readable error code.
+          readOnly: true
+          type: string
+          enum:
+            - internal error
+            - not found
+            - conflict
+            - invalid
+            - unprocessable entity
+            - empty value
+            - unavailable
+            - forbidden
+            - too many requests
+            - unauthorized
+            - method not allowed
+            - request too large
+            - unsupported media type
+        message:
+          readOnly: true
+          description: Human-readable message.
+          type: string
+        op:
+          readOnly: true
+          description: Describes the logical code operation when the error occurred. Useful for debugging.
+          type: string
+        err:
+          readOnly: true
+          description: Stack of errors that occurred during processing of the request. Useful for debugging.
+          type: string
+      required:
+        - code
+    ScriptBulkUpdateLabelRequest:
+      type: object
+      properties:
+        orgID:
+          description: The organization ID of the scripts for updating the label name.
+          type: string
+        oldLabelName:
+          description: The old label name.
+          type: string
+        newLabelName:
+          description: The new label name.
+          type: string
+    ScriptBulkRemoveLabelRequest:
+      type: object
+      properties:
+        orgID:
+          description: The organization ID of the scripts for removing the label.
+          type: string
+        label:
+          description: A label name to remove.
+          type: string

--- a/contracts/svc/invocable-scripts-internal.yml
+++ b/contracts/svc/invocable-scripts-internal.yml
@@ -27,7 +27,8 @@ paths:
 
         - Requires global (not org-scoped) permissions for `labels` and `functions`.
       requestBody:
-        description: The org ID and the label name to update.
+        description: |
+          The label update to apply to all scripts in the organization.
         required: true
         content:
           application/json:
@@ -67,7 +68,8 @@ paths:
 
         - Requires global (not org-scoped) permissions for `labels` and `functions`.
       requestBody:
-        description: The org ID and the label names to remove.
+        description: |
+          The label to remove from all scripts in the organization.
         required: true
         content:
           application/json:

--- a/contracts/svc/invocable-scripts-internal.yml
+++ b/contracts/svc/invocable-scripts-internal.yml
@@ -30,7 +30,7 @@ paths:
       responses:
         '204':
           description: |
-            Success. 
+            Success.
             The label name is updated in all scripts of the organization.
         '400':
           description: Bad request.
@@ -64,7 +64,7 @@ paths:
       responses:
         '204':
           description: |
-            Success. 
+            Success.
             The label is removed from all scripts of the organization.
         '400':
           description: Bad request.

--- a/contracts/svc/invocable-scripts-internal.yml
+++ b/contracts/svc/invocable-scripts-internal.yml
@@ -14,12 +14,18 @@ paths:
       tags:
         - Data I/O endpoints
         - Invokable Scripts
-      summary: Updates a label name in all scripts in the organization.
+      summary: Update a label name in all scripts in the organization.
       description: |
-        Updates a label name in all scripts in the organization.
-        This is a global operation and can only be called
-        internally between services. Global (not org-scoped)
-        access needed for `labels` and `functions`.
+        Updates a label name for all scripts in the organization.
+
+        #### Limitations
+
+        - This is a global operation that can only be called
+        internally between services.
+
+        #### Permissions
+
+        - Requires global (not org-scoped) permissions for `labels` and `functions`.
       requestBody:
         description: The org ID and the label name to update.
         required: true
@@ -31,7 +37,7 @@ paths:
         '204':
           description: |
             Success.
-            The label name is updated in all scripts of the organization.
+            The label name is updated for all scripts owned by the organization.
         '400':
           description: Bad request.
           $ref: '#/components/responses/ServerError'
@@ -48,12 +54,18 @@ paths:
       tags:
         - Data I/O endpoints
         - Invokable Scripts
-      summary: Removes a label from all scripts in the organization.
+      summary: Remove a label from all scripts in the organization.
       description: |
         Removes a label from all scripts in the organization.
-        This is a global operation and can only be called
-        internally between services. Global (not org-scoped)
-        access needed for `labels` and `functions`.
+
+        #### Limitations
+
+        - This is a global operation that can only be called
+        internally between services.
+
+        #### Permissions
+
+        - Requires global (not org-scoped) permissions for `labels` and `functions`.
       requestBody:
         description: The org ID and the label names to remove.
         required: true
@@ -65,7 +77,7 @@ paths:
         '204':
           description: |
             Success.
-            The label is removed from all scripts of the organization.
+            The label is removed from all scripts owned by the organization.
         '400':
           description: Bad request.
           $ref: '#/components/responses/ServerError'
@@ -159,7 +171,7 @@ components:
       type: object
       properties:
         orgID:
-          description: The organization ID of the scripts for updating the label name.
+          description: The ID of the organization that owns the scripts with the label.
           type: string
         oldLabelName:
           description: The old label name.
@@ -171,7 +183,7 @@ components:
       type: object
       properties:
         orgID:
-          description: The organization ID of the scripts for removing the label.
+          description: The ID of the organization that owns the scripts with the label.
           type: string
         label:
           description: A label name to remove.

--- a/src/svc-invocable-scripts-internal.yml
+++ b/src/svc-invocable-scripts-internal.yml
@@ -1,0 +1,29 @@
+openapi: '3.0.0'
+info:
+  title: InfluxData Invokable Scripts Internal API
+  version: 0.1.0
+  description: |
+      Internal API endpoints for Invokable Scripts.
+      These operations can only be called internally from other services.
+servers:
+  - url: '/'
+paths:
+  '/scripts/labels/update':
+    $ref: './svc/invocable-scripts-internal/paths/scripts_labels_update.yml'
+  '/scripts/labels/remove':
+    $ref: './svc/invocable-scripts-internal/paths/scripts_labels_remove.yml'
+components:
+  responses:
+    ServerError:
+      $ref: './common/responses/ServerError.yml'
+    AuthorizationError:
+      $ref: './common/responses/AuthorizationError.yml'
+    InternalServerError:
+      $ref: './common/responses/InternalServerError.yml'
+  schemas:
+    Error:
+      $ref: './common/schemas/Error.yml'
+    ScriptBulkUpdateLabelRequest:
+      $ref: './svc/invocable-scripts-internal/schemas/ScriptBulkUpdateLabelRequest.yml'
+    ScriptBulkRemoveLabelRequest:
+      $ref: './svc/invocable-scripts-internal/schemas/ScriptBulkRemoveLabelRequest.yml'

--- a/src/svc/invocable-scripts-internal/paths/scripts_labels_remove.yml
+++ b/src/svc/invocable-scripts-internal/paths/scripts_labels_remove.yml
@@ -1,0 +1,33 @@
+patch:
+  operationId: PatchScriptsBulkRemoveLabel
+  tags:
+    - Data I/O endpoints
+    - Invokable Scripts
+  summary: Removes a label from all scripts in the organization.
+  description: |
+    Removes a label from all scripts in the organization.
+    This is a global operation and can only be called
+    internally between services. Global (not org-scoped)
+    access needed for `labels` and `functions`.
+  requestBody:
+    description: The org ID and the label names to remove.
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/ScriptBulkRemoveLabelRequest.yml'
+  responses:
+    '204': 
+      description: |
+        Success. 
+        The label is removed from all scripts of the organization.
+    '400':
+      description: Bad request.
+      $ref: '../../../common/responses/ServerError.yml'
+    '401':
+      $ref: '../../../common/responses/AuthorizationError.yml'
+    '500':
+      $ref: '../../../common/responses/InternalServerError.yml'
+    default:
+      description: Unexpected error.
+      $ref: '../../../common/responses/ServerError.yml'

--- a/src/svc/invocable-scripts-internal/paths/scripts_labels_remove.yml
+++ b/src/svc/invocable-scripts-internal/paths/scripts_labels_remove.yml
@@ -3,12 +3,18 @@ patch:
   tags:
     - Data I/O endpoints
     - Invokable Scripts
-  summary: Removes a label from all scripts in the organization.
+  summary: Remove a label from all scripts in the organization.
   description: |
     Removes a label from all scripts in the organization.
-    This is a global operation and can only be called
-    internally between services. Global (not org-scoped)
-    access needed for `labels` and `functions`.
+    
+    #### Limitations
+   
+    - This is a global operation that can only be called
+    internally between services.
+    
+    #### Permissions
+    
+    - Requires global (not org-scoped) permissions for `labels` and `functions`.
   requestBody:
     description: The org ID and the label names to remove.
     required: true
@@ -20,7 +26,7 @@ patch:
     '204':
       description: |
         Success.
-        The label is removed from all scripts of the organization.
+        The label is removed from all scripts owned by the organization.
     '400':
       description: Bad request.
       $ref: '../../../common/responses/ServerError.yml'

--- a/src/svc/invocable-scripts-internal/paths/scripts_labels_remove.yml
+++ b/src/svc/invocable-scripts-internal/paths/scripts_labels_remove.yml
@@ -17,9 +17,9 @@ patch:
         schema:
           $ref: '../schemas/ScriptBulkRemoveLabelRequest.yml'
   responses:
-    '204': 
+    '204':
       description: |
-        Success. 
+        Success.
         The label is removed from all scripts of the organization.
     '400':
       description: Bad request.

--- a/src/svc/invocable-scripts-internal/paths/scripts_labels_remove.yml
+++ b/src/svc/invocable-scripts-internal/paths/scripts_labels_remove.yml
@@ -16,7 +16,8 @@ patch:
 
     - Requires global (not org-scoped) permissions for `labels` and `functions`.
   requestBody:
-    description: The org ID and the label names to remove.
+    description: |
+      The label to remove from all scripts in the organization.
     required: true
     content:
       application/json:

--- a/src/svc/invocable-scripts-internal/paths/scripts_labels_remove.yml
+++ b/src/svc/invocable-scripts-internal/paths/scripts_labels_remove.yml
@@ -6,12 +6,12 @@ patch:
   summary: Remove a label from all scripts in the organization.
   description: |
     Removes a label from all scripts in the organization.
-    
+
     #### Limitations
-   
+
     - This is a global operation that can only be called
     internally between services.
-    
+
     #### Permissions
     
     - Requires global (not org-scoped) permissions for `labels` and `functions`.

--- a/src/svc/invocable-scripts-internal/paths/scripts_labels_remove.yml
+++ b/src/svc/invocable-scripts-internal/paths/scripts_labels_remove.yml
@@ -13,7 +13,7 @@ patch:
     internally between services.
 
     #### Permissions
-    
+
     - Requires global (not org-scoped) permissions for `labels` and `functions`.
   requestBody:
     description: The org ID and the label names to remove.

--- a/src/svc/invocable-scripts-internal/paths/scripts_labels_update.yml
+++ b/src/svc/invocable-scripts-internal/paths/scripts_labels_update.yml
@@ -8,12 +8,12 @@ patch:
     Updates a label name for all scripts in the organization.
 
     #### Limitations
-   
+
     - This is a global operation that can only be called
     internally between services.
-    
+
     #### Permissions
-    
+
     - Requires global (not org-scoped) permissions for `labels` and `functions`.
   requestBody:
     description: The org ID and the label name to update.

--- a/src/svc/invocable-scripts-internal/paths/scripts_labels_update.yml
+++ b/src/svc/invocable-scripts-internal/paths/scripts_labels_update.yml
@@ -3,12 +3,18 @@ patch:
   tags:
     - Data I/O endpoints
     - Invokable Scripts
-  summary: Updates a label name in all scripts in the organization.
+  summary: Update a label name in all scripts in the organization.
   description: |
-    Updates a label name in all scripts in the organization.
-    This is a global operation and can only be called
-    internally between services. Global (not org-scoped)
-    access needed for `labels` and `functions`.
+    Updates a label name for all scripts in the organization.
+
+    #### Limitations
+   
+    - This is a global operation that can only be called
+    internally between services.
+    
+    #### Permissions
+    
+    - Requires global (not org-scoped) permissions for `labels` and `functions`.
   requestBody:
     description: The org ID and the label name to update.
     required: true
@@ -20,7 +26,7 @@ patch:
     '204':
       description: |
         Success.
-        The label name is updated in all scripts of the organization.
+        The label name is updated for all scripts owned by the organization.
     '400':
       description: Bad request.
       $ref: '../../../common/responses/ServerError.yml'

--- a/src/svc/invocable-scripts-internal/paths/scripts_labels_update.yml
+++ b/src/svc/invocable-scripts-internal/paths/scripts_labels_update.yml
@@ -1,0 +1,33 @@
+patch:
+  operationId: PatchScriptsBulkUpdateLabel
+  tags:
+    - Data I/O endpoints
+    - Invokable Scripts
+  summary: Updates a label name in all scripts in the organization.
+  description: |
+    Updates a label name in all scripts in the organization.
+    This is a global operation and can only be called
+    internally between services. Global (not org-scoped)
+    access needed for `labels` and `functions`.
+  requestBody:
+    description: The org ID and the label name to update.
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/ScriptBulkUpdateLabelRequest.yml'
+  responses:
+    '204': 
+      description: |
+        Success. 
+        The label name is updated in all scripts of the organization.
+    '400':
+      description: Bad request.
+      $ref: '../../../common/responses/ServerError.yml'
+    '401':
+      $ref: '../../../common/responses/AuthorizationError.yml'
+    '500':
+      $ref: '../../../common/responses/InternalServerError.yml'
+    default:
+      description: Unexpected error.
+      $ref: '../../../common/responses/ServerError.yml'

--- a/src/svc/invocable-scripts-internal/paths/scripts_labels_update.yml
+++ b/src/svc/invocable-scripts-internal/paths/scripts_labels_update.yml
@@ -17,9 +17,9 @@ patch:
         schema:
           $ref: '../schemas/ScriptBulkUpdateLabelRequest.yml'
   responses:
-    '204': 
+    '204':
       description: |
-        Success. 
+        Success.
         The label name is updated in all scripts of the organization.
     '400':
       description: Bad request.

--- a/src/svc/invocable-scripts-internal/paths/scripts_labels_update.yml
+++ b/src/svc/invocable-scripts-internal/paths/scripts_labels_update.yml
@@ -16,7 +16,8 @@ patch:
 
     - Requires global (not org-scoped) permissions for `labels` and `functions`.
   requestBody:
-    description: The org ID and the label name to update.
+    description: |
+      The label update to apply to all scripts in the organization.
     required: true
     content:
       application/json:

--- a/src/svc/invocable-scripts-internal/schemas/ScriptBulkRemoveLabelRequest.yml
+++ b/src/svc/invocable-scripts-internal/schemas/ScriptBulkRemoveLabelRequest.yml
@@ -1,0 +1,8 @@
+type: object
+properties:
+  orgID:
+    description: The organization ID of the scripts for removing the label.
+    type: string
+  label:
+    description: A label name to remove.
+    type: string

--- a/src/svc/invocable-scripts-internal/schemas/ScriptBulkRemoveLabelRequest.yml
+++ b/src/svc/invocable-scripts-internal/schemas/ScriptBulkRemoveLabelRequest.yml
@@ -1,7 +1,7 @@
 type: object
 properties:
   orgID:
-    description: The organization ID of the scripts for removing the label.
+    description: The ID of the organization that owns the scripts with the label.
     type: string
   label:
     description: A label name to remove.

--- a/src/svc/invocable-scripts-internal/schemas/ScriptBulkUpdateLabelRequest.yml
+++ b/src/svc/invocable-scripts-internal/schemas/ScriptBulkUpdateLabelRequest.yml
@@ -1,7 +1,7 @@
 type: object
 properties:
   orgID:
-    description: The organization ID of the scripts for updating the label name.
+    description: The ID of the organization that owns the scripts with the label.
     type: string
   oldLabelName:
     description: The old label name.

--- a/src/svc/invocable-scripts-internal/schemas/ScriptBulkUpdateLabelRequest.yml
+++ b/src/svc/invocable-scripts-internal/schemas/ScriptBulkUpdateLabelRequest.yml
@@ -1,0 +1,11 @@
+type: object
+properties:
+  orgID:
+    description: The organization ID of the scripts for updating the label name.
+    type: string
+  oldLabelName:
+    description: The old label name.
+    type: string
+  newLabelName:
+    description: The new label name.
+    type: string


### PR DESCRIPTION
Closes https://github.com/influxdata/idpe/issues/15643

This PR adds the new API endpoints for the scripts service. These APIs are not exposed on the edge and is only called internally by other services. This means they don't belong inside the existing `svc-invocable-scripts.yml` file, so I've created a new folder under `src/svc` called `invocable-scripts-internal` to include the paths and the schemas. And this folder is not added to the `generate.sh` script so that it won't be published.