### PR TITLE
fix: Use `Organization` schema for create orgs response

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -635,7 +635,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrganizationWithToken'
+                $ref: '#/components/schemas/Organization'
         '401':
           description: Unauthorized. The token passed doesn't have permissions necessary to complete the request.
           $ref: '#/components/responses/ServerError'

--- a/src/unity/paths/orgs.yml
+++ b/src/unity/paths/orgs.yml
@@ -17,7 +17,7 @@ post:
       content:
         application/json:
           schema:
-            $ref: '../schemas/OrganizationWithToken.yml'
+            $ref: '../schemas/Organization.yml'
     '401':
       description: Unauthorized. The token passed doesn't have permissions necessary to complete the request.
       $ref: '../../common/responses/ServerError.yml'


### PR DESCRIPTION
Fixes the schema being used for the `POST /api/v2private/orgs` endpoint.