### PR TITLE
chore: make `remoteOrgID` not required for ENT connection

### DIFF
--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -6278,7 +6278,6 @@ components:
         - name
         - orgID
         - remoteURL
-        - remoteOrgID
         - allowInsecureTLS
     RemoteConnections:
       type: object

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -23967,7 +23967,6 @@
           "name",
           "orgID",
           "remoteURL",
-          "remoteOrgID",
           "allowInsecureTLS"
         ]
       },

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -18272,7 +18272,6 @@ components:
         - name
         - orgID
         - remoteURL
-        - remoteOrgID
         - allowInsecureTLS
     RemoteConnections:
       type: object

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -3579,7 +3579,6 @@ components:
       - name
       - orgID
       - remoteURL
-      - remoteOrgID
       - allowInsecureTLS
       type: object
     RemoteConnectionCreationRequest:

--- a/src/oss/schemas/RemoteConnection.yml
+++ b/src/oss/schemas/RemoteConnection.yml
@@ -21,5 +21,4 @@ required:
   - name
   - orgID
   - remoteURL
-  - remoteOrgID
   - allowInsecureTLS


### PR DESCRIPTION
Makes `remoteOrgID` not a required field as we support remote connections to 1.x/Enterprise, and this field is unnecessary for a connection to that type of instance