### PR TITLE
chore: add `409` to PATCH /api/v2private/orgs/orgId

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -712,6 +712,9 @@ paths:
         '401':
           description: Unauthorized
           $ref: '#/components/responses/ServerError'
+        '409':
+          description: Conflict. The organization name is already in use.
+          $ref: '#/components/responses/ServerError'
         '422':
           description: Missing or invalid information
           $ref: '#/components/responses/ServerError'

--- a/src/unity/paths/orgs_orgId.yml
+++ b/src/unity/paths/orgs_orgId.yml
@@ -52,6 +52,9 @@ patch:
     '401':
       description: Unauthorized
       $ref: '../../common/responses/ServerError.yml'
+    '409':
+      description: Conflict. The organization name is already in use.
+      $ref: '../../common/responses/ServerError.yml'
     '422':
       description: Missing or invalid information
       $ref: '../../common/responses/ServerError.yml'


### PR DESCRIPTION
For multi-org, Quartz now checks for organization name conflicts within an account. It will return a `409` if a name is already in use. The path for `PATCH /api/v2private/orgs/{orgId}` has been updated to reflect that. 