### PR TITLE
feat(unity): convert upgrade option to enum

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -219,12 +219,16 @@ paths:
                   allowed:
                     type: boolean
                     description: is the operation allowed?
-                  upgradesAvailable:
-                    type: boolean
-                    description: are there upgrades available that would affect this allowance?
+                  availableUpgrade:
+                    description: what upgrade option is available for this allowance?
+                    type: string
+                    enum:
+                      - contract
+                      - none
+                      - pay_as_you_go
                 required:
                   - allowed
-                  - upgradesAvailable
+                  - availableUpgrade
   /clusters:
     get:
       operationId: GetClusters

--- a/src/unity/schemas/Allowance.yml
+++ b/src/unity/schemas/Allowance.yml
@@ -2,9 +2,9 @@ properties:
   allowed:
     type: boolean
     description: is the operation allowed?
-  upgradesAvailable:
-    type: boolean
-    description: are there upgrades available that would affect this allowance?
+  availableUpgrade:
+    $ref: './UpgradeOption.yml'
+    description: what upgrade option is available for this allowance?
 required:
   - allowed
-  - upgradesAvailable
+  - availableUpgrade

--- a/src/unity/schemas/UpgradeOption.yml
+++ b/src/unity/schemas/UpgradeOption.yml
@@ -1,0 +1,6 @@
+type: string
+description: Type of account upgrade available
+enum:
+  - contract
+  - none
+  - pay_as_you_go


### PR DESCRIPTION
Part of influxdata/quartz#6725

Change the `allowance` payload to return an enum value for what particular upgrade is available rather than just a boolean flag indicating that there is an upgrade available.

This endpoint is not yet in use, so there was no need to change this in an incremental, backwards-compatible way.