### PR TITLE
docs: cleanup org and orgID params in OSS and Cloud.

### DIFF
--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -3556,7 +3556,7 @@ paths:
 
             #### InfluxDB OSS
 
-            - Returns this error if an incorrect value is passed for `org` or `orgID`.
+            - Returns this error if an incorrect value is passed in the `org` parameter or `orgID` parameter.
           content:
             application/json:
               schema:

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -1616,7 +1616,7 @@
         "summary": "Write data",
         "description": "Writes data to a bucket.\n\nUse this endpoint to send data in [line protocol]({{% INFLUXDB_DOCS_URL %}}/reference/syntax/line-protocol/) format to InfluxDB.\n\n#### InfluxDB Cloud\n\n- Does the following when you send a write request:\n\n  1. Validates the request and queues the write.\n  2. If queued, responds with _success_ (HTTP `2xx` status code); _error_ otherwise.\n  3. Handles the delete asynchronously and reaches eventual consistency.\n\n  To ensure that InfluxDB Cloud handles writes and deletes in the order you request them,\n  wait for a success response (HTTP `2xx` status code) before you send the next request.\n\n  Because writes and deletes are asynchronous, your change might not yet be readable\n  when you receive the response.\n\n#### InfluxDB OSS\n\n- Validates the request and handles the write synchronously.\n- If all points were written successfully, responds with HTTP `2xx` status code;\n  otherwise, returns the first line that failed.\n\n#### Required permissions\n\n- `write-buckets` or `write-bucket BUCKET_ID`.\n\n *`BUCKET_ID`* is the ID of the destination bucket.\n\n#### Rate limits (with InfluxDB Cloud)\n\n`write` rate limits apply.\nFor more information, see [limits and adjustable quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/).\n\n#### Related guides\n\n- [Write data with the InfluxDB API]({{% INFLUXDB_DOCS_URL %}}/write-data/developer-tools/api)\n- [Optimize writes to InfluxDB]({{% INFLUXDB_DOCS_URL %}}/write-data/best-practices/optimize-writes/)\n- [Troubleshoot issues writing data]({{% INFLUXDB_DOCS_URL %}}/write-data/troubleshoot/)\n",
         "requestBody": {
-          "description": "Data in line protocol format.\n\nTo send compressed data, do the following:\n\n  1. Use [GZIP](https://www.gzip.org/) to compress the line protocol data.\n  2. In your request, send the compressed data and the\n     `Content-Encoding: gzip` header.\n\n#### Related guides\n\n- [Best practices for optimizing writes]({{% INFLUXDB_DOCS_URL %}}/write-data/best-practices/optimize-writes/)\n",
+          "description": "In the request body, provide data in [line protocol format]({{% INFLUXDB_DOCS_URL %}}/reference/syntax/line-protocol/).\n\nTo send compressed data, do the following:\n\n  1. Use [GZIP](https://www.gzip.org/) to compress the line protocol data.\n  2. In your request, send the compressed data and the\n     `Content-Encoding: gzip` header.\n\n#### Related guides\n\n- [Best practices for optimizing writes]({{% INFLUXDB_DOCS_URL %}}/write-data/best-practices/optimize-writes/)\n",
           "required": true,
           "content": {
             "text/plain": {
@@ -1689,7 +1689,7 @@
           {
             "in": "query",
             "name": "org",
-            "description": "The destination organization for writes.\nInfluxDB writes all points in the batch to this organization.\nIf you pass both `orgID` and `org`, they must both be valid.\n\n#### InfluxDB Cloud\n\n- Doesn't require `org` or `orgID`.\n- Writes to the bucket in the organization associated with the authorization (API token).\n\n#### InfluxDB OSS\n\n- Requires either `org` or `orgID`.\n- InfluxDB writes all points in the batch to this organization.\n",
+            "description": "An organization name or ID.\n\n#### InfluxDB Cloud\n\n- Doesn't use the `org` parameter or `orgID` parameter.\n- Writes data to the bucket in the organization\n  associated with the authorization (API token).\n\n#### InfluxDB OSS\n\n- Requires either the `org` parameter or the `orgID` parameter.\n- If you pass both `orgID` and `org`, they must both be valid.\n- Writes data to the bucket in the specified organization.\n",
             "required": true,
             "schema": {
               "type": "string",
@@ -1699,7 +1699,7 @@
           {
             "in": "query",
             "name": "orgID",
-            "description": "The ID of the destination organization for writes.\nIf you pass both `orgID` and `org`, they must both be valid.\n\n#### InfluxDB Cloud\n\n- Doesn't require `org` or `orgID`.\n- Writes to the bucket in the organization associated with the authorization (API token).\n\n\n#### InfluxDB OSS\n\n- Requires either `org` or `orgID`.\n- InfluxDB writes all points in the batch to this organization.\n",
+            "description": "An organization ID.\n\n#### InfluxDB Cloud\n\n- Doesn't use the `org` parameter or `orgID` parameter.\n- Writes data to the bucket in the organization\n  associated with the authorization (API token).\n\n#### InfluxDB OSS\n\n- Requires either the `org` parameter or the `orgID` parameter.\n- If you pass both `orgID` and `org`, they must both be valid.\n- Writes data to the bucket in the specified organization.\n",
             "schema": {
               "type": "string"
             }
@@ -1707,7 +1707,7 @@
           {
             "in": "query",
             "name": "bucket",
-            "description": "The destination bucket for writes.\nInfluxDB writes all points in the batch to this bucket.\n",
+            "description": "A bucket name or ID.\nInfluxDB writes all points in the batch to the specified bucket.\n",
             "required": true,
             "schema": {
               "type": "string",
@@ -1728,7 +1728,7 @@
             "description": "Success.\n\n#### InfluxDB Cloud\n\n- Validated and queued the request.\n- Handles the write asynchronously - the write might not have completed yet.\n\n#### InfluxDB OSS\n\n- Successfully wrote all points in the batch.\n\n#### Related guides\n\n- [How to check for write errors]({{% INFLUXDB_DOCS_URL %}}/write-data/troubleshoot/)\n"
           },
           "400": {
-            "description": "Bad request. The response body contains detail about the error.\n\nInfluxDB returns this error if the line protocol data in the request is malformed.\nThe response body contains the first malformed line in the data, and indicates what was expected.\nFor partial writes, the number of points written and the number of points rejected are also included.\nFor more information, check the `rejected_points` measurement in your `_monitoring` bucket.\n\n#### InfluxDB Cloud\n\n- Returns this error for bucket schema conflicts.\n\n#### InfluxDB OSS\n\n- Returns this error if `org` or `orgID` doesn't match an organization.\n",
+            "description": "Bad request. The response body contains detail about the error.\n\nInfluxDB returns this error if the line protocol data in the request is malformed.\nThe response body contains the first malformed line in the data, and indicates what was expected.\nFor partial writes, the number of points written and the number of points rejected are also included.\nFor more information, check the `rejected_points` measurement in your `_monitoring` bucket.\n\n#### InfluxDB Cloud\n\n- Returns this error for bucket schema conflicts.\n\n#### InfluxDB OSS\n\n- Returns this error if the `org` parameter or `orgID` parameter doesn't match an organization.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -1853,7 +1853,7 @@
           {
             "in": "query",
             "name": "org",
-            "description": "The organization to delete data from.\nIf you pass both `orgID` and `org`, they must both be valid.\n\n#### InfluxDB Cloud\n\n- Doesn't require `org` or `orgID`.\n- Deletes data from the bucket in the organization associated with the authorization (API token).\n\n#### InfluxDB OSS\n\n- Requires either `org` or `orgID`.\n",
+            "description": "An organization name or ID.\n\n#### InfluxDB Cloud\n\n- Doesn't use the `org` parameter or `orgID` parameter.\n- Deletes data from the bucket in the organization\n  associated with the authorization (API token).\n\n#### InfluxDB OSS\n\n- Requires either the `org` parameter or the `orgID` parameter.\n- Deletes data from the bucket in the specified organization.\n- If you pass both `orgID` and `org`, they must both be valid.\n",
             "schema": {
               "type": "string",
               "description": "The organization name or ID."
@@ -1862,7 +1862,7 @@
           {
             "in": "query",
             "name": "bucket",
-            "description": "The name or ID of the bucket to delete data from.\nIf you pass both `bucket` and `bucketID`, `bucketID` takes precedence.\n",
+            "description": "A bucket name or ID.\nSpecifies the bucket to delete data from.\nIf you pass both `bucket` and `bucketID`, `bucketID` takes precedence.\n",
             "schema": {
               "type": "string",
               "description": "The bucket name or ID."
@@ -1871,7 +1871,7 @@
           {
             "in": "query",
             "name": "orgID",
-            "description": "The ID of the organization to delete data from.\nIf you pass both `orgID` and `org`, they must both be valid.\n\n#### InfluxDB Cloud\n\n- Doesn't require `org` or `orgID`.\n- Deletes data from the bucket in the organization associated with the authorization (API token).\n\n#### InfluxDB OSS\n\n- Requires either `org` or `orgID`.\n",
+            "description": "An organization ID.\n\n#### InfluxDB Cloud\n\n- Doesn't use the `org` parameter or `orgID` parameter.\n- Deletes data from the bucket in the organization\n  associated with the authorization (API token).\n\n#### InfluxDB OSS\n\n- Requires either the `org` parameter or the `orgID` parameter.\n- Deletes data from the bucket in the specified organization.\n- If you pass both `orgID` and `org`, they must both be valid.\n",
             "schema": {
               "type": "string",
               "description": "The organization ID."
@@ -1880,7 +1880,7 @@
           {
             "in": "query",
             "name": "bucketID",
-            "description": "The ID of the bucket to delete data from.\nIf you pass both `bucket` and `bucketID`, `bucketID` takes precedence.\n",
+            "description": "A bucket ID.\nSpecifies the bucket to delete data from.\nIf you pass both `bucket` and `bucketID`, `bucketID` takes precedence.\n",
             "schema": {
               "type": "string",
               "description": "The bucket ID."
@@ -1892,7 +1892,7 @@
             "description": "Success.\n\n#### InfluxDB Cloud\n\n- Validated and queued the request.\n- Handles the delete asynchronously - the deletion might not have completed yet.\n\nAn HTTP `2xx` status code acknowledges that the write or delete is queued.\nTo ensure that InfluxDB Cloud handles writes and deletes in the order you request them,\nwait for a response before you send the next request.\n\nBecause writes are asynchronous, data might not yet be written\nwhen you receive the response.\n\n#### InfluxDB OSS\n\n- Deleted the data.\n"
           },
           "400": {
-            "description": "Bad request.\nThe response body contains detail about the error.\n\n#### InfluxDB OSS\n\n- Returns this error if `org` or `orgID` doesn't match an organization.\n",
+            "description": "Bad request.\nThe response body contains detail about the error.\n\n#### InfluxDB OSS\n\n- Returns this error if the `org` parameter or `orgID` parameter doesn't match an organization.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -4998,7 +4998,7 @@
           {
             "in": "query",
             "name": "org",
-            "description": "The name or ID of the organization executing the query.\n\n#### InfluxDB Cloud\n\n- Doesn't use `org` or `orgID`.\n- Queries the bucket in the organization associated with the authorization (API token).\n\n#### InfluxDB OSS\n\n- Requires either `org` or `orgID`.\n",
+            "description": "An organization name or ID.\n\n#### InfluxDB Cloud\n\n- Doesn't use the `org` parameter or `orgID` parameter.\n- Queries the bucket in the organization associated with the authorization (API token).\n\n#### InfluxDB OSS\n\n- Requires either the `org` parameter or `orgID` parameter.\n- Queries the bucket in the specified organization.\n",
             "schema": {
               "type": "string"
             }
@@ -5006,7 +5006,7 @@
           {
             "in": "query",
             "name": "orgID",
-            "description": "The ID of the organization executing the query.\n\n#### InfluxDB Cloud\n\n- Doesn't use `org` or `orgID`.\n- Queries the bucket in the organization associated with the authorization (API token).\n\n#### InfluxDB OSS\n\n- Requires either `org` or `orgID`.\n",
+            "description": "An organization ID.\n\n#### InfluxDB Cloud\n\n- Doesn't use the `org` parameter or `orgID` parameter.\n- Queries the bucket in the organization associated with the authorization (API token).\n\n#### InfluxDB OSS\n\n- Requires either the `org` parameter or `orgID` parameter.\n- Queries the bucket in the specified organization.\n",
             "schema": {
               "type": "string"
             }
@@ -5069,7 +5069,7 @@
             }
           },
           "400": {
-            "description": "Bad request.\nThe response body contains detail about the error.\n\n#### InfluxDB OSS\n\n- Returns this error if `org` or `orgID` doesn't match an organization.\n",
+            "description": "Bad request.\nThe response body contains detail about the error.\n\n#### InfluxDB OSS\n\n- Returns this error if the `org` parameter or `orgID` parameter doesn't match an organization.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -5121,7 +5121,7 @@
           "Buckets"
         ],
         "summary": "List buckets",
-        "description": "Retrieves a list of [buckets]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#bucket).\n\nInfluxDB retrieves buckets owned by the\n[organization]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#organization)\nassociated with the authorization\n([API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token)).\nTo limit which buckets are returned, pass query parameters in your request.\nIf no query parameters are passed, InfluxDB returns all buckets up to the\ndefault `limit`.\n\n#### InfluxDB Cloud\n\n- Doesn't use `org` or `orgID` parameters.\n\n#### InfluxDB OSS\n\n- If you use an _[operator token]({{% INFLUXDB_DOCS_URL %}}/security/tokens/#operator-token)_\n  to authenticate your request, InfluxDB retrieves resources for _all\n  organizations_ in the instance.\n  To retrieve resources for only a specific organization, use the\n  `org` parameter or the `orgID` parameter to specify the organization.\n\n#### Required permissions\n\n| Action                    | Permission required |\n|:--------------------------|:--------------------|\n| Retrieve _user buckets_   | `read-buckets`      |\n| Retrieve [_system buckets_]({{% INFLUXDB_DOCS_URL %}}/reference/internals/system-buckets/) | `read-orgs`         |\n\n#### Related Guides\n\n- [Manage buckets]({{% INFLUXDB_DOCS_URL %}}/organizations/buckets/)\n",
+        "description": "Retrieves a list of [buckets]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#bucket).\n\nInfluxDB retrieves buckets owned by the\n[organization]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#organization)\nassociated with the authorization\n([API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token)).\nTo limit which buckets are returned, pass query parameters in your request.\nIf no query parameters are passed, InfluxDB returns all buckets up to the\ndefault `limit`.\n\n#### InfluxDB OSS\n\n- If you use an _[operator token]({{% INFLUXDB_DOCS_URL %}}/security/tokens/#operator-token)_\n  to authenticate your request, InfluxDB retrieves resources for _all\n  organizations_ in the instance.\n  To retrieve resources for only a specific organization, use the\n  `org` parameter or the `orgID` parameter to specify the organization.\n\n#### Required permissions\n\n| Action                    | Permission required |\n|:--------------------------|:--------------------|\n| Retrieve _user buckets_   | `read-buckets`      |\n| Retrieve [_system buckets_]({{% INFLUXDB_DOCS_URL %}}/reference/internals/system-buckets/) | `read-orgs`         |\n\n#### Related Guides\n\n- [Manage buckets]({{% INFLUXDB_DOCS_URL %}}/organizations/buckets/)\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -5138,7 +5138,7 @@
           {
             "in": "query",
             "name": "org",
-            "description": "An organization name.\nOnly returns resources owned by the specified organization.\n\n#### InfluxDB Cloud\n\n- Doesn't use `org` or `orgID` parameters.\n",
+            "description": "An organization name.\n\n#### InfluxDB Cloud\n\n- Doesn't use the `org` parameter or `orgID` parameter.\n- Lists buckets for the organization associated with the authorization (API token).\n\n#### InfluxDB OSS\n\n- Lists buckets for the specified organization.\n",
             "schema": {
               "type": "string"
             }
@@ -5146,7 +5146,7 @@
           {
             "in": "query",
             "name": "orgID",
-            "description": "An organization ID.\nOnly returns resources owned by the specified organization.\n\n#### InfluxDB Cloud\n\n- Doesn't use `org` or `orgID` parameters.\n",
+            "description": "An organization ID.\n\n#### InfluxDB Cloud\n\n- Doesn't use the `org` parameter or `orgID` parameter.\n- Lists buckets for the organization associated with the authorization (API token).\n\n#### InfluxDB OSS\n\n- Requires either the `org` parameter or `orgID` parameter.\n- Lists buckets for the specified organization.\n",
             "schema": {
               "type": "string"
             }
@@ -7621,7 +7621,7 @@
             }
           },
           "400": {
-            "description": "Bad request.\nThe response body contains detail about the error.\n\n#### InfluxDB OSS\n\n- Returns this error if an incorrect value is passed for `org` or `orgID`.\n",
+            "description": "Bad request.\nThe response body contains detail about the error.\n\n#### InfluxDB OSS\n\n- Returns this error if an incorrect value is passed in the `org` parameter or `orgID` parameter.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -21784,7 +21784,7 @@
         }
       },
       "BadRequestError": {
-        "description": "Bad request.\nThe response body contains detail about the error.\n\n#### InfluxDB OSS\n\n- Returns this error if an incorrect value is passed for `org` or `orgID`.\n",
+        "description": "Bad request.\nThe response body contains detail about the error.\n\n#### InfluxDB OSS\n\n- Returns this error if an incorrect value is passed in the `org` parameter or `orgID` parameter.\n",
         "content": {
           "application/json": {
             "schema": {

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -1332,7 +1332,7 @@ paths:
         - [Troubleshoot issues writing data](https://docs.influxdata.com/influxdb/cloud/write-data/troubleshoot/)
       requestBody:
         description: |
-          Data in line protocol format.
+          In the request body, provide data in [line protocol format](https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol/).
 
           To send compressed data, do the following:
 
@@ -1420,19 +1420,19 @@ paths:
         - in: query
           name: org
           description: |
-            The destination organization for writes.
-            InfluxDB writes all points in the batch to this organization.
-            If you pass both `orgID` and `org`, they must both be valid.
+            An organization name or ID.
 
             #### InfluxDB Cloud
 
-            - Doesn't require `org` or `orgID`.
-            - Writes to the bucket in the organization associated with the authorization (API token).
+            - Doesn't use the `org` parameter or `orgID` parameter.
+            - Writes data to the bucket in the organization
+              associated with the authorization (API token).
 
             #### InfluxDB OSS
 
-            - Requires either `org` or `orgID`.
-            - InfluxDB writes all points in the batch to this organization.
+            - Requires either the `org` parameter or the `orgID` parameter.
+            - If you pass both `orgID` and `org`, they must both be valid.
+            - Writes data to the bucket in the specified organization.
           required: true
           schema:
             type: string
@@ -1440,26 +1440,26 @@ paths:
         - in: query
           name: orgID
           description: |
-            The ID of the destination organization for writes.
-            If you pass both `orgID` and `org`, they must both be valid.
+            An organization ID.
 
             #### InfluxDB Cloud
 
-            - Doesn't require `org` or `orgID`.
-            - Writes to the bucket in the organization associated with the authorization (API token).
-
+            - Doesn't use the `org` parameter or `orgID` parameter.
+            - Writes data to the bucket in the organization
+              associated with the authorization (API token).
 
             #### InfluxDB OSS
 
-            - Requires either `org` or `orgID`.
-            - InfluxDB writes all points in the batch to this organization.
+            - Requires either the `org` parameter or the `orgID` parameter.
+            - If you pass both `orgID` and `org`, they must both be valid.
+            - Writes data to the bucket in the specified organization.
           schema:
             type: string
         - in: query
           name: bucket
           description: |
-            The destination bucket for writes.
-            InfluxDB writes all points in the batch to this bucket.
+            A bucket name or ID.
+            InfluxDB writes all points in the batch to the specified bucket.
           required: true
           schema:
             type: string
@@ -1501,7 +1501,7 @@ paths:
 
             #### InfluxDB OSS
 
-            - Returns this error if `org` or `orgID` doesn't match an organization.
+            - Returns this error if the `org` parameter or `orgID` parameter doesn't match an organization.
           content:
             application/json:
               schema:
@@ -1682,24 +1682,27 @@ paths:
         - in: query
           name: org
           description: |
-            The organization to delete data from.
-            If you pass both `orgID` and `org`, they must both be valid.
+            An organization name or ID.
 
             #### InfluxDB Cloud
 
-            - Doesn't require `org` or `orgID`.
-            - Deletes data from the bucket in the organization associated with the authorization (API token).
+            - Doesn't use the `org` parameter or `orgID` parameter.
+            - Deletes data from the bucket in the organization
+              associated with the authorization (API token).
 
             #### InfluxDB OSS
 
-            - Requires either `org` or `orgID`.
+            - Requires either the `org` parameter or the `orgID` parameter.
+            - Deletes data from the bucket in the specified organization.
+            - If you pass both `orgID` and `org`, they must both be valid.
           schema:
             type: string
             description: The organization name or ID.
         - in: query
           name: bucket
           description: |
-            The name or ID of the bucket to delete data from.
+            A bucket name or ID.
+            Specifies the bucket to delete data from.
             If you pass both `bucket` and `bucketID`, `bucketID` takes precedence.
           schema:
             type: string
@@ -1707,24 +1710,27 @@ paths:
         - in: query
           name: orgID
           description: |
-            The ID of the organization to delete data from.
-            If you pass both `orgID` and `org`, they must both be valid.
+            An organization ID.
 
             #### InfluxDB Cloud
 
-            - Doesn't require `org` or `orgID`.
-            - Deletes data from the bucket in the organization associated with the authorization (API token).
+            - Doesn't use the `org` parameter or `orgID` parameter.
+            - Deletes data from the bucket in the organization
+              associated with the authorization (API token).
 
             #### InfluxDB OSS
 
-            - Requires either `org` or `orgID`.
+            - Requires either the `org` parameter or the `orgID` parameter.
+            - Deletes data from the bucket in the specified organization.
+            - If you pass both `orgID` and `org`, they must both be valid.
           schema:
             type: string
             description: The organization ID.
         - in: query
           name: bucketID
           description: |
-            The ID of the bucket to delete data from.
+            A bucket ID.
+            Specifies the bucket to delete data from.
             If you pass both `bucket` and `bucketID`, `bucketID` takes precedence.
           schema:
             type: string
@@ -1756,7 +1762,7 @@ paths:
 
             #### InfluxDB OSS
 
-            - Returns this error if `org` or `orgID` doesn't match an organization.
+            - Returns this error if the `org` parameter or `orgID` parameter doesn't match an organization.
           content:
             application/json:
               schema:
@@ -3920,31 +3926,33 @@ paths:
         - in: query
           name: org
           description: |
-            The name or ID of the organization executing the query.
+            An organization name or ID.
 
             #### InfluxDB Cloud
 
-            - Doesn't use `org` or `orgID`.
+            - Doesn't use the `org` parameter or `orgID` parameter.
             - Queries the bucket in the organization associated with the authorization (API token).
 
             #### InfluxDB OSS
 
-            - Requires either `org` or `orgID`.
+            - Requires either the `org` parameter or `orgID` parameter.
+            - Queries the bucket in the specified organization.
           schema:
             type: string
         - in: query
           name: orgID
           description: |
-            The ID of the organization executing the query.
+            An organization ID.
 
             #### InfluxDB Cloud
 
-            - Doesn't use `org` or `orgID`.
+            - Doesn't use the `org` parameter or `orgID` parameter.
             - Queries the bucket in the organization associated with the authorization (API token).
 
             #### InfluxDB OSS
 
-            - Requires either `org` or `orgID`.
+            - Requires either the `org` parameter or `orgID` parameter.
+            - Queries the bucket in the specified organization.
           schema:
             type: string
       x-codeSamples:
@@ -4006,7 +4014,7 @@ paths:
 
             #### InfluxDB OSS
 
-            - Returns this error if `org` or `orgID` doesn't match an organization.
+            - Returns this error if the `org` parameter or `orgID` parameter doesn't match an organization.
           content:
             application/json:
               schema:
@@ -4059,10 +4067,6 @@ paths:
         If no query parameters are passed, InfluxDB returns all buckets up to the
         default `limit`.
 
-        #### InfluxDB Cloud
-
-        - Doesn't use `org` or `orgID` parameters.
-
         #### InfluxDB OSS
 
         - If you use an _[operator token](https://docs.influxdata.com/influxdb/cloud/security/tokens/#operator-token)_
@@ -4090,22 +4094,31 @@ paths:
           name: org
           description: |
             An organization name.
-            Only returns resources owned by the specified organization.
 
             #### InfluxDB Cloud
 
-            - Doesn't use `org` or `orgID` parameters.
+            - Doesn't use the `org` parameter or `orgID` parameter.
+            - Lists buckets for the organization associated with the authorization (API token).
+
+            #### InfluxDB OSS
+
+            - Lists buckets for the specified organization.
           schema:
             type: string
         - in: query
           name: orgID
           description: |
             An organization ID.
-            Only returns resources owned by the specified organization.
 
             #### InfluxDB Cloud
 
-            - Doesn't use `org` or `orgID` parameters.
+            - Doesn't use the `org` parameter or `orgID` parameter.
+            - Lists buckets for the organization associated with the authorization (API token).
+
+            #### InfluxDB OSS
+
+            - Requires either the `org` parameter or `orgID` parameter.
+            - Lists buckets for the specified organization.
           schema:
             type: string
         - in: query
@@ -6332,7 +6345,7 @@ paths:
 
             #### InfluxDB OSS
 
-            - Returns this error if an incorrect value is passed for `org` or `orgID`.
+            - Returns this error if an incorrect value is passed in the `org` parameter or `orgID` parameter.
           content:
             application/json:
               schema:
@@ -17001,7 +17014,7 @@ components:
 
         #### InfluxDB OSS
 
-        - Returns this error if an incorrect value is passed for `org` or `orgID`.
+        - Returns this error if an incorrect value is passed in the `org` parameter or `orgID` parameter.
       content:
         application/json:
           schema:

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -1052,7 +1052,7 @@ paths:
         - [Troubleshoot issues writing data](https://docs.influxdata.com/influxdb/v2.3/write-data/troubleshoot/)
       requestBody:
         description: |
-          Data in line protocol format.
+          In the request body, provide data in [line protocol format](https://docs.influxdata.com/influxdb/v2.3/reference/syntax/line-protocol/).
 
           To send compressed data, do the following:
 
@@ -1140,19 +1140,19 @@ paths:
         - in: query
           name: org
           description: |
-            The destination organization for writes.
-            InfluxDB writes all points in the batch to this organization.
-            If you pass both `orgID` and `org`, they must both be valid.
+            An organization name or ID.
 
             #### InfluxDB Cloud
 
-            - Doesn't require `org` or `orgID`.
-            - Writes to the bucket in the organization associated with the authorization (API token).
+            - Doesn't use the `org` parameter or `orgID` parameter.
+            - Writes data to the bucket in the organization
+              associated with the authorization (API token).
 
             #### InfluxDB OSS
 
-            - Requires either `org` or `orgID`.
-            - InfluxDB writes all points in the batch to this organization.
+            - Requires either the `org` parameter or the `orgID` parameter.
+            - If you pass both `orgID` and `org`, they must both be valid.
+            - Writes data to the bucket in the specified organization.
           required: true
           schema:
             type: string
@@ -1160,26 +1160,26 @@ paths:
         - in: query
           name: orgID
           description: |
-            The ID of the destination organization for writes.
-            If you pass both `orgID` and `org`, they must both be valid.
+            An organization ID.
 
             #### InfluxDB Cloud
 
-            - Doesn't require `org` or `orgID`.
-            - Writes to the bucket in the organization associated with the authorization (API token).
-
+            - Doesn't use the `org` parameter or `orgID` parameter.
+            - Writes data to the bucket in the organization
+              associated with the authorization (API token).
 
             #### InfluxDB OSS
 
-            - Requires either `org` or `orgID`.
-            - InfluxDB writes all points in the batch to this organization.
+            - Requires either the `org` parameter or the `orgID` parameter.
+            - If you pass both `orgID` and `org`, they must both be valid.
+            - Writes data to the bucket in the specified organization.
           schema:
             type: string
         - in: query
           name: bucket
           description: |
-            The destination bucket for writes.
-            InfluxDB writes all points in the batch to this bucket.
+            A bucket name or ID.
+            InfluxDB writes all points in the batch to the specified bucket.
           required: true
           schema:
             type: string
@@ -1221,7 +1221,7 @@ paths:
 
             #### InfluxDB OSS
 
-            - Returns this error if `org` or `orgID` doesn't match an organization.
+            - Returns this error if the `org` parameter or `orgID` parameter doesn't match an organization.
           content:
             application/json:
               schema:
@@ -1402,24 +1402,27 @@ paths:
         - in: query
           name: org
           description: |
-            The organization to delete data from.
-            If you pass both `orgID` and `org`, they must both be valid.
+            An organization name or ID.
 
             #### InfluxDB Cloud
 
-            - Doesn't require `org` or `orgID`.
-            - Deletes data from the bucket in the organization associated with the authorization (API token).
+            - Doesn't use the `org` parameter or `orgID` parameter.
+            - Deletes data from the bucket in the organization
+              associated with the authorization (API token).
 
             #### InfluxDB OSS
 
-            - Requires either `org` or `orgID`.
+            - Requires either the `org` parameter or the `orgID` parameter.
+            - Deletes data from the bucket in the specified organization.
+            - If you pass both `orgID` and `org`, they must both be valid.
           schema:
             type: string
             description: The organization name or ID.
         - in: query
           name: bucket
           description: |
-            The name or ID of the bucket to delete data from.
+            A bucket name or ID.
+            Specifies the bucket to delete data from.
             If you pass both `bucket` and `bucketID`, `bucketID` takes precedence.
           schema:
             type: string
@@ -1427,24 +1430,27 @@ paths:
         - in: query
           name: orgID
           description: |
-            The ID of the organization to delete data from.
-            If you pass both `orgID` and `org`, they must both be valid.
+            An organization ID.
 
             #### InfluxDB Cloud
 
-            - Doesn't require `org` or `orgID`.
-            - Deletes data from the bucket in the organization associated with the authorization (API token).
+            - Doesn't use the `org` parameter or `orgID` parameter.
+            - Deletes data from the bucket in the organization
+              associated with the authorization (API token).
 
             #### InfluxDB OSS
 
-            - Requires either `org` or `orgID`.
+            - Requires either the `org` parameter or the `orgID` parameter.
+            - Deletes data from the bucket in the specified organization.
+            - If you pass both `orgID` and `org`, they must both be valid.
           schema:
             type: string
             description: The organization ID.
         - in: query
           name: bucketID
           description: |
-            The ID of the bucket to delete data from.
+            A bucket ID.
+            Specifies the bucket to delete data from.
             If you pass both `bucket` and `bucketID`, `bucketID` takes precedence.
           schema:
             type: string
@@ -1476,7 +1482,7 @@ paths:
 
             #### InfluxDB OSS
 
-            - Returns this error if `org` or `orgID` doesn't match an organization.
+            - Returns this error if the `org` parameter or `orgID` parameter doesn't match an organization.
           content:
             application/json:
               schema:
@@ -3640,31 +3646,33 @@ paths:
         - in: query
           name: org
           description: |
-            The name or ID of the organization executing the query.
+            An organization name or ID.
 
             #### InfluxDB Cloud
 
-            - Doesn't use `org` or `orgID`.
+            - Doesn't use the `org` parameter or `orgID` parameter.
             - Queries the bucket in the organization associated with the authorization (API token).
 
             #### InfluxDB OSS
 
-            - Requires either `org` or `orgID`.
+            - Requires either the `org` parameter or `orgID` parameter.
+            - Queries the bucket in the specified organization.
           schema:
             type: string
         - in: query
           name: orgID
           description: |
-            The ID of the organization executing the query.
+            An organization ID.
 
             #### InfluxDB Cloud
 
-            - Doesn't use `org` or `orgID`.
+            - Doesn't use the `org` parameter or `orgID` parameter.
             - Queries the bucket in the organization associated with the authorization (API token).
 
             #### InfluxDB OSS
 
-            - Requires either `org` or `orgID`.
+            - Requires either the `org` parameter or `orgID` parameter.
+            - Queries the bucket in the specified organization.
           schema:
             type: string
       x-codeSamples:
@@ -3726,7 +3734,7 @@ paths:
 
             #### InfluxDB OSS
 
-            - Returns this error if `org` or `orgID` doesn't match an organization.
+            - Returns this error if the `org` parameter or `orgID` parameter doesn't match an organization.
           content:
             application/json:
               schema:
@@ -3779,10 +3787,6 @@ paths:
         If no query parameters are passed, InfluxDB returns all buckets up to the
         default `limit`.
 
-        #### InfluxDB Cloud
-
-        - Doesn't use `org` or `orgID` parameters.
-
         #### InfluxDB OSS
 
         - If you use an _[operator token](https://docs.influxdata.com/influxdb/v2.3/security/tokens/#operator-token)_
@@ -3810,22 +3814,31 @@ paths:
           name: org
           description: |
             An organization name.
-            Only returns resources owned by the specified organization.
 
             #### InfluxDB Cloud
 
-            - Doesn't use `org` or `orgID` parameters.
+            - Doesn't use the `org` parameter or `orgID` parameter.
+            - Lists buckets for the organization associated with the authorization (API token).
+
+            #### InfluxDB OSS
+
+            - Lists buckets for the specified organization.
           schema:
             type: string
         - in: query
           name: orgID
           description: |
             An organization ID.
-            Only returns resources owned by the specified organization.
 
             #### InfluxDB Cloud
 
-            - Doesn't use `org` or `orgID` parameters.
+            - Doesn't use the `org` parameter or `orgID` parameter.
+            - Lists buckets for the organization associated with the authorization (API token).
+
+            #### InfluxDB OSS
+
+            - Requires either the `org` parameter or `orgID` parameter.
+            - Lists buckets for the specified organization.
           schema:
             type: string
         - in: query
@@ -6052,7 +6065,7 @@ paths:
 
             #### InfluxDB OSS
 
-            - Returns this error if an incorrect value is passed for `org` or `orgID`.
+            - Returns this error if an incorrect value is passed in the `org` parameter or `orgID` parameter.
           content:
             application/json:
               schema:
@@ -14161,7 +14174,7 @@ components:
 
         #### InfluxDB OSS
 
-        - Returns this error if an incorrect value is passed for `org` or `orgID`.
+        - Returns this error if an incorrect value is passed in the `org` parameter or `orgID` parameter.
       content:
         application/json:
           schema:

--- a/contracts/invocable-scripts.yml
+++ b/contracts/invocable-scripts.yml
@@ -611,7 +611,7 @@ components:
 
         #### InfluxDB OSS
 
-        - Returns this error if an incorrect value is passed for `org` or `orgID`.
+        - Returns this error if an incorrect value is passed in the `org` parameter or `orgID` parameter.
       content:
         application/json:
           schema:

--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -5252,7 +5252,7 @@ paths:
 
             #### InfluxDB OSS
 
-            - Returns this error if an incorrect value is passed for `org` or `orgID`.
+            - Returns this error if an incorrect value is passed in the `org` parameter or `orgID` parameter.
           content:
             application/json:
               schema:

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -1617,7 +1617,7 @@
         "summary": "Write data",
         "description": "Writes data to a bucket.\n\nUse this endpoint to send data in [line protocol]({{% INFLUXDB_DOCS_URL %}}/reference/syntax/line-protocol/) format to InfluxDB.\n\n#### InfluxDB Cloud\n\n- Does the following when you send a write request:\n\n  1. Validates the request and queues the write.\n  2. If queued, responds with _success_ (HTTP `2xx` status code); _error_ otherwise.\n  3. Handles the delete asynchronously and reaches eventual consistency.\n\n  To ensure that InfluxDB Cloud handles writes and deletes in the order you request them,\n  wait for a success response (HTTP `2xx` status code) before you send the next request.\n\n  Because writes and deletes are asynchronous, your change might not yet be readable\n  when you receive the response.\n\n#### InfluxDB OSS\n\n- Validates the request and handles the write synchronously.\n- If all points were written successfully, responds with HTTP `2xx` status code;\n  otherwise, returns the first line that failed.\n\n#### Required permissions\n\n- `write-buckets` or `write-bucket BUCKET_ID`.\n\n *`BUCKET_ID`* is the ID of the destination bucket.\n\n#### Rate limits (with InfluxDB Cloud)\n\n`write` rate limits apply.\nFor more information, see [limits and adjustable quotas](https://docs.influxdata.com/influxdb/cloud/account-management/limits/).\n\n#### Related guides\n\n- [Write data with the InfluxDB API]({{% INFLUXDB_DOCS_URL %}}/write-data/developer-tools/api)\n- [Optimize writes to InfluxDB]({{% INFLUXDB_DOCS_URL %}}/write-data/best-practices/optimize-writes/)\n- [Troubleshoot issues writing data]({{% INFLUXDB_DOCS_URL %}}/write-data/troubleshoot/)\n",
         "requestBody": {
-          "description": "Data in line protocol format.\n\nTo send compressed data, do the following:\n\n  1. Use [GZIP](https://www.gzip.org/) to compress the line protocol data.\n  2. In your request, send the compressed data and the\n     `Content-Encoding: gzip` header.\n\n#### Related guides\n\n- [Best practices for optimizing writes]({{% INFLUXDB_DOCS_URL %}}/write-data/best-practices/optimize-writes/)\n",
+          "description": "In the request body, provide data in [line protocol format]({{% INFLUXDB_DOCS_URL %}}/reference/syntax/line-protocol/).\n\nTo send compressed data, do the following:\n\n  1. Use [GZIP](https://www.gzip.org/) to compress the line protocol data.\n  2. In your request, send the compressed data and the\n     `Content-Encoding: gzip` header.\n\n#### Related guides\n\n- [Best practices for optimizing writes]({{% INFLUXDB_DOCS_URL %}}/write-data/best-practices/optimize-writes/)\n",
           "required": true,
           "content": {
             "text/plain": {
@@ -1690,7 +1690,7 @@
           {
             "in": "query",
             "name": "org",
-            "description": "The destination organization for writes.\nInfluxDB writes all points in the batch to this organization.\nIf you pass both `orgID` and `org`, they must both be valid.\n\n#### InfluxDB Cloud\n\n- Doesn't require `org` or `orgID`.\n- Writes to the bucket in the organization associated with the authorization (API token).\n\n#### InfluxDB OSS\n\n- Requires either `org` or `orgID`.\n- InfluxDB writes all points in the batch to this organization.\n",
+            "description": "An organization name or ID.\n\n#### InfluxDB Cloud\n\n- Doesn't use the `org` parameter or `orgID` parameter.\n- Writes data to the bucket in the organization\n  associated with the authorization (API token).\n\n#### InfluxDB OSS\n\n- Requires either the `org` parameter or the `orgID` parameter.\n- If you pass both `orgID` and `org`, they must both be valid.\n- Writes data to the bucket in the specified organization.\n",
             "required": true,
             "schema": {
               "type": "string",
@@ -1700,7 +1700,7 @@
           {
             "in": "query",
             "name": "orgID",
-            "description": "The ID of the destination organization for writes.\nIf you pass both `orgID` and `org`, they must both be valid.\n\n#### InfluxDB Cloud\n\n- Doesn't require `org` or `orgID`.\n- Writes to the bucket in the organization associated with the authorization (API token).\n\n\n#### InfluxDB OSS\n\n- Requires either `org` or `orgID`.\n- InfluxDB writes all points in the batch to this organization.\n",
+            "description": "An organization ID.\n\n#### InfluxDB Cloud\n\n- Doesn't use the `org` parameter or `orgID` parameter.\n- Writes data to the bucket in the organization\n  associated with the authorization (API token).\n\n#### InfluxDB OSS\n\n- Requires either the `org` parameter or the `orgID` parameter.\n- If you pass both `orgID` and `org`, they must both be valid.\n- Writes data to the bucket in the specified organization.\n",
             "schema": {
               "type": "string"
             }
@@ -1708,7 +1708,7 @@
           {
             "in": "query",
             "name": "bucket",
-            "description": "The destination bucket for writes.\nInfluxDB writes all points in the batch to this bucket.\n",
+            "description": "A bucket name or ID.\nInfluxDB writes all points in the batch to the specified bucket.\n",
             "required": true,
             "schema": {
               "type": "string",
@@ -1729,7 +1729,7 @@
             "description": "Success.\n\n#### InfluxDB Cloud\n\n- Validated and queued the request.\n- Handles the write asynchronously - the write might not have completed yet.\n\n#### InfluxDB OSS\n\n- Successfully wrote all points in the batch.\n\n#### Related guides\n\n- [How to check for write errors]({{% INFLUXDB_DOCS_URL %}}/write-data/troubleshoot/)\n"
           },
           "400": {
-            "description": "Bad request. The response body contains detail about the error.\n\nInfluxDB returns this error if the line protocol data in the request is malformed.\nThe response body contains the first malformed line in the data, and indicates what was expected.\nFor partial writes, the number of points written and the number of points rejected are also included.\nFor more information, check the `rejected_points` measurement in your `_monitoring` bucket.\n\n#### InfluxDB Cloud\n\n- Returns this error for bucket schema conflicts.\n\n#### InfluxDB OSS\n\n- Returns this error if `org` or `orgID` doesn't match an organization.\n",
+            "description": "Bad request. The response body contains detail about the error.\n\nInfluxDB returns this error if the line protocol data in the request is malformed.\nThe response body contains the first malformed line in the data, and indicates what was expected.\nFor partial writes, the number of points written and the number of points rejected are also included.\nFor more information, check the `rejected_points` measurement in your `_monitoring` bucket.\n\n#### InfluxDB Cloud\n\n- Returns this error for bucket schema conflicts.\n\n#### InfluxDB OSS\n\n- Returns this error if the `org` parameter or `orgID` parameter doesn't match an organization.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -1854,7 +1854,7 @@
           {
             "in": "query",
             "name": "org",
-            "description": "The organization to delete data from.\nIf you pass both `orgID` and `org`, they must both be valid.\n\n#### InfluxDB Cloud\n\n- Doesn't require `org` or `orgID`.\n- Deletes data from the bucket in the organization associated with the authorization (API token).\n\n#### InfluxDB OSS\n\n- Requires either `org` or `orgID`.\n",
+            "description": "An organization name or ID.\n\n#### InfluxDB Cloud\n\n- Doesn't use the `org` parameter or `orgID` parameter.\n- Deletes data from the bucket in the organization\n  associated with the authorization (API token).\n\n#### InfluxDB OSS\n\n- Requires either the `org` parameter or the `orgID` parameter.\n- Deletes data from the bucket in the specified organization.\n- If you pass both `orgID` and `org`, they must both be valid.\n",
             "schema": {
               "type": "string",
               "description": "The organization name or ID."
@@ -1863,7 +1863,7 @@
           {
             "in": "query",
             "name": "bucket",
-            "description": "The name or ID of the bucket to delete data from.\nIf you pass both `bucket` and `bucketID`, `bucketID` takes precedence.\n",
+            "description": "A bucket name or ID.\nSpecifies the bucket to delete data from.\nIf you pass both `bucket` and `bucketID`, `bucketID` takes precedence.\n",
             "schema": {
               "type": "string",
               "description": "The bucket name or ID."
@@ -1872,7 +1872,7 @@
           {
             "in": "query",
             "name": "orgID",
-            "description": "The ID of the organization to delete data from.\nIf you pass both `orgID` and `org`, they must both be valid.\n\n#### InfluxDB Cloud\n\n- Doesn't require `org` or `orgID`.\n- Deletes data from the bucket in the organization associated with the authorization (API token).\n\n#### InfluxDB OSS\n\n- Requires either `org` or `orgID`.\n",
+            "description": "An organization ID.\n\n#### InfluxDB Cloud\n\n- Doesn't use the `org` parameter or `orgID` parameter.\n- Deletes data from the bucket in the organization\n  associated with the authorization (API token).\n\n#### InfluxDB OSS\n\n- Requires either the `org` parameter or the `orgID` parameter.\n- Deletes data from the bucket in the specified organization.\n- If you pass both `orgID` and `org`, they must both be valid.\n",
             "schema": {
               "type": "string",
               "description": "The organization ID."
@@ -1881,7 +1881,7 @@
           {
             "in": "query",
             "name": "bucketID",
-            "description": "The ID of the bucket to delete data from.\nIf you pass both `bucket` and `bucketID`, `bucketID` takes precedence.\n",
+            "description": "A bucket ID.\nSpecifies the bucket to delete data from.\nIf you pass both `bucket` and `bucketID`, `bucketID` takes precedence.\n",
             "schema": {
               "type": "string",
               "description": "The bucket ID."
@@ -1893,7 +1893,7 @@
             "description": "Success.\n\n#### InfluxDB Cloud\n\n- Validated and queued the request.\n- Handles the delete asynchronously - the deletion might not have completed yet.\n\nAn HTTP `2xx` status code acknowledges that the write or delete is queued.\nTo ensure that InfluxDB Cloud handles writes and deletes in the order you request them,\nwait for a response before you send the next request.\n\nBecause writes are asynchronous, data might not yet be written\nwhen you receive the response.\n\n#### InfluxDB OSS\n\n- Deleted the data.\n"
           },
           "400": {
-            "description": "Bad request.\nThe response body contains detail about the error.\n\n#### InfluxDB OSS\n\n- Returns this error if `org` or `orgID` doesn't match an organization.\n",
+            "description": "Bad request.\nThe response body contains detail about the error.\n\n#### InfluxDB OSS\n\n- Returns this error if the `org` parameter or `orgID` parameter doesn't match an organization.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -4999,7 +4999,7 @@
           {
             "in": "query",
             "name": "org",
-            "description": "The name or ID of the organization executing the query.\n\n#### InfluxDB Cloud\n\n- Doesn't use `org` or `orgID`.\n- Queries the bucket in the organization associated with the authorization (API token).\n\n#### InfluxDB OSS\n\n- Requires either `org` or `orgID`.\n",
+            "description": "An organization name or ID.\n\n#### InfluxDB Cloud\n\n- Doesn't use the `org` parameter or `orgID` parameter.\n- Queries the bucket in the organization associated with the authorization (API token).\n\n#### InfluxDB OSS\n\n- Requires either the `org` parameter or `orgID` parameter.\n- Queries the bucket in the specified organization.\n",
             "schema": {
               "type": "string"
             }
@@ -5007,7 +5007,7 @@
           {
             "in": "query",
             "name": "orgID",
-            "description": "The ID of the organization executing the query.\n\n#### InfluxDB Cloud\n\n- Doesn't use `org` or `orgID`.\n- Queries the bucket in the organization associated with the authorization (API token).\n\n#### InfluxDB OSS\n\n- Requires either `org` or `orgID`.\n",
+            "description": "An organization ID.\n\n#### InfluxDB Cloud\n\n- Doesn't use the `org` parameter or `orgID` parameter.\n- Queries the bucket in the organization associated with the authorization (API token).\n\n#### InfluxDB OSS\n\n- Requires either the `org` parameter or `orgID` parameter.\n- Queries the bucket in the specified organization.\n",
             "schema": {
               "type": "string"
             }
@@ -5070,7 +5070,7 @@
             }
           },
           "400": {
-            "description": "Bad request.\nThe response body contains detail about the error.\n\n#### InfluxDB OSS\n\n- Returns this error if `org` or `orgID` doesn't match an organization.\n",
+            "description": "Bad request.\nThe response body contains detail about the error.\n\n#### InfluxDB OSS\n\n- Returns this error if the `org` parameter or `orgID` parameter doesn't match an organization.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -5122,7 +5122,7 @@
           "Buckets"
         ],
         "summary": "List buckets",
-        "description": "Retrieves a list of [buckets]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#bucket).\n\nInfluxDB retrieves buckets owned by the\n[organization]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#organization)\nassociated with the authorization\n([API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token)).\nTo limit which buckets are returned, pass query parameters in your request.\nIf no query parameters are passed, InfluxDB returns all buckets up to the\ndefault `limit`.\n\n#### InfluxDB Cloud\n\n- Doesn't use `org` or `orgID` parameters.\n\n#### InfluxDB OSS\n\n- If you use an _[operator token]({{% INFLUXDB_DOCS_URL %}}/security/tokens/#operator-token)_\n  to authenticate your request, InfluxDB retrieves resources for _all\n  organizations_ in the instance.\n  To retrieve resources for only a specific organization, use the\n  `org` parameter or the `orgID` parameter to specify the organization.\n\n#### Required permissions\n\n| Action                    | Permission required |\n|:--------------------------|:--------------------|\n| Retrieve _user buckets_   | `read-buckets`      |\n| Retrieve [_system buckets_]({{% INFLUXDB_DOCS_URL %}}/reference/internals/system-buckets/) | `read-orgs`         |\n\n#### Related Guides\n\n- [Manage buckets]({{% INFLUXDB_DOCS_URL %}}/organizations/buckets/)\n",
+        "description": "Retrieves a list of [buckets]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#bucket).\n\nInfluxDB retrieves buckets owned by the\n[organization]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#organization)\nassociated with the authorization\n([API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token)).\nTo limit which buckets are returned, pass query parameters in your request.\nIf no query parameters are passed, InfluxDB returns all buckets up to the\ndefault `limit`.\n\n#### InfluxDB OSS\n\n- If you use an _[operator token]({{% INFLUXDB_DOCS_URL %}}/security/tokens/#operator-token)_\n  to authenticate your request, InfluxDB retrieves resources for _all\n  organizations_ in the instance.\n  To retrieve resources for only a specific organization, use the\n  `org` parameter or the `orgID` parameter to specify the organization.\n\n#### Required permissions\n\n| Action                    | Permission required |\n|:--------------------------|:--------------------|\n| Retrieve _user buckets_   | `read-buckets`      |\n| Retrieve [_system buckets_]({{% INFLUXDB_DOCS_URL %}}/reference/internals/system-buckets/) | `read-orgs`         |\n\n#### Related Guides\n\n- [Manage buckets]({{% INFLUXDB_DOCS_URL %}}/organizations/buckets/)\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -5139,7 +5139,7 @@
           {
             "in": "query",
             "name": "org",
-            "description": "An organization name.\nOnly returns resources owned by the specified organization.\n\n#### InfluxDB Cloud\n\n- Doesn't use `org` or `orgID` parameters.\n",
+            "description": "An organization name.\n\n#### InfluxDB Cloud\n\n- Doesn't use the `org` parameter or `orgID` parameter.\n- Lists buckets for the organization associated with the authorization (API token).\n\n#### InfluxDB OSS\n\n- Lists buckets for the specified organization.\n",
             "schema": {
               "type": "string"
             }
@@ -5147,7 +5147,7 @@
           {
             "in": "query",
             "name": "orgID",
-            "description": "An organization ID.\nOnly returns resources owned by the specified organization.\n\n#### InfluxDB Cloud\n\n- Doesn't use `org` or `orgID` parameters.\n",
+            "description": "An organization ID.\n\n#### InfluxDB Cloud\n\n- Doesn't use the `org` parameter or `orgID` parameter.\n- Lists buckets for the organization associated with the authorization (API token).\n\n#### InfluxDB OSS\n\n- Requires either the `org` parameter or `orgID` parameter.\n- Lists buckets for the specified organization.\n",
             "schema": {
               "type": "string"
             }
@@ -7622,7 +7622,7 @@
             }
           },
           "400": {
-            "description": "Bad request.\nThe response body contains detail about the error.\n\n#### InfluxDB OSS\n\n- Returns this error if an incorrect value is passed for `org` or `orgID`.\n",
+            "description": "Bad request.\nThe response body contains detail about the error.\n\n#### InfluxDB OSS\n\n- Returns this error if an incorrect value is passed in the `org` parameter or `orgID` parameter.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -24428,7 +24428,7 @@
         }
       },
       "BadRequestError": {
-        "description": "Bad request.\nThe response body contains detail about the error.\n\n#### InfluxDB OSS\n\n- Returns this error if an incorrect value is passed for `org` or `orgID`.\n",
+        "description": "Bad request.\nThe response body contains detail about the error.\n\n#### InfluxDB OSS\n\n- Returns this error if an incorrect value is passed in the `org` parameter or `orgID` parameter.\n",
         "content": {
           "application/json": {
             "schema": {

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -1311,7 +1311,7 @@ paths:
         - [Troubleshoot issues writing data](https://docs.influxdata.com/influxdb/v2.3/write-data/troubleshoot/)
       requestBody:
         description: |
-          Data in line protocol format.
+          In the request body, provide data in [line protocol format](https://docs.influxdata.com/influxdb/v2.3/reference/syntax/line-protocol/).
 
           To send compressed data, do the following:
 
@@ -1399,19 +1399,19 @@ paths:
         - in: query
           name: org
           description: |
-            The destination organization for writes.
-            InfluxDB writes all points in the batch to this organization.
-            If you pass both `orgID` and `org`, they must both be valid.
+            An organization name or ID.
 
             #### InfluxDB Cloud
 
-            - Doesn't require `org` or `orgID`.
-            - Writes to the bucket in the organization associated with the authorization (API token).
+            - Doesn't use the `org` parameter or `orgID` parameter.
+            - Writes data to the bucket in the organization
+              associated with the authorization (API token).
 
             #### InfluxDB OSS
 
-            - Requires either `org` or `orgID`.
-            - InfluxDB writes all points in the batch to this organization.
+            - Requires either the `org` parameter or the `orgID` parameter.
+            - If you pass both `orgID` and `org`, they must both be valid.
+            - Writes data to the bucket in the specified organization.
           required: true
           schema:
             type: string
@@ -1419,26 +1419,26 @@ paths:
         - in: query
           name: orgID
           description: |
-            The ID of the destination organization for writes.
-            If you pass both `orgID` and `org`, they must both be valid.
+            An organization ID.
 
             #### InfluxDB Cloud
 
-            - Doesn't require `org` or `orgID`.
-            - Writes to the bucket in the organization associated with the authorization (API token).
-
+            - Doesn't use the `org` parameter or `orgID` parameter.
+            - Writes data to the bucket in the organization
+              associated with the authorization (API token).
 
             #### InfluxDB OSS
 
-            - Requires either `org` or `orgID`.
-            - InfluxDB writes all points in the batch to this organization.
+            - Requires either the `org` parameter or the `orgID` parameter.
+            - If you pass both `orgID` and `org`, they must both be valid.
+            - Writes data to the bucket in the specified organization.
           schema:
             type: string
         - in: query
           name: bucket
           description: |
-            The destination bucket for writes.
-            InfluxDB writes all points in the batch to this bucket.
+            A bucket name or ID.
+            InfluxDB writes all points in the batch to the specified bucket.
           required: true
           schema:
             type: string
@@ -1480,7 +1480,7 @@ paths:
 
             #### InfluxDB OSS
 
-            - Returns this error if `org` or `orgID` doesn't match an organization.
+            - Returns this error if the `org` parameter or `orgID` parameter doesn't match an organization.
           content:
             application/json:
               schema:
@@ -1661,24 +1661,27 @@ paths:
         - in: query
           name: org
           description: |
-            The organization to delete data from.
-            If you pass both `orgID` and `org`, they must both be valid.
+            An organization name or ID.
 
             #### InfluxDB Cloud
 
-            - Doesn't require `org` or `orgID`.
-            - Deletes data from the bucket in the organization associated with the authorization (API token).
+            - Doesn't use the `org` parameter or `orgID` parameter.
+            - Deletes data from the bucket in the organization
+              associated with the authorization (API token).
 
             #### InfluxDB OSS
 
-            - Requires either `org` or `orgID`.
+            - Requires either the `org` parameter or the `orgID` parameter.
+            - Deletes data from the bucket in the specified organization.
+            - If you pass both `orgID` and `org`, they must both be valid.
           schema:
             type: string
             description: The organization name or ID.
         - in: query
           name: bucket
           description: |
-            The name or ID of the bucket to delete data from.
+            A bucket name or ID.
+            Specifies the bucket to delete data from.
             If you pass both `bucket` and `bucketID`, `bucketID` takes precedence.
           schema:
             type: string
@@ -1686,24 +1689,27 @@ paths:
         - in: query
           name: orgID
           description: |
-            The ID of the organization to delete data from.
-            If you pass both `orgID` and `org`, they must both be valid.
+            An organization ID.
 
             #### InfluxDB Cloud
 
-            - Doesn't require `org` or `orgID`.
-            - Deletes data from the bucket in the organization associated with the authorization (API token).
+            - Doesn't use the `org` parameter or `orgID` parameter.
+            - Deletes data from the bucket in the organization
+              associated with the authorization (API token).
 
             #### InfluxDB OSS
 
-            - Requires either `org` or `orgID`.
+            - Requires either the `org` parameter or the `orgID` parameter.
+            - Deletes data from the bucket in the specified organization.
+            - If you pass both `orgID` and `org`, they must both be valid.
           schema:
             type: string
             description: The organization ID.
         - in: query
           name: bucketID
           description: |
-            The ID of the bucket to delete data from.
+            A bucket ID.
+            Specifies the bucket to delete data from.
             If you pass both `bucket` and `bucketID`, `bucketID` takes precedence.
           schema:
             type: string
@@ -1735,7 +1741,7 @@ paths:
 
             #### InfluxDB OSS
 
-            - Returns this error if `org` or `orgID` doesn't match an organization.
+            - Returns this error if the `org` parameter or `orgID` parameter doesn't match an organization.
           content:
             application/json:
               schema:
@@ -3899,31 +3905,33 @@ paths:
         - in: query
           name: org
           description: |
-            The name or ID of the organization executing the query.
+            An organization name or ID.
 
             #### InfluxDB Cloud
 
-            - Doesn't use `org` or `orgID`.
+            - Doesn't use the `org` parameter or `orgID` parameter.
             - Queries the bucket in the organization associated with the authorization (API token).
 
             #### InfluxDB OSS
 
-            - Requires either `org` or `orgID`.
+            - Requires either the `org` parameter or `orgID` parameter.
+            - Queries the bucket in the specified organization.
           schema:
             type: string
         - in: query
           name: orgID
           description: |
-            The ID of the organization executing the query.
+            An organization ID.
 
             #### InfluxDB Cloud
 
-            - Doesn't use `org` or `orgID`.
+            - Doesn't use the `org` parameter or `orgID` parameter.
             - Queries the bucket in the organization associated with the authorization (API token).
 
             #### InfluxDB OSS
 
-            - Requires either `org` or `orgID`.
+            - Requires either the `org` parameter or `orgID` parameter.
+            - Queries the bucket in the specified organization.
           schema:
             type: string
       x-codeSamples:
@@ -3985,7 +3993,7 @@ paths:
 
             #### InfluxDB OSS
 
-            - Returns this error if `org` or `orgID` doesn't match an organization.
+            - Returns this error if the `org` parameter or `orgID` parameter doesn't match an organization.
           content:
             application/json:
               schema:
@@ -4038,10 +4046,6 @@ paths:
         If no query parameters are passed, InfluxDB returns all buckets up to the
         default `limit`.
 
-        #### InfluxDB Cloud
-
-        - Doesn't use `org` or `orgID` parameters.
-
         #### InfluxDB OSS
 
         - If you use an _[operator token](https://docs.influxdata.com/influxdb/v2.3/security/tokens/#operator-token)_
@@ -4069,22 +4073,31 @@ paths:
           name: org
           description: |
             An organization name.
-            Only returns resources owned by the specified organization.
 
             #### InfluxDB Cloud
 
-            - Doesn't use `org` or `orgID` parameters.
+            - Doesn't use the `org` parameter or `orgID` parameter.
+            - Lists buckets for the organization associated with the authorization (API token).
+
+            #### InfluxDB OSS
+
+            - Lists buckets for the specified organization.
           schema:
             type: string
         - in: query
           name: orgID
           description: |
             An organization ID.
-            Only returns resources owned by the specified organization.
 
             #### InfluxDB Cloud
 
-            - Doesn't use `org` or `orgID` parameters.
+            - Doesn't use the `org` parameter or `orgID` parameter.
+            - Lists buckets for the organization associated with the authorization (API token).
+
+            #### InfluxDB OSS
+
+            - Requires either the `org` parameter or `orgID` parameter.
+            - Lists buckets for the specified organization.
           schema:
             type: string
         - in: query
@@ -6311,7 +6324,7 @@ paths:
 
             #### InfluxDB OSS
 
-            - Returns this error if an incorrect value is passed for `org` or `orgID`.
+            - Returns this error if an incorrect value is passed in the `org` parameter or `orgID` parameter.
           content:
             application/json:
               schema:
@@ -18629,7 +18642,7 @@ components:
 
         #### InfluxDB OSS
 
-        - Returns this error if an incorrect value is passed for `org` or `orgID`.
+        - Returns this error if an incorrect value is passed in the `org` parameter or `orgID` parameter.
       content:
         application/json:
           schema:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -109,7 +109,7 @@ components:
 
         #### InfluxDB OSS
 
-        - Returns this error if an incorrect value is passed for `org` or `orgID`.
+        - Returns this error if an incorrect value is passed in the `org` parameter or `orgID` parameter.
     GeneralServerError:
       content:
         application/json:
@@ -6951,10 +6951,6 @@ paths:
         If no query parameters are passed, InfluxDB returns all buckets up to the
         default `limit`.
 
-        #### InfluxDB Cloud
-
-        - Doesn't use `org` or `orgID` parameters.
-
         #### InfluxDB OSS
 
         - If you use an _[operator token](https://docs.influxdata.com/influxdb/cloud/security/tokens/#operator-token)_
@@ -6981,22 +6977,31 @@ paths:
       - $ref: '#/components/parameters/After'
       - description: |
           An organization name.
-          Only returns resources owned by the specified organization.
 
           #### InfluxDB Cloud
 
-          - Doesn't use `org` or `orgID` parameters.
+          - Doesn't use the `org` parameter or `orgID` parameter.
+          - Lists buckets for the organization associated with the authorization (API token).
+
+          #### InfluxDB OSS
+
+          - Lists buckets for the specified organization.
         in: query
         name: org
         schema:
           type: string
       - description: |
           An organization ID.
-          Only returns resources owned by the specified organization.
 
           #### InfluxDB Cloud
 
-          - Doesn't use `org` or `orgID` parameters.
+          - Doesn't use the `org` parameter or `orgID` parameter.
+          - Lists buckets for the organization associated with the authorization (API token).
+
+          #### InfluxDB OSS
+
+          - Requires either the `org` parameter or `orgID` parameter.
+          - Lists buckets for the specified organization.
         in: query
         name: orgID
         schema:
@@ -9908,24 +9913,27 @@ paths:
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
       - description: |
-          The organization to delete data from.
-          If you pass both `orgID` and `org`, they must both be valid.
+          An organization name or ID.
 
           #### InfluxDB Cloud
 
-          - Doesn't require `org` or `orgID`.
-          - Deletes data from the bucket in the organization associated with the authorization (API token).
+          - Doesn't use the `org` parameter or `orgID` parameter.
+          - Deletes data from the bucket in the organization
+            associated with the authorization (API token).
 
           #### InfluxDB OSS
 
-          - Requires either `org` or `orgID`.
+          - Requires either the `org` parameter or the `orgID` parameter.
+          - Deletes data from the bucket in the specified organization.
+          - If you pass both `orgID` and `org`, they must both be valid.
         in: query
         name: org
         schema:
           description: The organization name or ID.
           type: string
       - description: |
-          The name or ID of the bucket to delete data from.
+          A bucket name or ID.
+          Specifies the bucket to delete data from.
           If you pass both `bucket` and `bucketID`, `bucketID` takes precedence.
         in: query
         name: bucket
@@ -9933,24 +9941,27 @@ paths:
           description: The bucket name or ID.
           type: string
       - description: |
-          The ID of the organization to delete data from.
-          If you pass both `orgID` and `org`, they must both be valid.
+          An organization ID.
 
           #### InfluxDB Cloud
 
-          - Doesn't require `org` or `orgID`.
-          - Deletes data from the bucket in the organization associated with the authorization (API token).
+          - Doesn't use the `org` parameter or `orgID` parameter.
+          - Deletes data from the bucket in the organization
+            associated with the authorization (API token).
 
           #### InfluxDB OSS
 
-          - Requires either `org` or `orgID`.
+          - Requires either the `org` parameter or the `orgID` parameter.
+          - Deletes data from the bucket in the specified organization.
+          - If you pass both `orgID` and `org`, they must both be valid.
         in: query
         name: orgID
         schema:
           description: The organization ID.
           type: string
       - description: |
-          The ID of the bucket to delete data from.
+          A bucket ID.
+          Specifies the bucket to delete data from.
           If you pass both `bucket` and `bucketID`, `bucketID` takes precedence.
         in: query
         name: bucketID
@@ -10012,7 +10023,7 @@ paths:
 
             #### InfluxDB OSS
 
-            - Returns this error if `org` or `orgID` doesn't match an organization.
+            - Returns this error if the `org` parameter or `orgID` parameter doesn't match an organization.
         "401":
           $ref: '#/components/responses/AuthorizationError'
         "404":
@@ -12123,31 +12134,33 @@ paths:
           - application/vnd.flux
           type: string
       - description: |
-          The name or ID of the organization executing the query.
+          An organization name or ID.
 
           #### InfluxDB Cloud
 
-          - Doesn't use `org` or `orgID`.
+          - Doesn't use the `org` parameter or `orgID` parameter.
           - Queries the bucket in the organization associated with the authorization (API token).
 
           #### InfluxDB OSS
 
-          - Requires either `org` or `orgID`.
+          - Requires either the `org` parameter or `orgID` parameter.
+          - Queries the bucket in the specified organization.
         in: query
         name: org
         schema:
           type: string
       - description: |
-          The ID of the organization executing the query.
+          An organization ID.
 
           #### InfluxDB Cloud
 
-          - Doesn't use `org` or `orgID`.
+          - Doesn't use the `org` parameter or `orgID` parameter.
           - Queries the bucket in the organization associated with the authorization (API token).
 
           #### InfluxDB OSS
 
-          - Requires either `org` or `orgID`.
+          - Requires either the `org` parameter or `orgID` parameter.
+          - Queries the bucket in the specified organization.
         in: query
         name: orgID
         schema:
@@ -12211,7 +12224,7 @@ paths:
 
             #### InfluxDB OSS
 
-            - Returns this error if `org` or `orgID` doesn't match an organization.
+            - Returns this error if the `org` parameter or `orgID` parameter doesn't match an organization.
         "401":
           $ref: '#/components/responses/AuthorizationError'
         "404":
@@ -14422,7 +14435,7 @@ paths:
 
             #### InfluxDB OSS
 
-            - Returns this error if an incorrect value is passed for `org` or `orgID`.
+            - Returns this error if an incorrect value is passed in the `org` parameter or `orgID` parameter.
         "401":
           $ref: '#/components/responses/AuthorizationError'
         "500":
@@ -17625,19 +17638,19 @@ paths:
           - application/json
           type: string
       - description: |
-          The destination organization for writes.
-          InfluxDB writes all points in the batch to this organization.
-          If you pass both `orgID` and `org`, they must both be valid.
+          An organization name or ID.
 
           #### InfluxDB Cloud
 
-          - Doesn't require `org` or `orgID`.
-          - Writes to the bucket in the organization associated with the authorization (API token).
+          - Doesn't use the `org` parameter or `orgID` parameter.
+          - Writes data to the bucket in the organization
+            associated with the authorization (API token).
 
           #### InfluxDB OSS
 
-          - Requires either `org` or `orgID`.
-          - InfluxDB writes all points in the batch to this organization.
+          - Requires either the `org` parameter or the `orgID` parameter.
+          - If you pass both `orgID` and `org`, they must both be valid.
+          - Writes data to the bucket in the specified organization.
         in: query
         name: org
         required: true
@@ -17645,26 +17658,26 @@ paths:
           description: The organization name or ID.
           type: string
       - description: |
-          The ID of the destination organization for writes.
-          If you pass both `orgID` and `org`, they must both be valid.
+          An organization ID.
 
           #### InfluxDB Cloud
 
-          - Doesn't require `org` or `orgID`.
-          - Writes to the bucket in the organization associated with the authorization (API token).
-
+          - Doesn't use the `org` parameter or `orgID` parameter.
+          - Writes data to the bucket in the organization
+            associated with the authorization (API token).
 
           #### InfluxDB OSS
 
-          - Requires either `org` or `orgID`.
-          - InfluxDB writes all points in the batch to this organization.
+          - Requires either the `org` parameter or the `orgID` parameter.
+          - If you pass both `orgID` and `org`, they must both be valid.
+          - Writes data to the bucket in the specified organization.
         in: query
         name: orgID
         schema:
           type: string
       - description: |
-          The destination bucket for writes.
-          InfluxDB writes all points in the batch to this bucket.
+          A bucket name or ID.
+          InfluxDB writes all points in the batch to the specified bucket.
         in: query
         name: bucket
         required: true
@@ -17688,7 +17701,7 @@ paths:
               format: byte
               type: string
         description: |
-          Data in line protocol format.
+          In the request body, provide data in [line protocol format](https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol/).
 
           To send compressed data, do the following:
 
@@ -17751,7 +17764,7 @@ paths:
 
             #### InfluxDB OSS
 
-            - Returns this error if `org` or `orgID` doesn't match an organization.
+            - Returns this error if the `org` parameter or `orgID` parameter doesn't match an organization.
         "401":
           $ref: '#/components/responses/AuthorizationError'
         "404":

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -109,7 +109,7 @@ components:
 
         #### InfluxDB OSS
 
-        - Returns this error if an incorrect value is passed for `org` or `orgID`.
+        - Returns this error if an incorrect value is passed in the `org` parameter or `orgID` parameter.
     GeneralServerError:
       content:
         application/json:
@@ -7116,10 +7116,6 @@ paths:
         If no query parameters are passed, InfluxDB returns all buckets up to the
         default `limit`.
 
-        #### InfluxDB Cloud
-
-        - Doesn't use `org` or `orgID` parameters.
-
         #### InfluxDB OSS
 
         - If you use an _[operator token](https://docs.influxdata.com/influxdb/v2.3/security/tokens/#operator-token)_
@@ -7146,22 +7142,31 @@ paths:
       - $ref: '#/components/parameters/After'
       - description: |
           An organization name.
-          Only returns resources owned by the specified organization.
 
           #### InfluxDB Cloud
 
-          - Doesn't use `org` or `orgID` parameters.
+          - Doesn't use the `org` parameter or `orgID` parameter.
+          - Lists buckets for the organization associated with the authorization (API token).
+
+          #### InfluxDB OSS
+
+          - Lists buckets for the specified organization.
         in: query
         name: org
         schema:
           type: string
       - description: |
           An organization ID.
-          Only returns resources owned by the specified organization.
 
           #### InfluxDB Cloud
 
-          - Doesn't use `org` or `orgID` parameters.
+          - Doesn't use the `org` parameter or `orgID` parameter.
+          - Lists buckets for the organization associated with the authorization (API token).
+
+          #### InfluxDB OSS
+
+          - Requires either the `org` parameter or `orgID` parameter.
+          - Lists buckets for the specified organization.
         in: query
         name: orgID
         schema:
@@ -10445,24 +10450,27 @@ paths:
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
       - description: |
-          The organization to delete data from.
-          If you pass both `orgID` and `org`, they must both be valid.
+          An organization name or ID.
 
           #### InfluxDB Cloud
 
-          - Doesn't require `org` or `orgID`.
-          - Deletes data from the bucket in the organization associated with the authorization (API token).
+          - Doesn't use the `org` parameter or `orgID` parameter.
+          - Deletes data from the bucket in the organization
+            associated with the authorization (API token).
 
           #### InfluxDB OSS
 
-          - Requires either `org` or `orgID`.
+          - Requires either the `org` parameter or the `orgID` parameter.
+          - Deletes data from the bucket in the specified organization.
+          - If you pass both `orgID` and `org`, they must both be valid.
         in: query
         name: org
         schema:
           description: The organization name or ID.
           type: string
       - description: |
-          The name or ID of the bucket to delete data from.
+          A bucket name or ID.
+          Specifies the bucket to delete data from.
           If you pass both `bucket` and `bucketID`, `bucketID` takes precedence.
         in: query
         name: bucket
@@ -10470,24 +10478,27 @@ paths:
           description: The bucket name or ID.
           type: string
       - description: |
-          The ID of the organization to delete data from.
-          If you pass both `orgID` and `org`, they must both be valid.
+          An organization ID.
 
           #### InfluxDB Cloud
 
-          - Doesn't require `org` or `orgID`.
-          - Deletes data from the bucket in the organization associated with the authorization (API token).
+          - Doesn't use the `org` parameter or `orgID` parameter.
+          - Deletes data from the bucket in the organization
+            associated with the authorization (API token).
 
           #### InfluxDB OSS
 
-          - Requires either `org` or `orgID`.
+          - Requires either the `org` parameter or the `orgID` parameter.
+          - Deletes data from the bucket in the specified organization.
+          - If you pass both `orgID` and `org`, they must both be valid.
         in: query
         name: orgID
         schema:
           description: The organization ID.
           type: string
       - description: |
-          The ID of the bucket to delete data from.
+          A bucket ID.
+          Specifies the bucket to delete data from.
           If you pass both `bucket` and `bucketID`, `bucketID` takes precedence.
         in: query
         name: bucketID
@@ -10549,7 +10560,7 @@ paths:
 
             #### InfluxDB OSS
 
-            - Returns this error if `org` or `orgID` doesn't match an organization.
+            - Returns this error if the `org` parameter or `orgID` parameter doesn't match an organization.
         "401":
           $ref: '#/components/responses/AuthorizationError'
         "404":
@@ -12653,31 +12664,33 @@ paths:
           - application/vnd.flux
           type: string
       - description: |
-          The name or ID of the organization executing the query.
+          An organization name or ID.
 
           #### InfluxDB Cloud
 
-          - Doesn't use `org` or `orgID`.
+          - Doesn't use the `org` parameter or `orgID` parameter.
           - Queries the bucket in the organization associated with the authorization (API token).
 
           #### InfluxDB OSS
 
-          - Requires either `org` or `orgID`.
+          - Requires either the `org` parameter or `orgID` parameter.
+          - Queries the bucket in the specified organization.
         in: query
         name: org
         schema:
           type: string
       - description: |
-          The ID of the organization executing the query.
+          An organization ID.
 
           #### InfluxDB Cloud
 
-          - Doesn't use `org` or `orgID`.
+          - Doesn't use the `org` parameter or `orgID` parameter.
           - Queries the bucket in the organization associated with the authorization (API token).
 
           #### InfluxDB OSS
 
-          - Requires either `org` or `orgID`.
+          - Requires either the `org` parameter or `orgID` parameter.
+          - Queries the bucket in the specified organization.
         in: query
         name: orgID
         schema:
@@ -12741,7 +12754,7 @@ paths:
 
             #### InfluxDB OSS
 
-            - Returns this error if `org` or `orgID` doesn't match an organization.
+            - Returns this error if the `org` parameter or `orgID` parameter doesn't match an organization.
         "401":
           $ref: '#/components/responses/AuthorizationError'
         "404":
@@ -15548,7 +15561,7 @@ paths:
 
             #### InfluxDB OSS
 
-            - Returns this error if an incorrect value is passed for `org` or `orgID`.
+            - Returns this error if an incorrect value is passed in the `org` parameter or `orgID` parameter.
         "401":
           $ref: '#/components/responses/AuthorizationError'
         "500":
@@ -18623,19 +18636,19 @@ paths:
           - application/json
           type: string
       - description: |
-          The destination organization for writes.
-          InfluxDB writes all points in the batch to this organization.
-          If you pass both `orgID` and `org`, they must both be valid.
+          An organization name or ID.
 
           #### InfluxDB Cloud
 
-          - Doesn't require `org` or `orgID`.
-          - Writes to the bucket in the organization associated with the authorization (API token).
+          - Doesn't use the `org` parameter or `orgID` parameter.
+          - Writes data to the bucket in the organization
+            associated with the authorization (API token).
 
           #### InfluxDB OSS
 
-          - Requires either `org` or `orgID`.
-          - InfluxDB writes all points in the batch to this organization.
+          - Requires either the `org` parameter or the `orgID` parameter.
+          - If you pass both `orgID` and `org`, they must both be valid.
+          - Writes data to the bucket in the specified organization.
         in: query
         name: org
         required: true
@@ -18643,26 +18656,26 @@ paths:
           description: The organization name or ID.
           type: string
       - description: |
-          The ID of the destination organization for writes.
-          If you pass both `orgID` and `org`, they must both be valid.
+          An organization ID.
 
           #### InfluxDB Cloud
 
-          - Doesn't require `org` or `orgID`.
-          - Writes to the bucket in the organization associated with the authorization (API token).
-
+          - Doesn't use the `org` parameter or `orgID` parameter.
+          - Writes data to the bucket in the organization
+            associated with the authorization (API token).
 
           #### InfluxDB OSS
 
-          - Requires either `org` or `orgID`.
-          - InfluxDB writes all points in the batch to this organization.
+          - Requires either the `org` parameter or the `orgID` parameter.
+          - If you pass both `orgID` and `org`, they must both be valid.
+          - Writes data to the bucket in the specified organization.
         in: query
         name: orgID
         schema:
           type: string
       - description: |
-          The destination bucket for writes.
-          InfluxDB writes all points in the batch to this bucket.
+          A bucket name or ID.
+          InfluxDB writes all points in the batch to the specified bucket.
         in: query
         name: bucket
         required: true
@@ -18686,7 +18699,7 @@ paths:
               format: byte
               type: string
         description: |
-          Data in line protocol format.
+          In the request body, provide data in [line protocol format](https://docs.influxdata.com/influxdb/v2.3/reference/syntax/line-protocol/).
 
           To send compressed data, do the following:
 
@@ -18749,7 +18762,7 @@ paths:
 
             #### InfluxDB OSS
 
-            - Returns this error if `org` or `orgID` doesn't match an organization.
+            - Returns this error if the `org` parameter or `orgID` parameter doesn't match an organization.
         "401":
           $ref: '#/components/responses/AuthorizationError'
         "404":

--- a/contracts/svc/invocable-scripts-internal.yml
+++ b/contracts/svc/invocable-scripts-internal.yml
@@ -45,7 +45,7 @@ paths:
 
             #### InfluxDB OSS
 
-            - Returns this error if an incorrect value is passed for `org` or `orgID`.
+            - Returns this error if an incorrect value is passed in the `org` parameter or `orgID` parameter.
           content:
             application/json:
               schema:

--- a/contracts/svc/invocable-scripts.yml
+++ b/contracts/svc/invocable-scripts.yml
@@ -611,7 +611,7 @@ components:
 
         #### InfluxDB OSS
 
-        - Returns this error if an incorrect value is passed for `org` or `orgID`.
+        - Returns this error if an incorrect value is passed in the `org` parameter or `orgID` parameter.
       content:
         application/json:
           schema:

--- a/src/common/paths/buckets.yml
+++ b/src/common/paths/buckets.yml
@@ -14,10 +14,6 @@ get:
     If no query parameters are passed, InfluxDB returns all buckets up to the
     default `limit`.
 
-    #### InfluxDB Cloud
-
-    - Doesn't use `org` or `orgID` parameters.
-
     #### InfluxDB OSS
 
     - If you use an _[operator token]({{% INFLUXDB_DOCS_URL %}}/security/tokens/#operator-token)_
@@ -45,22 +41,32 @@ get:
       name: org
       description: |
         An organization name.
-        Only returns resources owned by the specified organization.
 
         #### InfluxDB Cloud
 
-        - Doesn't use `org` or `orgID` parameters.
+        - Doesn't use the `org` parameter or `orgID` parameter.
+        - Lists buckets for the organization associated with the authorization (API token).
+
+        #### InfluxDB OSS
+
+        - Lists buckets for the specified organization.
+
       schema:
         type: string
     - in: query
       name: orgID
       description: |
         An organization ID.
-        Only returns resources owned by the specified organization.
 
         #### InfluxDB Cloud
 
-        - Doesn't use `org` or `orgID` parameters.
+        - Doesn't use the `org` parameter or `orgID` parameter.
+        - Lists buckets for the organization associated with the authorization (API token).
+
+        #### InfluxDB OSS
+
+        - Requires either the `org` parameter or `orgID` parameter.
+        - Lists buckets for the specified organization.
       schema:
         type: string
     - in: query

--- a/src/common/paths/delete.yml
+++ b/src/common/paths/delete.yml
@@ -80,24 +80,27 @@ post:
     - in: query
       name: org
       description: |
-        The organization to delete data from.
-        If you pass both `orgID` and `org`, they must both be valid.
+        An organization name or ID.
 
         #### InfluxDB Cloud
 
-        - Doesn't require `org` or `orgID`.
-        - Deletes data from the bucket in the organization associated with the authorization (API token).
+        - Doesn't use the `org` parameter or `orgID` parameter.
+        - Deletes data from the bucket in the organization
+          associated with the authorization (API token).
 
         #### InfluxDB OSS
 
-        - Requires either `org` or `orgID`.
+        - Requires either the `org` parameter or the `orgID` parameter.
+        - Deletes data from the bucket in the specified organization.
+        - If you pass both `orgID` and `org`, they must both be valid.
       schema:
         type: string
         description: The organization name or ID.
     - in: query
       name: bucket
       description: |
-        The name or ID of the bucket to delete data from.
+        A bucket name or ID.
+        Specifies the bucket to delete data from.
         If you pass both `bucket` and `bucketID`, `bucketID` takes precedence.
       schema:
         type: string
@@ -105,24 +108,27 @@ post:
     - in: query
       name: orgID
       description: |
-        The ID of the organization to delete data from.
-        If you pass both `orgID` and `org`, they must both be valid.
+        An organization ID.
 
         #### InfluxDB Cloud
 
-        - Doesn't require `org` or `orgID`.
-        - Deletes data from the bucket in the organization associated with the authorization (API token).
+        - Doesn't use the `org` parameter or `orgID` parameter.
+        - Deletes data from the bucket in the organization
+          associated with the authorization (API token).
 
         #### InfluxDB OSS
 
-        - Requires either `org` or `orgID`.
+        - Requires either the `org` parameter or the `orgID` parameter.
+        - Deletes data from the bucket in the specified organization.
+        - If you pass both `orgID` and `org`, they must both be valid.
       schema:
         type: string
         description: The organization ID.
     - in: query
       name: bucketID
       description: |
-        The ID of the bucket to delete data from.
+        A bucket ID.
+        Specifies the bucket to delete data from.
         If you pass both `bucket` and `bucketID`, `bucketID` takes precedence.
       schema:
         type: string
@@ -154,7 +160,7 @@ post:
 
         #### InfluxDB OSS
 
-        - Returns this error if `org` or `orgID` doesn't match an organization.
+        - Returns this error if the `org` parameter or `orgID` parameter doesn't match an organization.
       content:
         application/json:
           schema:

--- a/src/common/paths/query.yml
+++ b/src/common/paths/query.yml
@@ -40,31 +40,33 @@ post:
     - in: query
       name: org
       description: |
-        The name or ID of the organization executing the query.
+        An organization name or ID.
 
         #### InfluxDB Cloud
 
-        - Doesn't use `org` or `orgID`.
+        - Doesn't use the `org` parameter or `orgID` parameter.
         - Queries the bucket in the organization associated with the authorization (API token).
 
         #### InfluxDB OSS
 
-        - Requires either `org` or `orgID`.
+        - Requires either the `org` parameter or `orgID` parameter.
+        - Queries the bucket in the specified organization.
       schema:
         type: string
     - in: query
       name: orgID
       description: |
-        The ID of the organization executing the query.
+        An organization ID.
 
         #### InfluxDB Cloud
 
-        - Doesn't use `org` or `orgID`.
+        - Doesn't use the `org` parameter or `orgID` parameter.
         - Queries the bucket in the organization associated with the authorization (API token).
 
         #### InfluxDB OSS
 
-        - Requires either `org` or `orgID`.
+        - Requires either the `org` parameter or `orgID` parameter.
+        - Queries the bucket in the specified organization.
       schema:
         type: string
   x-codeSamples:
@@ -144,7 +146,7 @@ post:
 
         #### InfluxDB OSS
 
-        - Returns this error if `org` or `orgID` doesn't match an organization.
+        - Returns this error if the `org` parameter or `orgID` parameter doesn't match an organization.
       content:
         application/json:
           schema:

--- a/src/common/paths/stacks.yml
+++ b/src/common/paths/stacks.yml
@@ -76,7 +76,7 @@ get:
 
         #### InfluxDB OSS
 
-        - Returns this error if an incorrect value is passed for `org` or `orgID`.
+        - Returns this error if an incorrect value is passed in the `org` parameter or `orgID` parameter.
       content:
         application/json:
           schema:

--- a/src/common/paths/write.yml
+++ b/src/common/paths/write.yml
@@ -47,7 +47,7 @@ post:
     - [Troubleshoot issues writing data]({{% INFLUXDB_DOCS_URL %}}/write-data/troubleshoot/)
   requestBody:
     description: |
-      Data in line protocol format.
+      In the request body, provide data in [line protocol format]({{% INFLUXDB_DOCS_URL %}}/reference/syntax/line-protocol/).
 
       To send compressed data, do the following:
 
@@ -135,19 +135,19 @@ post:
     - in: query
       name: org
       description: |
-        The destination organization for writes.
-        InfluxDB writes all points in the batch to this organization.
-        If you pass both `orgID` and `org`, they must both be valid.
+        An organization name or ID.
 
         #### InfluxDB Cloud
 
-        - Doesn't require `org` or `orgID`.
-        - Writes to the bucket in the organization associated with the authorization (API token).
+        - Doesn't use the `org` parameter or `orgID` parameter.
+        - Writes data to the bucket in the organization
+          associated with the authorization (API token).
 
         #### InfluxDB OSS
 
-        - Requires either `org` or `orgID`.
-        - InfluxDB writes all points in the batch to this organization.
+        - Requires either the `org` parameter or the `orgID` parameter.
+        - If you pass both `orgID` and `org`, they must both be valid.
+        - Writes data to the bucket in the specified organization.
       required: true
       schema:
         type: string
@@ -155,27 +155,26 @@ post:
     - in: query
       name: orgID
       description: |
-        The ID of the destination organization for writes.
-        If you pass both `orgID` and `org`, they must both be valid.
+        An organization ID.
 
         #### InfluxDB Cloud
 
-        - Doesn't require `org` or `orgID`.
-        - Writes to the bucket in the organization associated with the authorization (API token).
-
+        - Doesn't use the `org` parameter or `orgID` parameter.
+        - Writes data to the bucket in the organization
+          associated with the authorization (API token).
 
         #### InfluxDB OSS
 
-        - Requires either `org` or `orgID`.
-        - InfluxDB writes all points in the batch to this organization.
-
+        - Requires either the `org` parameter or the `orgID` parameter.
+        - If you pass both `orgID` and `org`, they must both be valid.
+        - Writes data to the bucket in the specified organization.
       schema:
         type: string
     - in: query
       name: bucket
       description: |
-        The destination bucket for writes.
-        InfluxDB writes all points in the batch to this bucket.
+        A bucket name or ID.
+        InfluxDB writes all points in the batch to the specified bucket.
       required: true
       schema:
         type: string
@@ -217,8 +216,7 @@ post:
 
         #### InfluxDB OSS
 
-        - Returns this error if `org` or `orgID` doesn't match an organization.
-
+        - Returns this error if the `org` parameter or `orgID` parameter doesn't match an organization.
       content:
         application/json:
           schema:

--- a/src/common/responses/BadRequestError.yml
+++ b/src/common/responses/BadRequestError.yml
@@ -5,7 +5,7 @@
 
     #### InfluxDB OSS
 
-    - Returns this error if an incorrect value is passed for `org` or `orgID`.
+    - Returns this error if an incorrect value is passed in the `org` parameter or `orgID` parameter.
   content:
     application/json:
       schema:


### PR DESCRIPTION
- Revise descriptions for `org` and `orgID` parameters.

Part of my previous PR #574, splitting for sanity.