### PR TITLE
fix(user): POST operation for `/users/{userID}/password` doesn't require basic auth

### DIFF
--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -9465,7 +9465,7 @@
           "Users"
         ],
         "summary": "Update a password",
-        "description": "Updates a user password.\n\nUse this endpoint to let a user authenticate with\n[Basic authentication credentials](#section/Authentication/BasicAuthentication)\nand set a new password.\n\n#### InfluxDB Cloud\n\n- Doesn't allow you to manage user passwords through the API.\n  Use the InfluxDB Cloud user interface (UI) to update a password.\n\n#### Related guides\n\n- [InfluxDB Cloud - Change your password](https://docs.influxdata.com/influxdb/cloud/account-management/change-password/)\n- [InfluxDB OSS - Change your password](https://docs.influxdata.com/influxdb/latest/users/change-password/)\n",
+        "description": "Updates a user password.\n\n#### InfluxDB Cloud\n\n- Doesn't allow you to manage user passwords through the API.\n  Use the InfluxDB Cloud user interface (UI) to update a password.\n\n#### Related guides\n\n- [InfluxDB Cloud - Change your password](https://docs.influxdata.com/influxdb/cloud/account-management/change-password/)\n- [InfluxDB OSS - Change your password](https://docs.influxdata.com/influxdb/latest/users/change-password/)\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -9522,8 +9522,8 @@
         "x-codeSamples": [
           {
             "lang": "Shell",
-            "label": "cURL: use Basic auth to update the user password",
-            "source": "curl --request POST \\\n   \"http://localhost:8086/api/v2/users/USER_ID/password\" \\\n  --header 'Content-type: application/json' \\\n  --user \"USERNAME:PASSWORD\" \\\n  --data-binary @- << EOF\n    {\"password\": \"\"}\nEOF\n"
+            "label": "cURL: use HTTP POST to update the user password",
+            "source": "curl --request POST \\\n   \"http://localhost:8086/api/v2/users/USER_ID/password\" \\\n  --header 'Content-type: application/json' \\\n  --header \"Authorization: Token INFLUX_TOKEN\" \\\n  --data-binary @- << EOF\n    {\"password\": \"\"}\nEOF\n"
           }
         ]
       },

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -9466,6 +9466,75 @@
         ],
         "summary": "Update a password",
         "description": "Updates a user password.\n\nUse this endpoint to let a user authenticate with\n[Basic authentication credentials](#section/Authentication/BasicAuthentication)\nand set a new password.\n\n#### InfluxDB Cloud\n\n- Doesn't allow you to manage user passwords through the API.\n  Use the InfluxDB Cloud user interface (UI) to update a password.\n\n#### Related guides\n\n- [InfluxDB Cloud - Change your password](https://docs.influxdata.com/influxdb/cloud/account-management/change-password/)\n- [InfluxDB OSS - Change your password](https://docs.influxdata.com/influxdb/latest/users/change-password/)\n",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TraceSpan"
+          },
+          {
+            "in": "path",
+            "name": "userID",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "The ID of the user to set the password for."
+          }
+        ],
+        "requestBody": {
+          "description": "The new password to set for the user.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PasswordResetBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Success. The password is updated."
+          },
+          "400": {
+            "description": "Bad request.\n\n#### InfluxDB Cloud\n\n- Doesn't allow you to manage passwords through the API; always responds with this status.\n\n#### InfluxDB OSS\n\n- Doesn't understand a value passed in the request.\n",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "updatePasswordNotAllowed": {
+                    "summary": "Cloud API can't update passwords",
+                    "value": {
+                      "code": "invalid",
+                      "message": "passwords cannot be changed through the InfluxDB Cloud API"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "$ref": "#/components/responses/GeneralServerError"
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "Shell",
+            "label": "cURL: use Basic auth to update the user password",
+            "source": "curl --request POST \\\n   \"http://localhost:8086/api/v2/users/USER_ID/password\" \\\n  --header 'Content-type: application/json' \\\n  --user \"USERNAME:PASSWORD\" \\\n  --data-binary @- << EOF\n    {\"password\": \"\"}\nEOF\n"
+          }
+        ]
+      },
+      "put": {
+        "operationId": "PostUsersIDPassword",
+        "tags": [
+          "Security and access endpoints",
+          "Users"
+        ],
+        "summary": "Update a password",
+        "description": "Updates a user password.\n\nUse this endpoint to let a user authenticate with\n[Basic authentication credentials](#section/Authentication/BasicAuthentication)\nand set a new password.\n\n#### InfluxDB Cloud\n\n- Doesn't allow you to manage user passwords through the API.\n  Use the InfluxDB Cloud user interface (UI) to update a password.\n\n#### Related guides\n\n- [InfluxDB Cloud - Change your password](https://docs.influxdata.com/influxdb/cloud/account-management/change-password/)\n- [InfluxDB OSS - Change your password](https://docs.influxdata.com/influxdb/latest/users/change-password/)\n",
         "security": [
           {
             "BasicAuthentication": []

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -9523,7 +9523,7 @@
           {
             "lang": "Shell",
             "label": "cURL: use HTTP POST to update the user password",
-            "source": "curl --request POST \\\n   \"http://localhost:8086/api/v2/users/USER_ID/password\" \\\n  --header 'Content-type: application/json' \\\n  --header \"Authorization: Token INFLUX_TOKEN\" \\\n  --data-binary @- << EOF\n    {\"password\": \"\"}\nEOF\n"
+            "source": "curl --request POST \\\n   \"http://localhost:8086/api/v2/users/USER_ID/password\" \\\n  --header 'Content-type: application/json' \\\n  --header \"Authorization: Token INFLUX_TOKEN\" \\\n  --data-binary @- << EOF\n    {\"password\": \"NEW_USER_PASSWORD\"}\nEOF\n"
           }
         ]
       },
@@ -9597,7 +9597,7 @@
           {
             "lang": "Shell",
             "label": "cURL: use Basic auth to update the user password",
-            "source": "curl --request POST \\\n   \"http://localhost:8086/api/v2/users/USER_ID/password\" \\\n  --header 'Content-type: application/json' \\\n  --user \"USERNAME:PASSWORD\" \\\n  --data-binary @- << EOF\n    {\"password\": \"\"}\nEOF\n"
+            "source": "curl -c ./cookie-file.tmp --request POST \\\n   \"http://localhost:8086/api/v2/signin\" \\\n  --user \"${INFLUX_USER_NAME}:${INFLUX_USER_PASSWORD}\"\n\ncurl -b ./cookie-file.tmp --request PUT \\\n   \"http://localhost:8086/api/v2/users/USER_ID/password\" \\\n  --header 'Content-type: application/json' \\\n  --data-binary @- << EOF\n    {\"password\": \"NEW_USER_PASSWORD\"}\nEOF\n"
           }
         ]
       }

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -9528,7 +9528,7 @@
         ]
       },
       "put": {
-        "operationId": "PostUsersIDPassword",
+        "operationId": "PutUsersIDPassword",
         "tags": [
           "Security and access endpoints",
           "Users"

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -7781,6 +7781,81 @@ paths:
 
         - [InfluxDB Cloud - Change your password](https://docs.influxdata.com/influxdb/cloud/account-management/change-password/)
         - [InfluxDB OSS - Change your password](https://docs.influxdata.com/influxdb/latest/users/change-password/)
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: path
+          name: userID
+          schema:
+            type: string
+          required: true
+          description: The ID of the user to set the password for.
+      requestBody:
+        description: The new password to set for the user.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PasswordResetBody'
+      responses:
+        '204':
+          description: Success. The password is updated.
+        '400':
+          description: |
+            Bad request.
+
+            #### InfluxDB Cloud
+
+            - Doesn't allow you to manage passwords through the API; always responds with this status.
+
+            #### InfluxDB OSS
+
+            - Doesn't understand a value passed in the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                updatePasswordNotAllowed:
+                  summary: Cloud API can't update passwords
+                  value:
+                    code: invalid
+                    message: passwords cannot be changed through the InfluxDB Cloud API
+        default:
+          description: Unexpected error
+          $ref: '#/components/responses/GeneralServerError'
+      x-codeSamples:
+        - lang: Shell
+          label: 'cURL: use Basic auth to update the user password'
+          source: |
+            curl --request POST \
+               "http://localhost:8086/api/v2/users/USER_ID/password" \
+              --header 'Content-type: application/json' \
+              --user "USERNAME:PASSWORD" \
+              --data-binary @- << EOF
+                {"password": ""}
+            EOF
+    put:
+      operationId: PostUsersIDPassword
+      tags:
+        - Security and access endpoints
+        - Users
+      summary: Update a password
+      description: |
+        Updates a user password.
+
+        Use this endpoint to let a user authenticate with
+        [Basic authentication credentials](#section/Authentication/BasicAuthentication)
+        and set a new password.
+
+        #### InfluxDB Cloud
+
+        - Doesn't allow you to manage user passwords through the API.
+          Use the InfluxDB Cloud user interface (UI) to update a password.
+
+        #### Related guides
+
+        - [InfluxDB Cloud - Change your password](https://docs.influxdata.com/influxdb/cloud/account-management/change-password/)
+        - [InfluxDB OSS - Change your password](https://docs.influxdata.com/influxdb/latest/users/change-password/)
       security:
         - BasicAuthentication: []
       parameters:

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -7768,10 +7768,6 @@ paths:
       description: |
         Updates a user password.
 
-        Use this endpoint to let a user authenticate with
-        [Basic authentication credentials](#section/Authentication/BasicAuthentication)
-        and set a new password.
-
         #### InfluxDB Cloud
 
         - Doesn't allow you to manage user passwords through the API.
@@ -7825,12 +7821,12 @@ paths:
           $ref: '#/components/responses/GeneralServerError'
       x-codeSamples:
         - lang: Shell
-          label: 'cURL: use Basic auth to update the user password'
+          label: 'cURL: use HTTP POST to update the user password'
           source: |
             curl --request POST \
                "http://localhost:8086/api/v2/users/USER_ID/password" \
               --header 'Content-type: application/json' \
-              --user "USERNAME:PASSWORD" \
+              --header "Authorization: Token INFLUX_TOKEN" \
               --data-binary @- << EOF
                 {"password": ""}
             EOF

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -7835,7 +7835,7 @@ paths:
                 {"password": ""}
             EOF
     put:
-      operationId: PostUsersIDPassword
+      operationId: PutUsersIDPassword
       tags:
         - Security and access endpoints
         - Users

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -7828,7 +7828,7 @@ paths:
               --header 'Content-type: application/json' \
               --header "Authorization: Token INFLUX_TOKEN" \
               --data-binary @- << EOF
-                {"password": ""}
+                {"password": "NEW_USER_PASSWORD"}
             EOF
     put:
       operationId: PutUsersIDPassword
@@ -7900,12 +7900,15 @@ paths:
         - lang: Shell
           label: 'cURL: use Basic auth to update the user password'
           source: |
-            curl --request POST \
+            curl -c ./cookie-file.tmp --request POST \
+               "http://localhost:8086/api/v2/signin" \
+              --user "${INFLUX_USER_NAME}:${INFLUX_USER_PASSWORD}"
+
+            curl -b ./cookie-file.tmp --request PUT \
                "http://localhost:8086/api/v2/users/USER_ID/password" \
               --header 'Content-type: application/json' \
-              --user "USERNAME:PASSWORD" \
               --data-binary @- << EOF
-                {"password": ""}
+                {"password": "NEW_USER_PASSWORD"}
             EOF
   /checks:
     get:

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -7593,7 +7593,7 @@ paths:
               --header 'Content-type: application/json' \
               --header "Authorization: Token INFLUX_TOKEN" \
               --data-binary @- << EOF
-                {"password": ""}
+                {"password": "NEW_USER_PASSWORD"}
             EOF
     put:
       operationId: PutUsersIDPassword
@@ -7665,12 +7665,15 @@ paths:
         - lang: Shell
           label: 'cURL: use Basic auth to update the user password'
           source: |
-            curl --request POST \
+            curl -c ./cookie-file.tmp --request POST \
+               "http://localhost:8086/api/v2/signin" \
+              --user "${INFLUX_USER_NAME}:${INFLUX_USER_PASSWORD}"
+
+            curl -b ./cookie-file.tmp --request PUT \
                "http://localhost:8086/api/v2/users/USER_ID/password" \
               --header 'Content-type: application/json' \
-              --user "USERNAME:PASSWORD" \
               --data-binary @- << EOF
-                {"password": ""}
+                {"password": "NEW_USER_PASSWORD"}
             EOF
   /checks:
     get:

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -7533,10 +7533,6 @@ paths:
       description: |
         Updates a user password.
 
-        Use this endpoint to let a user authenticate with
-        [Basic authentication credentials](#section/Authentication/BasicAuthentication)
-        and set a new password.
-
         #### InfluxDB Cloud
 
         - Doesn't allow you to manage user passwords through the API.
@@ -7590,12 +7586,12 @@ paths:
           $ref: '#/components/responses/GeneralServerError'
       x-codeSamples:
         - lang: Shell
-          label: 'cURL: use Basic auth to update the user password'
+          label: 'cURL: use HTTP POST to update the user password'
           source: |
             curl --request POST \
                "http://localhost:8086/api/v2/users/USER_ID/password" \
               --header 'Content-type: application/json' \
-              --user "USERNAME:PASSWORD" \
+              --header "Authorization: Token INFLUX_TOKEN" \
               --data-binary @- << EOF
                 {"password": ""}
             EOF

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -7546,6 +7546,81 @@ paths:
 
         - [InfluxDB Cloud - Change your password](https://docs.influxdata.com/influxdb/cloud/account-management/change-password/)
         - [InfluxDB OSS - Change your password](https://docs.influxdata.com/influxdb/latest/users/change-password/)
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: path
+          name: userID
+          schema:
+            type: string
+          required: true
+          description: The ID of the user to set the password for.
+      requestBody:
+        description: The new password to set for the user.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PasswordResetBody'
+      responses:
+        '204':
+          description: Success. The password is updated.
+        '400':
+          description: |
+            Bad request.
+
+            #### InfluxDB Cloud
+
+            - Doesn't allow you to manage passwords through the API; always responds with this status.
+
+            #### InfluxDB OSS
+
+            - Doesn't understand a value passed in the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                updatePasswordNotAllowed:
+                  summary: Cloud API can't update passwords
+                  value:
+                    code: invalid
+                    message: passwords cannot be changed through the InfluxDB Cloud API
+        default:
+          description: Unexpected error
+          $ref: '#/components/responses/GeneralServerError'
+      x-codeSamples:
+        - lang: Shell
+          label: 'cURL: use Basic auth to update the user password'
+          source: |
+            curl --request POST \
+               "http://localhost:8086/api/v2/users/USER_ID/password" \
+              --header 'Content-type: application/json' \
+              --user "USERNAME:PASSWORD" \
+              --data-binary @- << EOF
+                {"password": ""}
+            EOF
+    put:
+      operationId: PostUsersIDPassword
+      tags:
+        - Security and access endpoints
+        - Users
+      summary: Update a password
+      description: |
+        Updates a user password.
+
+        Use this endpoint to let a user authenticate with
+        [Basic authentication credentials](#section/Authentication/BasicAuthentication)
+        and set a new password.
+
+        #### InfluxDB Cloud
+
+        - Doesn't allow you to manage user passwords through the API.
+          Use the InfluxDB Cloud user interface (UI) to update a password.
+
+        #### Related guides
+
+        - [InfluxDB Cloud - Change your password](https://docs.influxdata.com/influxdb/cloud/account-management/change-password/)
+        - [InfluxDB OSS - Change your password](https://docs.influxdata.com/influxdb/latest/users/change-password/)
       security:
         - BasicAuthentication: []
       parameters:

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -7600,7 +7600,7 @@ paths:
                 {"password": ""}
             EOF
     put:
-      operationId: PostUsersIDPassword
+      operationId: PutUsersIDPassword
       tags:
         - Security and access endpoints
         - Users

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -9465,7 +9465,7 @@
           "Users"
         ],
         "summary": "Update a password",
-        "description": "Updates a user password.\n\nUse this endpoint to let a user authenticate with\n[Basic authentication credentials](#section/Authentication/BasicAuthentication)\nand set a new password.\n\n#### InfluxDB Cloud\n\n- Doesn't allow you to manage user passwords through the API.\n  Use the InfluxDB Cloud user interface (UI) to update a password.\n\n#### Related guides\n\n- [InfluxDB Cloud - Change your password](https://docs.influxdata.com/influxdb/cloud/account-management/change-password/)\n- [InfluxDB OSS - Change your password](https://docs.influxdata.com/influxdb/latest/users/change-password/)\n",
+        "description": "Updates a user password.\n\n#### InfluxDB Cloud\n\n- Doesn't allow you to manage user passwords through the API.\n  Use the InfluxDB Cloud user interface (UI) to update a password.\n\n#### Related guides\n\n- [InfluxDB Cloud - Change your password](https://docs.influxdata.com/influxdb/cloud/account-management/change-password/)\n- [InfluxDB OSS - Change your password](https://docs.influxdata.com/influxdb/latest/users/change-password/)\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -9522,8 +9522,8 @@
         "x-codeSamples": [
           {
             "lang": "Shell",
-            "label": "cURL: use Basic auth to update the user password",
-            "source": "curl --request POST \\\n   \"http://localhost:8086/api/v2/users/USER_ID/password\" \\\n  --header 'Content-type: application/json' \\\n  --user \"USERNAME:PASSWORD\" \\\n  --data-binary @- << EOF\n    {\"password\": \"\"}\nEOF\n"
+            "label": "cURL: use HTTP POST to update the user password",
+            "source": "curl --request POST \\\n   \"http://localhost:8086/api/v2/users/USER_ID/password\" \\\n  --header 'Content-type: application/json' \\\n  --header \"Authorization: Token INFLUX_TOKEN\" \\\n  --data-binary @- << EOF\n    {\"password\": \"\"}\nEOF\n"
           }
         ]
       },

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -9466,6 +9466,75 @@
         ],
         "summary": "Update a password",
         "description": "Updates a user password.\n\nUse this endpoint to let a user authenticate with\n[Basic authentication credentials](#section/Authentication/BasicAuthentication)\nand set a new password.\n\n#### InfluxDB Cloud\n\n- Doesn't allow you to manage user passwords through the API.\n  Use the InfluxDB Cloud user interface (UI) to update a password.\n\n#### Related guides\n\n- [InfluxDB Cloud - Change your password](https://docs.influxdata.com/influxdb/cloud/account-management/change-password/)\n- [InfluxDB OSS - Change your password](https://docs.influxdata.com/influxdb/latest/users/change-password/)\n",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TraceSpan"
+          },
+          {
+            "in": "path",
+            "name": "userID",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "The ID of the user to set the password for."
+          }
+        ],
+        "requestBody": {
+          "description": "The new password to set for the user.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PasswordResetBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Success. The password is updated."
+          },
+          "400": {
+            "description": "Bad request.\n\n#### InfluxDB Cloud\n\n- Doesn't allow you to manage passwords through the API; always responds with this status.\n\n#### InfluxDB OSS\n\n- Doesn't understand a value passed in the request.\n",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "updatePasswordNotAllowed": {
+                    "summary": "Cloud API can't update passwords",
+                    "value": {
+                      "code": "invalid",
+                      "message": "passwords cannot be changed through the InfluxDB Cloud API"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "$ref": "#/components/responses/GeneralServerError"
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "Shell",
+            "label": "cURL: use Basic auth to update the user password",
+            "source": "curl --request POST \\\n   \"http://localhost:8086/api/v2/users/USER_ID/password\" \\\n  --header 'Content-type: application/json' \\\n  --user \"USERNAME:PASSWORD\" \\\n  --data-binary @- << EOF\n    {\"password\": \"\"}\nEOF\n"
+          }
+        ]
+      },
+      "put": {
+        "operationId": "PostUsersIDPassword",
+        "tags": [
+          "Security and access endpoints",
+          "Users"
+        ],
+        "summary": "Update a password",
+        "description": "Updates a user password.\n\nUse this endpoint to let a user authenticate with\n[Basic authentication credentials](#section/Authentication/BasicAuthentication)\nand set a new password.\n\n#### InfluxDB Cloud\n\n- Doesn't allow you to manage user passwords through the API.\n  Use the InfluxDB Cloud user interface (UI) to update a password.\n\n#### Related guides\n\n- [InfluxDB Cloud - Change your password](https://docs.influxdata.com/influxdb/cloud/account-management/change-password/)\n- [InfluxDB OSS - Change your password](https://docs.influxdata.com/influxdb/latest/users/change-password/)\n",
         "security": [
           {
             "BasicAuthentication": []

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -9523,7 +9523,7 @@
           {
             "lang": "Shell",
             "label": "cURL: use HTTP POST to update the user password",
-            "source": "curl --request POST \\\n   \"http://localhost:8086/api/v2/users/USER_ID/password\" \\\n  --header 'Content-type: application/json' \\\n  --header \"Authorization: Token INFLUX_TOKEN\" \\\n  --data-binary @- << EOF\n    {\"password\": \"\"}\nEOF\n"
+            "source": "curl --request POST \\\n   \"http://localhost:8086/api/v2/users/USER_ID/password\" \\\n  --header 'Content-type: application/json' \\\n  --header \"Authorization: Token INFLUX_TOKEN\" \\\n  --data-binary @- << EOF\n    {\"password\": \"NEW_USER_PASSWORD\"}\nEOF\n"
           }
         ]
       },
@@ -9597,7 +9597,7 @@
           {
             "lang": "Shell",
             "label": "cURL: use Basic auth to update the user password",
-            "source": "curl --request POST \\\n   \"http://localhost:8086/api/v2/users/USER_ID/password\" \\\n  --header 'Content-type: application/json' \\\n  --user \"USERNAME:PASSWORD\" \\\n  --data-binary @- << EOF\n    {\"password\": \"\"}\nEOF\n"
+            "source": "curl -c ./cookie-file.tmp --request POST \\\n   \"http://localhost:8086/api/v2/signin\" \\\n  --user \"${INFLUX_USER_NAME}:${INFLUX_USER_PASSWORD}\"\n\ncurl -b ./cookie-file.tmp --request PUT \\\n   \"http://localhost:8086/api/v2/users/USER_ID/password\" \\\n  --header 'Content-type: application/json' \\\n  --data-binary @- << EOF\n    {\"password\": \"NEW_USER_PASSWORD\"}\nEOF\n"
           }
         ]
       }

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -9528,7 +9528,7 @@
         ]
       },
       "put": {
-        "operationId": "PostUsersIDPassword",
+        "operationId": "PutUsersIDPassword",
         "tags": [
           "Security and access endpoints",
           "Users"

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -7810,7 +7810,7 @@ paths:
               --header 'Content-type: application/json' \
               --header "Authorization: Token INFLUX_TOKEN" \
               --data-binary @- << EOF
-                {"password": ""}
+                {"password": "NEW_USER_PASSWORD"}
             EOF
     put:
       operationId: PutUsersIDPassword
@@ -7882,12 +7882,15 @@ paths:
         - lang: Shell
           label: 'cURL: use Basic auth to update the user password'
           source: |
-            curl --request POST \
+            curl -c ./cookie-file.tmp --request POST \
+               "http://localhost:8086/api/v2/signin" \
+              --user "${INFLUX_USER_NAME}:${INFLUX_USER_PASSWORD}"
+
+            curl -b ./cookie-file.tmp --request PUT \
                "http://localhost:8086/api/v2/users/USER_ID/password" \
               --header 'Content-type: application/json' \
-              --user "USERNAME:PASSWORD" \
               --data-binary @- << EOF
-                {"password": ""}
+                {"password": "NEW_USER_PASSWORD"}
             EOF
   /checks:
     get:

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -7750,10 +7750,6 @@ paths:
       description: |
         Updates a user password.
 
-        Use this endpoint to let a user authenticate with
-        [Basic authentication credentials](#section/Authentication/BasicAuthentication)
-        and set a new password.
-
         #### InfluxDB Cloud
 
         - Doesn't allow you to manage user passwords through the API.
@@ -7807,12 +7803,12 @@ paths:
           $ref: '#/components/responses/GeneralServerError'
       x-codeSamples:
         - lang: Shell
-          label: 'cURL: use Basic auth to update the user password'
+          label: 'cURL: use HTTP POST to update the user password'
           source: |
             curl --request POST \
                "http://localhost:8086/api/v2/users/USER_ID/password" \
               --header 'Content-type: application/json' \
-              --user "USERNAME:PASSWORD" \
+              --header "Authorization: Token INFLUX_TOKEN" \
               --data-binary @- << EOF
                 {"password": ""}
             EOF

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -7817,7 +7817,7 @@ paths:
                 {"password": ""}
             EOF
     put:
-      operationId: PostUsersIDPassword
+      operationId: PutUsersIDPassword
       tags:
         - Security and access endpoints
         - Users

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -7763,6 +7763,81 @@ paths:
 
         - [InfluxDB Cloud - Change your password](https://docs.influxdata.com/influxdb/cloud/account-management/change-password/)
         - [InfluxDB OSS - Change your password](https://docs.influxdata.com/influxdb/latest/users/change-password/)
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: path
+          name: userID
+          schema:
+            type: string
+          required: true
+          description: The ID of the user to set the password for.
+      requestBody:
+        description: The new password to set for the user.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PasswordResetBody'
+      responses:
+        '204':
+          description: Success. The password is updated.
+        '400':
+          description: |
+            Bad request.
+
+            #### InfluxDB Cloud
+
+            - Doesn't allow you to manage passwords through the API; always responds with this status.
+
+            #### InfluxDB OSS
+
+            - Doesn't understand a value passed in the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                updatePasswordNotAllowed:
+                  summary: Cloud API can't update passwords
+                  value:
+                    code: invalid
+                    message: passwords cannot be changed through the InfluxDB Cloud API
+        default:
+          description: Unexpected error
+          $ref: '#/components/responses/GeneralServerError'
+      x-codeSamples:
+        - lang: Shell
+          label: 'cURL: use Basic auth to update the user password'
+          source: |
+            curl --request POST \
+               "http://localhost:8086/api/v2/users/USER_ID/password" \
+              --header 'Content-type: application/json' \
+              --user "USERNAME:PASSWORD" \
+              --data-binary @- << EOF
+                {"password": ""}
+            EOF
+    put:
+      operationId: PostUsersIDPassword
+      tags:
+        - Security and access endpoints
+        - Users
+      summary: Update a password
+      description: |
+        Updates a user password.
+
+        Use this endpoint to let a user authenticate with
+        [Basic authentication credentials](#section/Authentication/BasicAuthentication)
+        and set a new password.
+
+        #### InfluxDB Cloud
+
+        - Doesn't allow you to manage user passwords through the API.
+          Use the InfluxDB Cloud user interface (UI) to update a password.
+
+        #### Related guides
+
+        - [InfluxDB Cloud - Change your password](https://docs.influxdata.com/influxdb/cloud/account-management/change-password/)
+        - [InfluxDB OSS - Change your password](https://docs.influxdata.com/influxdb/latest/users/change-password/)
       security:
         - BasicAuthentication: []
       parameters:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -16813,7 +16813,7 @@ paths:
             --header 'Content-type: application/json' \
             --header "Authorization: Token INFLUX_TOKEN" \
             --data-binary @- << EOF
-              {"password": ""}
+              {"password": "NEW_USER_PASSWORD"}
           EOF
     put:
       description: |
@@ -16886,12 +16886,15 @@ paths:
       - label: 'cURL: use Basic auth to update the user password'
         lang: Shell
         source: |
-          curl --request POST \
+          curl -c ./cookie-file.tmp --request POST \
+             "http://localhost:8086/api/v2/signin" \
+            --user "${INFLUX_USER_NAME}:${INFLUX_USER_PASSWORD}"
+
+          curl -b ./cookie-file.tmp --request PUT \
              "http://localhost:8086/api/v2/users/USER_ID/password" \
             --header 'Content-type: application/json' \
-            --user "USERNAME:PASSWORD" \
             --data-binary @- << EOF
-              {"password": ""}
+              {"password": "NEW_USER_PASSWORD"}
           EOF
   /api/v2/variables:
     get:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -16836,7 +16836,7 @@ paths:
 
         - [InfluxDB Cloud - Change your password](https://docs.influxdata.com/influxdb/cloud/account-management/change-password/)
         - [InfluxDB OSS - Change your password](https://docs.influxdata.com/influxdb/latest/users/change-password/)
-      operationId: PostUsersIDPassword
+      operationId: PutUsersIDPassword
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
       - description: The ID of the user to set the password for.

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -16804,6 +16804,82 @@ paths:
         default:
           $ref: '#/components/responses/GeneralServerError'
           description: Unexpected error
+      summary: Update a password
+      tags:
+      - Security and access endpoints
+      - Users
+      x-codeSamples:
+      - label: 'cURL: use Basic auth to update the user password'
+        lang: Shell
+        source: |
+          curl --request POST \
+             "http://localhost:8086/api/v2/users/USER_ID/password" \
+            --header 'Content-type: application/json' \
+            --user "USERNAME:PASSWORD" \
+            --data-binary @- << EOF
+              {"password": ""}
+          EOF
+    put:
+      description: |
+        Updates a user password.
+
+        Use this endpoint to let a user authenticate with
+        [Basic authentication credentials](#section/Authentication/BasicAuthentication)
+        and set a new password.
+
+        #### InfluxDB Cloud
+
+        - Doesn't allow you to manage user passwords through the API.
+          Use the InfluxDB Cloud user interface (UI) to update a password.
+
+        #### Related guides
+
+        - [InfluxDB Cloud - Change your password](https://docs.influxdata.com/influxdb/cloud/account-management/change-password/)
+        - [InfluxDB OSS - Change your password](https://docs.influxdata.com/influxdb/latest/users/change-password/)
+      operationId: PostUsersIDPassword
+      parameters:
+      - $ref: '#/components/parameters/TraceSpan'
+      - description: The ID of the user to set the password for.
+        in: path
+        name: userID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PasswordResetBody'
+        description: The new password to set for the user.
+        required: true
+      responses:
+        "204":
+          description: Success. The password is updated.
+        "400":
+          content:
+            application/json:
+              examples:
+                updatePasswordNotAllowed:
+                  summary: Cloud API can't update passwords
+                  value:
+                    code: invalid
+                    message: passwords cannot be changed through the InfluxDB Cloud
+                      API
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            Bad request.
+
+            #### InfluxDB Cloud
+
+            - Doesn't allow you to manage passwords through the API; always responds with this status.
+
+            #### InfluxDB OSS
+
+            - Doesn't understand a value passed in the request.
+        default:
+          $ref: '#/components/responses/GeneralServerError'
+          description: Unexpected error
       security:
       - BasicAuthentication: []
       summary: Update a password

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -16747,10 +16747,6 @@ paths:
       description: |
         Updates a user password.
 
-        Use this endpoint to let a user authenticate with
-        [Basic authentication credentials](#section/Authentication/BasicAuthentication)
-        and set a new password.
-
         #### InfluxDB Cloud
 
         - Doesn't allow you to manage user passwords through the API.
@@ -16809,13 +16805,13 @@ paths:
       - Security and access endpoints
       - Users
       x-codeSamples:
-      - label: 'cURL: use Basic auth to update the user password'
+      - label: 'cURL: use HTTP POST to update the user password'
         lang: Shell
         source: |
           curl --request POST \
              "http://localhost:8086/api/v2/users/USER_ID/password" \
             --header 'Content-type: application/json' \
-            --user "USERNAME:PASSWORD" \
+            --header "Authorization: Token INFLUX_TOKEN" \
             --data-binary @- << EOF
               {"password": ""}
           EOF

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -17943,6 +17943,82 @@ paths:
         default:
           $ref: '#/components/responses/GeneralServerError'
           description: Unexpected error
+      summary: Update a password
+      tags:
+      - Security and access endpoints
+      - Users
+      x-codeSamples:
+      - label: 'cURL: use Basic auth to update the user password'
+        lang: Shell
+        source: |
+          curl --request POST \
+             "http://localhost:8086/api/v2/users/USER_ID/password" \
+            --header 'Content-type: application/json' \
+            --user "USERNAME:PASSWORD" \
+            --data-binary @- << EOF
+              {"password": ""}
+          EOF
+    put:
+      description: |
+        Updates a user password.
+
+        Use this endpoint to let a user authenticate with
+        [Basic authentication credentials](#section/Authentication/BasicAuthentication)
+        and set a new password.
+
+        #### InfluxDB Cloud
+
+        - Doesn't allow you to manage user passwords through the API.
+          Use the InfluxDB Cloud user interface (UI) to update a password.
+
+        #### Related guides
+
+        - [InfluxDB Cloud - Change your password](https://docs.influxdata.com/influxdb/cloud/account-management/change-password/)
+        - [InfluxDB OSS - Change your password](https://docs.influxdata.com/influxdb/latest/users/change-password/)
+      operationId: PostUsersIDPassword
+      parameters:
+      - $ref: '#/components/parameters/TraceSpan'
+      - description: The ID of the user to set the password for.
+        in: path
+        name: userID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PasswordResetBody'
+        description: The new password to set for the user.
+        required: true
+      responses:
+        "204":
+          description: Success. The password is updated.
+        "400":
+          content:
+            application/json:
+              examples:
+                updatePasswordNotAllowed:
+                  summary: Cloud API can't update passwords
+                  value:
+                    code: invalid
+                    message: passwords cannot be changed through the InfluxDB Cloud
+                      API
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: |
+            Bad request.
+
+            #### InfluxDB Cloud
+
+            - Doesn't allow you to manage passwords through the API; always responds with this status.
+
+            #### InfluxDB OSS
+
+            - Doesn't understand a value passed in the request.
+        default:
+          $ref: '#/components/responses/GeneralServerError'
+          description: Unexpected error
       security:
       - BasicAuthentication: []
       summary: Update a password

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -17952,7 +17952,7 @@ paths:
             --header 'Content-type: application/json' \
             --header "Authorization: Token INFLUX_TOKEN" \
             --data-binary @- << EOF
-              {"password": ""}
+              {"password": "NEW_USER_PASSWORD"}
           EOF
     put:
       description: |
@@ -18025,12 +18025,15 @@ paths:
       - label: 'cURL: use Basic auth to update the user password'
         lang: Shell
         source: |
-          curl --request POST \
+          curl -c ./cookie-file.tmp --request POST \
+             "http://localhost:8086/api/v2/signin" \
+            --user "${INFLUX_USER_NAME}:${INFLUX_USER_PASSWORD}"
+
+          curl -b ./cookie-file.tmp --request PUT \
              "http://localhost:8086/api/v2/users/USER_ID/password" \
             --header 'Content-type: application/json' \
-            --user "USERNAME:PASSWORD" \
             --data-binary @- << EOF
-              {"password": ""}
+              {"password": "NEW_USER_PASSWORD"}
           EOF
   /api/v2/variables:
     get:

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -17886,10 +17886,6 @@ paths:
       description: |
         Updates a user password.
 
-        Use this endpoint to let a user authenticate with
-        [Basic authentication credentials](#section/Authentication/BasicAuthentication)
-        and set a new password.
-
         #### InfluxDB Cloud
 
         - Doesn't allow you to manage user passwords through the API.
@@ -17948,13 +17944,13 @@ paths:
       - Security and access endpoints
       - Users
       x-codeSamples:
-      - label: 'cURL: use Basic auth to update the user password'
+      - label: 'cURL: use HTTP POST to update the user password'
         lang: Shell
         source: |
           curl --request POST \
              "http://localhost:8086/api/v2/users/USER_ID/password" \
             --header 'Content-type: application/json' \
-            --user "USERNAME:PASSWORD" \
+            --header "Authorization: Token INFLUX_TOKEN" \
             --data-binary @- << EOF
               {"password": ""}
           EOF

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -17975,7 +17975,7 @@ paths:
 
         - [InfluxDB Cloud - Change your password](https://docs.influxdata.com/influxdb/cloud/account-management/change-password/)
         - [InfluxDB OSS - Change your password](https://docs.influxdata.com/influxdb/latest/users/change-password/)
-      operationId: PostUsersIDPassword
+      operationId: PutUsersIDPassword
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
       - description: The ID of the user to set the password for.

--- a/src/common/paths/users_userID_password.yml
+++ b/src/common/paths/users_userID_password.yml
@@ -20,6 +20,82 @@ post:
 
     - [InfluxDB Cloud - Change your password](https://docs.influxdata.com/influxdb/cloud/account-management/change-password/)
     - [InfluxDB OSS - Change your password](https://docs.influxdata.com/influxdb/latest/users/change-password/)
+  parameters:
+    - $ref: '../parameters/TraceSpan.yml'
+    - in: path
+      name: userID
+      schema:
+        type: string
+      required: true
+      description: The ID of the user to set the password for.
+  requestBody:
+    description: The new password to set for the user.
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/PasswordResetBody.yml'
+  responses:
+    '204':
+      description: Success. The password is updated.
+    '400':
+      description: |
+        Bad request.
+
+        #### InfluxDB Cloud
+
+        - Doesn't allow you to manage passwords through the API; always responds with this status.
+
+        #### InfluxDB OSS
+
+        - Doesn't understand a value passed in the request.
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/Error.yml"
+          examples:
+            updatePasswordNotAllowed:
+               summary: Cloud API can't update passwords
+               value: {
+                        "code": "invalid",
+                        "message": "passwords cannot be changed through the InfluxDB Cloud API"
+                      }
+    default:
+      description: Unexpected error
+      $ref: '../responses/ServerError.yml'
+  x-codeSamples:
+    - lang: Shell
+      label: "cURL: use Basic auth to update the user password"
+      source: |
+        curl --request POST \
+           "http://localhost:8086/api/v2/users/USER_ID/password" \
+          --header 'Content-type: application/json' \
+          --user "USERNAME:PASSWORD" \
+          --data-binary @- << EOF
+            {"password": ""}
+        EOF
+put:
+  operationId: PostUsersIDPassword
+  tags:
+    - Security and access endpoints
+    - Users
+  summary: Update a password
+  description: |
+    Updates a user password.
+
+    Use this endpoint to let a user authenticate with
+    [Basic authentication credentials](#section/Authentication/BasicAuthentication)
+    and set a new password.
+
+    #### InfluxDB Cloud
+
+    - Doesn't allow you to manage user passwords through the API.
+      Use the InfluxDB Cloud user interface (UI) to update a password.
+
+    #### Related guides
+
+    - [InfluxDB Cloud - Change your password](https://docs.influxdata.com/influxdb/cloud/account-management/change-password/)
+    - [InfluxDB OSS - Change your password](https://docs.influxdata.com/influxdb/latest/users/change-password/)
   security:
     - BasicAuthentication: []
   parameters:
@@ -76,4 +152,3 @@ post:
           --data-binary @- << EOF
             {"password": ""}
         EOF
-

--- a/src/common/paths/users_userID_password.yml
+++ b/src/common/paths/users_userID_password.yml
@@ -75,7 +75,7 @@ post:
             {"password": ""}
         EOF
 put:
-  operationId: PostUsersIDPassword
+  operationId: PutUsersIDPassword
   tags:
     - Security and access endpoints
     - Users

--- a/src/common/paths/users_userID_password.yml
+++ b/src/common/paths/users_userID_password.yml
@@ -7,10 +7,6 @@ post:
   description: |
     Updates a user password.
 
-    Use this endpoint to let a user authenticate with
-    [Basic authentication credentials](#section/Authentication/BasicAuthentication)
-    and set a new password.
-
     #### InfluxDB Cloud
 
     - Doesn't allow you to manage user passwords through the API.
@@ -65,12 +61,12 @@ post:
       $ref: '../responses/ServerError.yml'
   x-codeSamples:
     - lang: Shell
-      label: "cURL: use Basic auth to update the user password"
+      label: "cURL: use HTTP POST to update the user password"
       source: |
         curl --request POST \
            "http://localhost:8086/api/v2/users/USER_ID/password" \
           --header 'Content-type: application/json' \
-          --user "USERNAME:PASSWORD" \
+          --header "Authorization: Token INFLUX_TOKEN" \
           --data-binary @- << EOF
             {"password": ""}
         EOF

--- a/src/common/paths/users_userID_password.yml
+++ b/src/common/paths/users_userID_password.yml
@@ -144,7 +144,7 @@ put:
         curl -c ./cookie-file.tmp --request POST \
            "http://localhost:8086/api/v2/signin" \
           --user "${INFLUX_USER_NAME}:${INFLUX_USER_PASSWORD}"
-        
+
         curl -b ./cookie-file.tmp --request PUT \
            "http://localhost:8086/api/v2/users/USER_ID/password" \
           --header 'Content-type: application/json' \

--- a/src/common/paths/users_userID_password.yml
+++ b/src/common/paths/users_userID_password.yml
@@ -68,7 +68,7 @@ post:
           --header 'Content-type: application/json' \
           --header "Authorization: Token INFLUX_TOKEN" \
           --data-binary @- << EOF
-            {"password": ""}
+            {"password": "NEW_USER_PASSWORD"}
         EOF
 put:
   operationId: PutUsersIDPassword
@@ -141,10 +141,13 @@ put:
     - lang: Shell
       label: "cURL: use Basic auth to update the user password"
       source: |
-        curl --request POST \
+        curl -c ./cookie-file.tmp --request POST \
+           "http://localhost:8086/api/v2/signin" \
+          --user "${INFLUX_USER_NAME}:${INFLUX_USER_PASSWORD}"
+        
+        curl -b ./cookie-file.tmp --request PUT \
            "http://localhost:8086/api/v2/users/USER_ID/password" \
           --header 'Content-type: application/json' \
-          --user "USERNAME:PASSWORD" \
           --data-binary @- << EOF
-            {"password": ""}
+            {"password": "NEW_USER_PASSWORD"}
         EOF


### PR DESCRIPTION
Related to https://influxcommunity.slack.com/archives/CHQ5VG6F8/p1662739448171649

The `POST` operation for `/users/{userID}/password` is used by InfluxDB clients (for more info see https://github.com/influxdata/influxdb-client-python/pull/498) and with current `oss.yml` we can't update the user's password.

This PR change the contracts according to current OSS implementation:
- Remove `BasicAuth` from POST operation for `/users/{userID}/password`
- Add `PUT` operation for `/users/{userID}/password`

For more info see:

- https://github.com/influxdata/influxdb/blob/b0a0e734e0c46384499cdc1f08f2673b6a28ff98/tenant/http_server_user.go#L91
- https://github.com/influxdata/influx-cli/blob/3a593e718476d9e671b4a003679722c0b32dc47b/clients/user/user.go#L148