### PR TITLE
chore: remove unfunctional property 'oauthID'

### DIFF
--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -3655,8 +3655,6 @@ components:
         id:
           readOnly: true
           type: string
-        oauthID:
-          type: string
         name:
           type: string
         status:

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -20697,9 +20697,6 @@
             "readOnly": true,
             "type": "string"
           },
-          "oauthID": {
-            "type": "string"
-          },
           "name": {
             "type": "string"
           },

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -15962,8 +15962,6 @@ components:
         id:
           readOnly: true
           type: string
-        oauthID:
-          type: string
         name:
           type: string
         status:

--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -5435,9 +5435,6 @@ components:
           readOnly: true
           type: string
           description: The user ID.
-        oauthID:
-          type: string
-          description: The OAuth ID.
         name:
           type: string
           description: The user name.

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -23141,10 +23141,6 @@
             "type": "string",
             "description": "The user ID."
           },
-          "oauthID": {
-            "type": "string",
-            "description": "The OAuth ID."
-          },
           "name": {
             "type": "string",
             "description": "The user name."

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -17576,9 +17576,6 @@ components:
           readOnly: true
           type: string
           description: The user ID.
-        oauthID:
-          type: string
-          description: The OAuth ID.
         name:
           type: string
           description: The user name.

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -6208,8 +6208,6 @@ components:
           type: string
         name:
           type: string
-        oauthID:
-          type: string
         org_id:
           type: string
         role:

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -6266,9 +6266,6 @@ components:
         name:
           description: The user name.
           type: string
-        oauthID:
-          description: The OAuth ID.
-          type: string
         status:
           default: active
           description: |

--- a/src/cloud/schemas/User.yml
+++ b/src/cloud/schemas/User.yml
@@ -2,8 +2,6 @@
     id:
       readOnly: true
       type: string
-    oauthID:
-      type: string
     name:
       type: string
     status:

--- a/src/common/schemas/User.yml
+++ b/src/common/schemas/User.yml
@@ -3,9 +3,6 @@
       readOnly: true
       type: string
       description: The user ID.
-    oauthID:
-      type: string
-      description: The OAuth ID.
     name:
       type: string
       description: The user name.


### PR DESCRIPTION
This removes an apparent unused schema property from both cloud and oss.