### PR TITLE
chore(unity): remove obsolete isRegionBeta from Organization

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -2400,16 +2400,12 @@ components:
         provider:
           type: string
           description: provider of the org
-        isRegionBeta:
-          type: boolean
-          description: is the region of the organization in beta
         clusterHost:
           type: string
           description: the url of the current cluster
       required:
         - id
         - clusterHost
-        - isRegionBeta
         - regionCode
         - regionName
     OrganizationWithToken:

--- a/src/unity/schemas/Organization.yml
+++ b/src/unity/schemas/Organization.yml
@@ -22,10 +22,7 @@ properties:
   provider:
     type: string
     description: provider of the org
-  isRegionBeta:
-    type: boolean
-    description: is the region of the organization in beta
   clusterHost:
     type: string
     description: the url of the current cluster
-required: [id, clusterHost, isRegionBeta, regionCode, regionName]
+required: [id, clusterHost, regionCode, regionName]


### PR DESCRIPTION
This field is no longer used by the UI, so is obsolete and can be removed.