### PR TITLE
feat(unity): add query for org creation allowance

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -200,6 +200,31 @@ paths:
         default:
           description: Unexpected error
           $ref: '#/components/responses/ServerError'
+  /allowances/orgs/create:
+    get:
+      operationId: GetAllowancesOrgsCreate
+      tags:
+        - Allowances
+        - Organizations
+      summary: Return whether a new Organization can be created.
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+      responses:
+        '200':
+          description: The Allowance
+          content:
+            application/json:
+              schema:
+                properties:
+                  allowed:
+                    type: boolean
+                    description: is the operation allowed?
+                  upgradesAvailable:
+                    type: boolean
+                    description: are there upgrades available that would affect this allowance?
+                required:
+                  - allowed
+                  - upgradesAvailable
   /clusters:
     get:
       operationId: GetClusters

--- a/src/unity.yml
+++ b/src/unity.yml
@@ -20,6 +20,8 @@ paths:
     $ref: './unity/paths/accounts_accountId_orgs_default.yml'
   '/accounts/default':
     $ref: './unity/paths/accounts_default.yml'
+  '/allowances/orgs/create':
+    $ref: './unity/paths/allowances_org_create.yml'
   '/clusters':
     $ref: './unity/paths/clusters.yml'
   '/billing':

--- a/src/unity/paths/allowances_org_create.yml
+++ b/src/unity/paths/allowances_org_create.yml
@@ -1,0 +1,15 @@
+get:
+  operationId: GetAllowancesOrgsCreate
+  tags:
+    - Allowances
+    - Organizations
+  summary: Return whether a new Organization can be created.
+  parameters:
+    - $ref: "../../common/parameters/TraceSpan.yml"
+  responses:
+    "200":
+      description: The Allowance
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/Allowance.yml"

--- a/src/unity/schemas/Allowance.yml
+++ b/src/unity/schemas/Allowance.yml
@@ -1,0 +1,10 @@
+properties:
+  allowed:
+    type: boolean
+    description: is the operation allowed?
+  upgradesAvailable:
+    type: boolean
+    description: are there upgrades available that would affect this allowance?
+required:
+  - allowed
+  - upgradesAvailable


### PR DESCRIPTION
Part of influxdata/quartz#6725

This introduces the concept of an "allowance": is the current user/org/account **allowed** to perform an operation? The response contains the answer to the question as well as additional information that allows a UI to show more useful information.

For now, all we need is a flag indicating whether a plan upgrade would allow an operation that is currently denied, but we can expand this in the future when/if it becomes necessary.

Implementation-wise, an allowance encapsulates any business logic around permitting an operation, including entitlements (aka plan limits) as well as (in the future) roles/permissions.

It also introduces the first allowance query we need for multi-org: can an organization be created?