### PR TITLE
chore: fix required `remoteOrgID` in remote creation req

### DIFF
--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -6313,7 +6313,6 @@ components:
         - orgID
         - remoteURL
         - remoteAPIToken
-        - remoteOrgID
         - allowInsecureTLS
     RemoteConnectionUpdateRequest:
       type: object

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -24016,7 +24016,6 @@
           "orgID",
           "remoteURL",
           "remoteAPIToken",
-          "remoteOrgID",
           "allowInsecureTLS"
         ]
       },

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -18307,7 +18307,6 @@ components:
         - orgID
         - remoteURL
         - remoteAPIToken
-        - remoteOrgID
         - allowInsecureTLS
     RemoteConnectionUpdateRequest:
       type: object

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -3607,7 +3607,6 @@ components:
       - orgID
       - remoteURL
       - remoteAPIToken
-      - remoteOrgID
       - allowInsecureTLS
       type: object
     RemoteConnectionUpdateRequest:

--- a/src/oss/schemas/RemoteConnectionCreationRequest.yml
+++ b/src/oss/schemas/RemoteConnectionCreationRequest.yml
@@ -21,5 +21,4 @@ required:
   - orgID
   - remoteURL
   - remoteAPIToken
-  - remoteOrgID
   - allowInsecureTLS


### PR DESCRIPTION
Fixes a missed change needed in #583