### PR TITLE
feat(uiproxyd): add quartz-login-url route

### DIFF
--- a/contracts/priv/uiproxyd.yml
+++ b/contracts/priv/uiproxyd.yml
@@ -51,6 +51,17 @@ paths:
           $ref: '#/components/responses/AuthorizationError'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /uiproxy/quartz-login-url:
+    get:
+      summary: Retrieves the value of the Quartz Login URL
+      operationId: getQuartzLoginUrl
+      responses:
+        '200':
+          description: Returns the login URL for the current environment
+        '401':
+          $ref: '#/components/responses/AuthorizationError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 components:
   schemas:
     Token:

--- a/contracts/svc/uiproxyd.yml
+++ b/contracts/svc/uiproxyd.yml
@@ -51,6 +51,17 @@ paths:
           $ref: '#/components/responses/AuthorizationError'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /uiproxy/quartz-login-url:
+    get:
+      summary: Retrieves the value of the Quartz Login URL
+      operationId: getQuartzLoginUrl
+      responses:
+        '200':
+          description: Returns the login URL for the current environment
+        '401':
+          $ref: '#/components/responses/AuthorizationError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 components:
   schemas:
     Token:

--- a/src/svc-uiproxyd.yml
+++ b/src/svc-uiproxyd.yml
@@ -12,6 +12,8 @@ paths:
     $ref: "./svc/uiproxyd/paths/mapToken.yml"
   /uiproxy/sfdc-support:
     $ref: "./svc/uiproxyd/paths/sfdcSupport.yml"
+  /uiproxy/quartz-login-url:
+    $ref: "./svc/uiproxyd/paths/quartzLoginUrl.yml"
 components:
   schemas:
     Token:

--- a/src/svc/uiproxyd/paths/quartzLoginUrl.yml
+++ b/src/svc/uiproxyd/paths/quartzLoginUrl.yml
@@ -1,0 +1,10 @@
+get:
+  summary: Retrieves the value of the Quartz Login URL
+  operationId: getQuartzLoginUrl
+  responses:
+    '200':
+      description: Returns the login URL for the current environment
+    '401':
+      $ref: '../../../common/responses/AuthorizationError.yml'
+    '500':
+      $ref: '../../../common/responses/InternalServerError.yml'


### PR DESCRIPTION
Adds the `quartz-login-url` route for sending an environment variable to the ui