### PR TITLE
chore: Add Provider information to org summaries

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -2383,6 +2383,15 @@ components:
           isDefault:
             type: boolean
             description: is this the user's default organization in this account?
+          provider:
+            type: string
+            description: provider of the org
+          region:
+            type: string
+            description: the canonical code for the region where the organization is hosted
+          regionName:
+            type: string
+            description: the friendly name of the region where the organization is hosted
         required:
           - id
           - name

--- a/src/unity/schemas/OrganizationSummary.yml
+++ b/src/unity/schemas/OrganizationSummary.yml
@@ -12,4 +12,13 @@ properties:
   isDefault:
     type: boolean
     description: is this the user's default organization in this account?
+  provider:
+    type: string
+    description: provider of the org
+  region:
+    type: string
+    description: the canonical code for the region where the organization is hosted
+  regionName:
+    type: string
+    description: the friendly name of the region where the organization is hosted
 required: [id, name, isActive, isDefault]


### PR DESCRIPTION
This adds the following field to the `/api/v2private/accounts/:account_id/orgs` endpoint: `provider`, `region`, and `regionName`.