### PR TITLE
chore(nifid): add clientID

### DIFF
--- a/contracts/priv/nifid.yml
+++ b/contracts/priv/nifid.yml
@@ -305,6 +305,8 @@ components:
           default: true
         timestampPrecision:
           type: string
+        clientID:
+          type: string
     Subscription:
       properties:
         id:
@@ -327,7 +329,7 @@ components:
           type: string
         topic:
           type: string
-        certProvidedAt:
+        brokerCertCreationDate:
           type: string
         authType:
           description: auth type for broker security
@@ -399,6 +401,8 @@ components:
         token:
           type: string
         timestampPrecision:
+          type: string
+        clientID:
           type: string
     SubscriptionArray:
       type: array

--- a/contracts/svc/nifid.yml
+++ b/contracts/svc/nifid.yml
@@ -305,6 +305,8 @@ components:
           default: true
         timestampPrecision:
           type: string
+        clientID:
+          type: string
     Subscription:
       properties:
         id:
@@ -327,7 +329,7 @@ components:
           type: string
         topic:
           type: string
-        certProvidedAt:
+        brokerCertCreationDate:
           type: string
         authType:
           description: auth type for broker security
@@ -399,6 +401,8 @@ components:
         token:
           type: string
         timestampPrecision:
+          type: string
+        clientID:
           type: string
     SubscriptionArray:
       type: array

--- a/src/svc/nifid/schemas/Subscription.yml
+++ b/src/svc/nifid/schemas/Subscription.yml
@@ -19,7 +19,7 @@ properties:
     type: string
   topic:
     type: string
-  certProvidedAt:
+  brokerCertCreationDate:
     type: string
   authType:
     description: auth type for broker security
@@ -91,4 +91,6 @@ properties:
   token:
     type: string
   timestampPrecision:
+    type: string
+  clientID:
     type: string

--- a/src/svc/nifid/schemas/SubscriptionParams.yml
+++ b/src/svc/nifid/schemas/SubscriptionParams.yml
@@ -83,3 +83,5 @@ properties:
     default: true
   timestampPrecision:
     type: string
+  clientID:
+    type: string


### PR DESCRIPTION
Helps https://github.com/influxdata/data-acquisition/issues/464

Changes name of `certProvidedAt` to `brokerCertCreationDate` as we've done in the code already.

Adds `clientID` property to params and response in preparation for new feature.