### PR TITLE
fix: repair GeoTrackMapViewLayer type

### DIFF
--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -2675,21 +2675,21 @@ paths:
                                                           - speed
                                                           - randomColors
                                                           - trackPointVisualization
-                                                    properties:
-                                                      trackWidth:
-                                                        description: Width of the track
-                                                        type: integer
-                                                      speed:
-                                                        description: Speed of the track animation
-                                                        type: integer
-                                                      randomColors:
-                                                        description: Assign different colors to different tracks
-                                                        type: boolean
-                                                      colors:
-                                                        description: Colors define color encoding of data into a visualization
-                                                        type: array
-                                                        items:
-                                                          $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/1/allOf/1/properties/cells/items/allOf/1/properties/properties/oneOf/0/properties/colors/items'
+                                                        properties:
+                                                          trackWidth:
+                                                            description: Width of the track
+                                                            type: integer
+                                                          speed:
+                                                            description: Speed of the track animation
+                                                            type: integer
+                                                          randomColors:
+                                                            description: Assign different colors to different tracks
+                                                            type: boolean
+                                                          colors:
+                                                            description: Colors define color encoding of data into a visualization
+                                                            type: array
+                                                            items:
+                                                              $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/1/allOf/1/properties/cells/items/allOf/1/properties/properties/oneOf/0/properties/colors/items'
                           labels:
                             $ref: '#/components/schemas/Task/properties/labels'
         default:

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -17785,30 +17785,30 @@
               "speed",
               "randomColors",
               "trackPointVisualization"
-            ]
-          }
-        ],
-        "properties": {
-          "trackWidth": {
-            "description": "Width of the track",
-            "type": "integer"
-          },
-          "speed": {
-            "description": "Speed of the track animation",
-            "type": "integer"
-          },
-          "randomColors": {
-            "description": "Assign different colors to different tracks",
-            "type": "boolean"
-          },
-          "colors": {
-            "description": "Colors define color encoding of data into a visualization",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/DashboardColor"
+            ],
+            "properties": {
+              "trackWidth": {
+                "description": "Width of the track",
+                "type": "integer"
+              },
+              "speed": {
+                "description": "Speed of the track animation",
+                "type": "integer"
+              },
+              "randomColors": {
+                "description": "Assign different colors to different tracks",
+                "type": "boolean"
+              },
+              "colors": {
+                "description": "Colors define color encoding of data into a visualization",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/DashboardColor"
+                }
+              }
             }
           }
-        }
+        ]
       },
       "GeoHeatMapViewLayer": {
         "allOf": [

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -13583,21 +13583,21 @@ components:
             - speed
             - randomColors
             - trackPointVisualization
-      properties:
-        trackWidth:
-          description: Width of the track
-          type: integer
-        speed:
-          description: Speed of the track animation
-          type: integer
-        randomColors:
-          description: Assign different colors to different tracks
-          type: boolean
-        colors:
-          description: Colors define color encoding of data into a visualization
-          type: array
-          items:
-            $ref: '#/components/schemas/DashboardColor'
+          properties:
+            trackWidth:
+              description: Width of the track
+              type: integer
+            speed:
+              description: Speed of the track animation
+              type: integer
+            randomColors:
+              description: Assign different colors to different tracks
+              type: boolean
+            colors:
+              description: Colors define color encoding of data into a visualization
+              type: array
+              items:
+                $ref: '#/components/schemas/DashboardColor'
     GeoHeatMapViewLayer:
       allOf:
         - $ref: '#/components/schemas/GeoViewLayerProperties'

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -11895,21 +11895,21 @@ components:
             - speed
             - randomColors
             - trackPointVisualization
-      properties:
-        trackWidth:
-          description: Width of the track
-          type: integer
-        speed:
-          description: Speed of the track animation
-          type: integer
-        randomColors:
-          description: Assign different colors to different tracks
-          type: boolean
-        colors:
-          description: Colors define color encoding of data into a visualization
-          type: array
-          items:
-            $ref: '#/components/schemas/DashboardColor'
+          properties:
+            trackWidth:
+              description: Width of the track
+              type: integer
+            speed:
+              description: Speed of the track animation
+              type: integer
+            randomColors:
+              description: Assign different colors to different tracks
+              type: boolean
+            colors:
+              description: Colors define color encoding of data into a visualization
+              type: array
+              items:
+                $ref: '#/components/schemas/DashboardColor'
     GeoHeatMapViewLayer:
       allOf:
         - $ref: '#/components/schemas/GeoViewLayerProperties'

--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -4723,21 +4723,21 @@ paths:
                                                           - speed
                                                           - randomColors
                                                           - trackPointVisualization
-                                                    properties:
-                                                      trackWidth:
-                                                        description: Width of the track
-                                                        type: integer
-                                                      speed:
-                                                        description: Speed of the track animation
-                                                        type: integer
-                                                      randomColors:
-                                                        description: Assign different colors to different tracks
-                                                        type: boolean
-                                                      colors:
-                                                        description: Colors define color encoding of data into a visualization
-                                                        type: array
-                                                        items:
-                                                          $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/1/allOf/1/properties/cells/items/allOf/1/properties/properties/oneOf/0/properties/colors/items'
+                                                        properties:
+                                                          trackWidth:
+                                                            description: Width of the track
+                                                            type: integer
+                                                          speed:
+                                                            description: Speed of the track animation
+                                                            type: integer
+                                                          randomColors:
+                                                            description: Assign different colors to different tracks
+                                                            type: boolean
+                                                          colors:
+                                                            description: Colors define color encoding of data into a visualization
+                                                            type: array
+                                                            items:
+                                                              $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/1/allOf/1/properties/cells/items/allOf/1/properties/properties/oneOf/0/properties/colors/items'
                           labels:
                             $ref: '#/components/schemas/Task/properties/labels'
         default:

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -20335,30 +20335,30 @@
               "speed",
               "randomColors",
               "trackPointVisualization"
-            ]
-          }
-        ],
-        "properties": {
-          "trackWidth": {
-            "description": "Width of the track",
-            "type": "integer"
-          },
-          "speed": {
-            "description": "Speed of the track animation",
-            "type": "integer"
-          },
-          "randomColors": {
-            "description": "Assign different colors to different tracks",
-            "type": "boolean"
-          },
-          "colors": {
-            "description": "Colors define color encoding of data into a visualization",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/DashboardColor"
+            ],
+            "properties": {
+              "trackWidth": {
+                "description": "Width of the track",
+                "type": "integer"
+              },
+              "speed": {
+                "description": "Speed of the track animation",
+                "type": "integer"
+              },
+              "randomColors": {
+                "description": "Assign different colors to different tracks",
+                "type": "boolean"
+              },
+              "colors": {
+                "description": "Colors define color encoding of data into a visualization",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/DashboardColor"
+                }
+              }
             }
           }
-        }
+        ]
       },
       "GeoHeatMapViewLayer": {
         "allOf": [

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -15367,21 +15367,21 @@ components:
             - speed
             - randomColors
             - trackPointVisualization
-      properties:
-        trackWidth:
-          description: Width of the track
-          type: integer
-        speed:
-          description: Speed of the track animation
-          type: integer
-        randomColors:
-          description: Assign different colors to different tracks
-          type: boolean
-        colors:
-          description: Colors define color encoding of data into a visualization
-          type: array
-          items:
-            $ref: '#/components/schemas/DashboardColor'
+          properties:
+            trackWidth:
+              description: Width of the track
+              type: integer
+            speed:
+              description: Speed of the track animation
+              type: integer
+            randomColors:
+              description: Assign different colors to different tracks
+              type: boolean
+            colors:
+              description: Colors define color encoding of data into a visualization
+              type: array
+              items:
+                $ref: '#/components/schemas/DashboardColor'
     GeoHeatMapViewLayer:
       allOf:
         - $ref: '#/components/schemas/GeoViewLayerProperties'

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -1662,27 +1662,27 @@ components:
     GeoTrackMapViewLayer:
       allOf:
       - $ref: '#/components/schemas/GeoViewLayerProperties'
-      - required:
+      - properties:
+          colors:
+            description: Colors define color encoding of data into a visualization
+            items:
+              $ref: '#/components/schemas/DashboardColor'
+            type: array
+          randomColors:
+            description: Assign different colors to different tracks
+            type: boolean
+          speed:
+            description: Speed of the track animation
+            type: integer
+          trackWidth:
+            description: Width of the track
+            type: integer
+        required:
         - trackWidth
         - speed
         - randomColors
         - trackPointVisualization
         type: object
-      properties:
-        colors:
-          description: Colors define color encoding of data into a visualization
-          items:
-            $ref: '#/components/schemas/DashboardColor'
-          type: array
-        randomColors:
-          description: Assign different colors to different tracks
-          type: boolean
-        speed:
-          description: Speed of the track animation
-          type: integer
-        trackWidth:
-          description: Width of the track
-          type: integer
     GeoViewLayer:
       oneOf:
       - $ref: '#/components/schemas/GeoCircleViewLayer'

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -1720,27 +1720,27 @@ components:
     GeoTrackMapViewLayer:
       allOf:
       - $ref: '#/components/schemas/GeoViewLayerProperties'
-      - required:
+      - properties:
+          colors:
+            description: Colors define color encoding of data into a visualization
+            items:
+              $ref: '#/components/schemas/DashboardColor'
+            type: array
+          randomColors:
+            description: Assign different colors to different tracks
+            type: boolean
+          speed:
+            description: Speed of the track animation
+            type: integer
+          trackWidth:
+            description: Width of the track
+            type: integer
+        required:
         - trackWidth
         - speed
         - randomColors
         - trackPointVisualization
         type: object
-      properties:
-        colors:
-          description: Colors define color encoding of data into a visualization
-          items:
-            $ref: '#/components/schemas/DashboardColor'
-          type: array
-        randomColors:
-          description: Assign different colors to different tracks
-          type: boolean
-        speed:
-          description: Speed of the track animation
-          type: integer
-        trackWidth:
-          description: Width of the track
-          type: integer
     GeoViewLayer:
       oneOf:
       - $ref: '#/components/schemas/GeoCircleViewLayer'

--- a/src/common/schemas/GeoTrackMapViewLayer.yml
+++ b/src/common/schemas/GeoTrackMapViewLayer.yml
@@ -2,18 +2,18 @@
     - $ref: "./GeoViewLayerProperties.yml"
     - type: object
       required: [trackWidth, speed, randomColors, trackPointVisualization]
-  properties:
-    trackWidth:
-      description: Width of the track
-      type: integer
-    speed:
-      description: Speed of the track animation
-      type: integer
-    randomColors:
-      description: Assign different colors to different tracks
-      type: boolean
-    colors:
-      description: Colors define color encoding of data into a visualization
-      type: array
-      items:
-          $ref: "./DashboardColor.yml"
+      properties:
+        trackWidth:
+          description: Width of the track
+          type: integer
+        speed:
+          description: Speed of the track animation
+          type: integer
+        randomColors:
+          description: Assign different colors to different tracks
+          type: boolean
+        colors:
+          description: Colors define color encoding of data into a visualization
+          type: array
+          items:
+              $ref: "./DashboardColor.yml"


### PR DESCRIPTION
This PR repairs `GeoTrackMapViewLayer` type so that `allOf` combinator includes the required properties. Previous type definition was somehow ignored by code generators, GeoTrackMapViewLayer type with `allOf` and `properties` did not make sense.