### PR TITLE
docs: move code samples to request examples, fix descriptions:

### DIFF
--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -433,7 +433,7 @@ paths:
         - Authorizations
       summary: List authorizations
       description: |
-        Retrieves a list of authorizations.
+        Lists authorizations.
 
         To limit which authorizations are returned, pass query parameters in your request.
         If no query parameters are passed, InfluxDB returns all authorizations for the organization.
@@ -444,7 +444,7 @@ paths:
           values in `GET /api/v2/authorizations` responses;
           returns `token: redacted` for all authorizations.
 
-        #### Required permissions for InfluxDB Cloud
+        #### Required permissions
 
         - `read-authorizations`
 
@@ -529,20 +529,14 @@ paths:
         Use this endpoint to create an authorization, which generates an API token
         with permissions to `read` or `write` to a specific resource or `type` of resource.
 
-        Keep the following in mind when creating and updating authorizations:
-
-        - To apply a permission to a specific resource, specify the resource `id` field.
-        - To apply a permission to all resources with the type, omit the resource `id`.
-        - To scope an authorization to a specific user, provide the `userID` property.
-
         #### Limitations
 
         To follow best practices for secure API token generation and retrieval,
         InfluxDB Cloud enforces access restrictions on API tokens.
 
-        - InfluxDB Cloud only allows access to the API token value immediately after the authorization is created.
-        - You can’t change access (read/write) permissions for an API token after it’s created.
-        - Tokens stop working when the user who created the token is deleted.
+        - InfluxDB only allows access to the API token value immediately after the authorization is created.
+        - You can't update an authorization's permissions.
+        - A token stops working when the user who created the authorization is deleted.
 
         We recommend the following for managing your tokens:
 
@@ -560,7 +554,112 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AuthorizationPostRequest'
+              required:
+                - orgID
+                - permissions
+              allOf:
+                - $ref: '#/paths/~1authorizations~1%7BauthID%7D/patch/requestBody/content/application~1json/schema'
+                - type: object
+                  properties:
+                    orgID:
+                      type: string
+                      description: |
+                        An organization ID.
+                        Specifies the organization that owns the authorization.
+                    userID:
+                      type: string
+                      description: |
+                        A user ID.
+                        Specifies the user that the authorization is scoped to.
+
+                        When a user authenticates with username and password,
+                        InfluxDB generates a _user session_ with all the permissions
+                        specified by all the user's authorizations.
+                    permissions:
+                      type: array
+                      minItems: 1
+                      description: |
+                        A list of permissions for an authorization.
+                        In the list, provide at least one `permission` object.
+
+                        In a `permission`, the `resource.type` property grants access to all
+                        resources of the specified type.
+                        To grant access to only a specific resource, specify the
+                        `resource.id` property.
+                      items:
+                        required:
+                          - action
+                          - resource
+                        properties:
+                          action:
+                            type: string
+                            enum:
+                              - read
+                              - write
+                          resource:
+                            type: object
+                            required:
+                              - type
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  - authorizations
+                                  - buckets
+                                  - dashboards
+                                  - orgs
+                                  - tasks
+                                  - telegrafs
+                                  - users
+                                  - variables
+                                  - secrets
+                                  - labels
+                                  - views
+                                  - documents
+                                  - notificationRules
+                                  - notificationEndpoints
+                                  - checks
+                                  - dbrp
+                                  - annotations
+                                  - sources
+                                  - scrapers
+                                  - notebooks
+                                  - remotes
+                                  - replications
+                                  - instance
+                                  - flows
+                                  - functions
+                                  - subscriptions
+                                description: |
+                                  A resource type.
+                                  Identifies the API resource's type (or _kind_).
+                              id:
+                                type: string
+                                description: |
+                                  A resource ID.
+                                  Identifies a specific resource.
+                              name:
+                                type: string
+                                description: |
+                                  The name of the resource.
+                                  _Note: not all resource types have a `name` property_.
+                              orgID:
+                                type: string
+                                description: |
+                                  An organization ID.
+                                  Identifies the organization that owns the resource.
+                              org:
+                                type: string
+                                description: |
+                                  An organization name.
+                                  The organization that owns the resource.
+            examples:
+              AuthorizationPostRequest:
+                $ref: '#/components/examples/AuthorizationPostRequest'
+              AuthorizationWithResourcePostRequest:
+                $ref: '#/components/examples/AuthorizationWithResourcePostRequest'
+              AuthorizationWithUserPostRequest:
+                $ref: '#/components/examples/AuthorizationWithUserPostRequest'
       responses:
         '201':
           description: |
@@ -579,40 +678,6 @@ paths:
         default:
           description: Unexpected error
           $ref: '#/paths/~1tasks/get/responses/default'
-      x-codeSample:
-        - lang: Shell
-          label: 'cURL: Create auth to read all buckets'
-          source: |
-            curl --request POST \
-            "http://localhost:8086/api/v2/authorizations" \
-            --header "Authorization: Token INFLUX_API_TOKEN" \
-            --header 'Content-Type: application/json' \
-            --data @- << EOF
-              {
-                "orgID": "INFLUX_ORG_ID",
-                "description": "iot_users read buckets",
-                "permissions": [
-                  {"action": "read", "resource": {"type": "buckets"}}
-                ]
-              }
-            EOF
-        - lang: Shell
-          label: 'cURL: Create auth scoped to a user'
-          source: |
-            curl --request POST \
-            "http://localhost:8086/api/v2/authorizations" \
-            --header "Authorization: Token INFLUX_API_TOKEN" \
-            --header 'Content-Type: application/json' \
-            --data @- << EOF
-              {
-                "orgID": "INFLUX_ORG_ID",
-                "userID": "INFLUX_USER_ID",
-                "description": "iot_user write to bucket",
-                "permissions": [
-                  {"action": "write", "resource": {"type": "buckets", "id: "INFLUX_BUCKET_ID"}}
-                ]
-              }
-            EOF
   '/authorizations/{authID}':
     get:
       operationId: GetAuthorizationsID
@@ -649,7 +714,17 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AuthorizationPostRequest/allOf/0'
+              properties:
+                status:
+                  description: 'Status of the token. If `inactive`, requests using the token will be rejected.'
+                  default: active
+                  type: string
+                  enum:
+                    - active
+                    - inactive
+                description:
+                  type: string
+                  description: A description of the token.
       parameters:
         - $ref: '#/paths/~1users/get/parameters/0'
         - in: path
@@ -3733,108 +3808,6 @@ paths:
 components:
   parameters: null
   schemas:
-    AuthorizationPostRequest:
-      required:
-        - orgID
-        - permissions
-      allOf:
-        - properties:
-            status:
-              description: 'Status of the token. If `inactive`, requests using the token will be rejected.'
-              default: active
-              type: string
-              enum:
-                - active
-                - inactive
-            description:
-              type: string
-              description: A description of the token.
-        - type: object
-          properties:
-            orgID:
-              type: string
-              description: |
-                The ID of the organization that owns the authorization.
-            userID:
-              type: string
-              description: |
-                The ID of the user that the authorization is scoped to.
-            permissions:
-              type: array
-              minItems: 1
-              description: |
-                A list of permissions for an authorization.
-                An authorization must have at least one permission.
-              items:
-                $ref: '#/components/schemas/Permission'
-    Permission:
-      required:
-        - action
-        - resource
-      properties:
-        action:
-          type: string
-          enum:
-            - read
-            - write
-        resource:
-          $ref: '#/components/schemas/Resource'
-    Resource:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - authorizations
-            - buckets
-            - dashboards
-            - orgs
-            - tasks
-            - telegrafs
-            - users
-            - variables
-            - secrets
-            - labels
-            - views
-            - documents
-            - notificationRules
-            - notificationEndpoints
-            - checks
-            - dbrp
-            - annotations
-            - sources
-            - scrapers
-            - notebooks
-            - remotes
-            - replications
-            - instance
-            - flows
-            - functions
-            - subscriptions
-          description: |
-            The type of resource.
-            In a `permission`, applies the permission to all resources of this type.
-        id:
-          type: string
-          description: |
-            The ID of a specific resource.
-            In a `permission`, applies the permission to only the resource with this ID.
-        name:
-          type: string
-          description: |
-            Optional: A name for the resource.
-            Not all resource types have a name field.
-        orgID:
-          type: string
-          description: |
-            The ID of the organization that owns the resource.
-            In a `permission`, applies the permission to all resources of `type` owned by this organization.
-        org:
-          type: string
-          description: |
-            Optional: The name of the organization with `orgID`.
     User:
       properties:
         id:
@@ -4105,7 +4078,7 @@ components:
             - orgID
             - permissions
           allOf:
-            - $ref: '#/components/schemas/AuthorizationPostRequest/allOf/0'
+            - $ref: '#/paths/~1authorizations~1%7BauthID%7D/patch/requestBody/content/application~1json/schema'
             - type: object
               properties:
                 createdAt:
@@ -4128,7 +4101,7 @@ components:
                     The list of permissions.
                     An authorization must have at least one permission.
                   items:
-                    $ref: '#/components/schemas/Permission'
+                    $ref: '#/paths/~1authorizations/post/requestBody/content/application~1json/schema/allOf/1/properties/permissions/items'
                 id:
                   readOnly: true
                   type: string
@@ -4835,6 +4808,61 @@ components:
           description: Update the 'scriptParameters' of the task.
           type: object
   responses: null
+  examples:
+    AuthorizationPostRequest:
+      summary: An authorization for a resource type
+      description: Creates an authorization.
+      value:
+        orgID: INFLUX_ORG_ID
+        description: iot_users read buckets
+        permissions:
+          - action: read
+            resource:
+              type: buckets
+    AuthorizationWithResourcePostRequest:
+      summary: An authorization for a resource
+      description: Creates an authorization for access to a specific resource.
+      value:
+        orgID: INFLUX_ORG_ID
+        description: iot_users read buckets
+        permissions:
+          - action: read
+            resource:
+              type: buckets
+              id: INFLUX_BUCKET_ID
+    AuthorizationWithUserPostRequest:
+      summary: An authorization scoped to a user
+      description: Creates an authorization scoped to a specific user.
+      value:
+        orgID: INFLUX_ORG_ID
+        userID: INFLUX_USER_ID
+        description: iot_user write to bucket
+        permissions:
+          - action: write
+            resource:
+              type: buckets
+              id: INFLUX_BUCKET_ID
+    TaskWithFluxRequest:
+      summary: A task with Flux
+      description: Sets the `flux` property with Flux task options and a query.
+      value:
+        flux: "option task = {name: \"CPU Total 1 Hour New\", every: 1h}from(bucket: \"telegraf\") |> range(start: -1h) |> filter(fn: (r) => (r._measurement == \"cpu\")) |> filter(fn: (r) =>\n\t\t(r._field == \"usage_system\")) |> filter(fn: (r) => (r.cpu == \"cpu-total\")) |> aggregateWindow(every: 1h, fn: max) |> to(bucket: \"cpu_usage_user_total_1h\", org: \"INFLUX_ORG\")"
+        status: active
+        description: This task contains Flux that configures the task schedule and downsamples CPU data every hour.
+    TaskWithScriptRequest:
+      summary: A task with an invokable script
+      description: |
+        Sets properties for a task that runs an _invokable script_.
+      value:
+        name: CPU Total 1 Hour New
+        every: 1h
+        scriptID: SCRIPT_ID
+        scriptParameters:
+          rangeStart: '-1h'
+          bucket: telegraf
+          filterField: cpu-total
+        status: active
+        description: This task runs an invokable script every hour with the defined parameters.
   securitySchemes:
     TokenAuthentication:
       type: apiKey

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -11574,7 +11574,7 @@
           "Authorizations"
         ],
         "summary": "List authorizations",
-        "description": "Retrieves a list of authorizations.\n\nTo limit which authorizations are returned, pass query parameters in your request.\nIf no query parameters are passed, InfluxDB returns all authorizations for the organization.\n\n#### InfluxDB Cloud\n\n- InfluxDB Cloud doesn't expose [API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token)\n  values in `GET /api/v2/authorizations` responses;\n  returns `token: redacted` for all authorizations.\n\n#### Required permissions for InfluxDB Cloud\n\n- `read-authorizations`\n\n#### Related guides\n\n- [View tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens/view-tokens/)\n",
+        "description": "Lists authorizations.\n\nTo limit which authorizations are returned, pass query parameters in your request.\nIf no query parameters are passed, InfluxDB returns all authorizations for the organization.\n\n#### InfluxDB Cloud\n\n- InfluxDB Cloud doesn't expose [API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token)\n  values in `GET /api/v2/authorizations` responses;\n  returns `token: redacted` for all authorizations.\n\n#### Required permissions\n\n- `read-authorizations`\n\n#### Related guides\n\n- [View tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens/view-tokens/)\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -11653,7 +11653,7 @@
           "Authorizations"
         ],
         "summary": "Create an authorization",
-        "description": "Creates an authorization and returns the authorization with the\ngenerated API [token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token).\n\nUse this endpoint to create an authorization, which generates an API token\nwith permissions to `read` or `write` to a specific resource or `type` of resource.\n\nKeep the following in mind when creating and updating authorizations:\n\n- To apply a permission to a specific resource, specify the resource `id` field.\n- To apply a permission to all resources with the type, omit the resource `id`.\n- To scope an authorization to a specific user, provide the `userID` property.\n\n#### Limitations\n\nTo follow best practices for secure API token generation and retrieval,\nInfluxDB Cloud enforces access restrictions on API tokens.\n\n- InfluxDB Cloud only allows access to the API token value immediately after the authorization is created.\n- You can’t change access (read/write) permissions for an API token after it’s created.\n- Tokens stop working when the user who created the token is deleted.\n\nWe recommend the following for managing your tokens:\n\n- Create a generic user to create and manage tokens for writing data.\n- Store your tokens in a secure password vault for future access.\n\n#### Related guides\n\n- [Create a token]({{% INFLUXDB_DOCS_URL %}}/security/tokens/create-token/)\n",
+        "description": "Creates an authorization and returns the authorization with the\ngenerated API [token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token).\n\nUse this endpoint to create an authorization, which generates an API token\nwith permissions to `read` or `write` to a specific resource or `type` of resource.\n\n#### Limitations\n\nTo follow best practices for secure API token generation and retrieval,\nInfluxDB Cloud enforces access restrictions on API tokens.\n\n- InfluxDB only allows access to the API token value immediately after the authorization is created.\n- You can't update an authorization's permissions.\n- A token stops working when the user who created the authorization is deleted.\n\nWe recommend the following for managing your tokens:\n\n- Create a generic user to create and manage tokens for writing data.\n- Store your tokens in a secure password vault for future access.\n\n#### Related guides\n\n- [Create a token]({{% INFLUXDB_DOCS_URL %}}/security/tokens/create-token/)\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -11666,6 +11666,17 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/AuthorizationPostRequest"
+              },
+              "examples": {
+                "AuthorizationPostRequest": {
+                  "$ref": "#/components/examples/AuthorizationPostRequest"
+                },
+                "AuthorizationWithResourcePostRequest": {
+                  "$ref": "#/components/examples/AuthorizationWithResourcePostRequest"
+                },
+                "AuthorizationWithUserPostRequest": {
+                  "$ref": "#/components/examples/AuthorizationWithUserPostRequest"
+                }
               }
             }
           }
@@ -11695,19 +11706,7 @@
             "description": "Unexpected error",
             "$ref": "#/components/responses/GeneralServerError"
           }
-        },
-        "x-codeSample": [
-          {
-            "lang": "Shell",
-            "label": "cURL: Create auth to read all buckets",
-            "source": "curl --request POST \\\n\"http://localhost:8086/api/v2/authorizations\" \\\n--header \"Authorization: Token INFLUX_API_TOKEN\" \\\n--header 'Content-Type: application/json' \\\n--data @- << EOF\n  {\n    \"orgID\": \"INFLUX_ORG_ID\",\n    \"description\": \"iot_users read buckets\",\n    \"permissions\": [\n      {\"action\": \"read\", \"resource\": {\"type\": \"buckets\"}}\n    ]\n  }\nEOF\n"
-          },
-          {
-            "lang": "Shell",
-            "label": "cURL: Create auth scoped to a user",
-            "source": "curl --request POST \\\n\"http://localhost:8086/api/v2/authorizations\" \\\n--header \"Authorization: Token INFLUX_API_TOKEN\" \\\n--header 'Content-Type: application/json' \\\n--data @- << EOF\n  {\n    \"orgID\": \"INFLUX_ORG_ID\",\n    \"userID\": \"INFLUX_USER_ID\",\n    \"description\": \"iot_user write to bucket\",\n    \"permissions\": [\n      {\"action\": \"write\", \"resource\": {\"type\": \"buckets\", \"id: \"INFLUX_BUCKET_ID\"}}\n    ]\n  }\nEOF\n"
-          }
-        ]
+        }
       }
     },
     "/authorizations/{authID}": {
@@ -14241,6 +14240,38 @@
           }
         }
       },
+      "AuthorizationPostRequest": {
+        "required": [
+          "orgID",
+          "permissions"
+        ],
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AuthorizationUpdateRequest"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "orgID": {
+                "type": "string",
+                "description": "An organization ID.\nSpecifies the organization that owns the authorization.\n"
+              },
+              "userID": {
+                "type": "string",
+                "description": "A user ID.\nSpecifies the user that the authorization is scoped to.\n\nWhen a user authenticates with username and password,\nInfluxDB generates a _user session_ with all the permissions\nspecified by all the user's authorizations.\n"
+              },
+              "permissions": {
+                "type": "array",
+                "minItems": 1,
+                "description": "A list of permissions for an authorization.\nIn the list, provide at least one `permission` object.\n\nIn a `permission`, the `resource.type` property grants access to all\nresources of the specified type.\nTo grant access to only a specific resource, specify the\n`resource.id` property.\n",
+                "items": {
+                  "$ref": "#/components/schemas/Permission"
+                }
+              }
+            }
+          }
+        ]
+      },
       "AuthorizationUpdateRequest": {
         "properties": {
           "status": {
@@ -16295,6 +16326,62 @@
       "Flags": {
         "type": "object",
         "additionalProperties": true
+      },
+      "Resource": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "authorizations",
+              "buckets",
+              "dashboards",
+              "orgs",
+              "tasks",
+              "telegrafs",
+              "users",
+              "variables",
+              "secrets",
+              "labels",
+              "views",
+              "documents",
+              "notificationRules",
+              "notificationEndpoints",
+              "checks",
+              "dbrp",
+              "annotations",
+              "sources",
+              "scrapers",
+              "notebooks",
+              "remotes",
+              "replications",
+              "instance",
+              "flows",
+              "functions",
+              "subscriptions"
+            ],
+            "description": "A resource type.\nIdentifies the API resource's type (or _kind_).\n"
+          },
+          "id": {
+            "type": "string",
+            "description": "A resource ID.\nIdentifies a specific resource.\n"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the resource.\n_Note: not all resource types have a `name` property_.\n"
+          },
+          "orgID": {
+            "type": "string",
+            "description": "An organization ID.\nIdentifies the organization that owns the resource.\n"
+          },
+          "org": {
+            "type": "string",
+            "description": "An organization name.\nThe organization that owns the resource.\n"
+          }
+        }
       },
       "ResourceMember": {
         "allOf": [
@@ -20770,38 +20857,6 @@
           "configcat_deployments-autopromotionblocker": "#663cd0"
         }
       },
-      "AuthorizationPostRequest": {
-        "required": [
-          "orgID",
-          "permissions"
-        ],
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/AuthorizationUpdateRequest"
-          },
-          {
-            "type": "object",
-            "properties": {
-              "orgID": {
-                "type": "string",
-                "description": "The ID of the organization that owns the authorization.\n"
-              },
-              "userID": {
-                "type": "string",
-                "description": "The ID of the user that the authorization is scoped to.\n"
-              },
-              "permissions": {
-                "type": "array",
-                "minItems": 1,
-                "description": "A list of permissions for an authorization.\nAn authorization must have at least one permission.\n",
-                "items": {
-                  "$ref": "#/components/schemas/Permission"
-                }
-              }
-            }
-          }
-        ]
-      },
       "Permission": {
         "required": [
           "action",
@@ -20817,62 +20872,6 @@
           },
           "resource": {
             "$ref": "#/components/schemas/Resource"
-          }
-        }
-      },
-      "Resource": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "authorizations",
-              "buckets",
-              "dashboards",
-              "orgs",
-              "tasks",
-              "telegrafs",
-              "users",
-              "variables",
-              "secrets",
-              "labels",
-              "views",
-              "documents",
-              "notificationRules",
-              "notificationEndpoints",
-              "checks",
-              "dbrp",
-              "annotations",
-              "sources",
-              "scrapers",
-              "notebooks",
-              "remotes",
-              "replications",
-              "instance",
-              "flows",
-              "functions",
-              "subscriptions"
-            ],
-            "description": "The type of resource.\nIn a `permission`, applies the permission to all resources of this type.\n"
-          },
-          "id": {
-            "type": "string",
-            "description": "The ID of a specific resource.\nIn a `permission`, applies the permission to only the resource with this ID.\n"
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional: A name for the resource.\nNot all resource types have a name field.\n"
-          },
-          "orgID": {
-            "type": "string",
-            "description": "The ID of the organization that owns the resource.\nIn a `permission`, applies the permission to all resources of `type` owned by this organization.\n"
-          },
-          "org": {
-            "type": "string",
-            "description": "Optional: The name of the organization with `orgID`.\n"
           }
         }
       },
@@ -21853,6 +21852,84 @@
               }
             }
           }
+        }
+      }
+    },
+    "examples": {
+      "AuthorizationPostRequest": {
+        "summary": "An authorization for a resource type",
+        "description": "Creates an authorization.",
+        "value": {
+          "orgID": "INFLUX_ORG_ID",
+          "description": "iot_users read buckets",
+          "permissions": [
+            {
+              "action": "read",
+              "resource": {
+                "type": "buckets"
+              }
+            }
+          ]
+        }
+      },
+      "AuthorizationWithResourcePostRequest": {
+        "summary": "An authorization for a resource",
+        "description": "Creates an authorization for access to a specific resource.",
+        "value": {
+          "orgID": "INFLUX_ORG_ID",
+          "description": "iot_users read buckets",
+          "permissions": [
+            {
+              "action": "read",
+              "resource": {
+                "type": "buckets",
+                "id": "INFLUX_BUCKET_ID"
+              }
+            }
+          ]
+        }
+      },
+      "AuthorizationWithUserPostRequest": {
+        "summary": "An authorization scoped to a user",
+        "description": "Creates an authorization scoped to a specific user.",
+        "value": {
+          "orgID": "INFLUX_ORG_ID",
+          "userID": "INFLUX_USER_ID",
+          "description": "iot_user write to bucket",
+          "permissions": [
+            {
+              "action": "write",
+              "resource": {
+                "type": "buckets",
+                "id": "INFLUX_BUCKET_ID"
+              }
+            }
+          ]
+        }
+      },
+      "TaskWithFluxRequest": {
+        "summary": "A task with Flux",
+        "description": "Sets the `flux` property with Flux task options and a query.",
+        "value": {
+          "flux": "option task = {name: \"CPU Total 1 Hour New\", every: 1h}from(bucket: \"telegraf\") |> range(start: -1h) |> filter(fn: (r) => (r._measurement == \"cpu\")) |> filter(fn: (r) =>\n\t\t(r._field == \"usage_system\")) |> filter(fn: (r) => (r.cpu == \"cpu-total\")) |> aggregateWindow(every: 1h, fn: max) |> to(bucket: \"cpu_usage_user_total_1h\", org: \"INFLUX_ORG\")",
+          "status": "active",
+          "description": "This task contains Flux that configures the task schedule and downsamples CPU data every hour."
+        }
+      },
+      "TaskWithScriptRequest": {
+        "summary": "A task with an invokable script",
+        "description": "Sets properties for a task that runs an _invokable script_.\n",
+        "value": {
+          "name": "CPU Total 1 Hour New",
+          "every": "1h",
+          "scriptID": "SCRIPT_ID",
+          "scriptParameters": {
+            "rangeStart": "-1h",
+            "bucket": "telegraf",
+            "filterField": "cpu-total"
+          },
+          "status": "active",
+          "description": "This task runs an invokable script every hour with the defined parameters."
         }
       }
     },

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -9332,7 +9332,7 @@ paths:
         - Authorizations
       summary: List authorizations
       description: |
-        Retrieves a list of authorizations.
+        Lists authorizations.
 
         To limit which authorizations are returned, pass query parameters in your request.
         If no query parameters are passed, InfluxDB returns all authorizations for the organization.
@@ -9343,7 +9343,7 @@ paths:
           values in `GET /api/v2/authorizations` responses;
           returns `token: redacted` for all authorizations.
 
-        #### Required permissions for InfluxDB Cloud
+        #### Required permissions
 
         - `read-authorizations`
 
@@ -9420,20 +9420,14 @@ paths:
         Use this endpoint to create an authorization, which generates an API token
         with permissions to `read` or `write` to a specific resource or `type` of resource.
 
-        Keep the following in mind when creating and updating authorizations:
-
-        - To apply a permission to a specific resource, specify the resource `id` field.
-        - To apply a permission to all resources with the type, omit the resource `id`.
-        - To scope an authorization to a specific user, provide the `userID` property.
-
         #### Limitations
 
         To follow best practices for secure API token generation and retrieval,
         InfluxDB Cloud enforces access restrictions on API tokens.
 
-        - InfluxDB Cloud only allows access to the API token value immediately after the authorization is created.
-        - You can’t change access (read/write) permissions for an API token after it’s created.
-        - Tokens stop working when the user who created the token is deleted.
+        - InfluxDB only allows access to the API token value immediately after the authorization is created.
+        - You can't update an authorization's permissions.
+        - A token stops working when the user who created the authorization is deleted.
 
         We recommend the following for managing your tokens:
 
@@ -9452,6 +9446,13 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/AuthorizationPostRequest'
+            examples:
+              AuthorizationPostRequest:
+                $ref: '#/components/examples/AuthorizationPostRequest'
+              AuthorizationWithResourcePostRequest:
+                $ref: '#/components/examples/AuthorizationWithResourcePostRequest'
+              AuthorizationWithUserPostRequest:
+                $ref: '#/components/examples/AuthorizationWithUserPostRequest'
       responses:
         '201':
           description: |
@@ -9470,40 +9471,6 @@ paths:
         default:
           description: Unexpected error
           $ref: '#/components/responses/GeneralServerError'
-      x-codeSample:
-        - lang: Shell
-          label: 'cURL: Create auth to read all buckets'
-          source: |
-            curl --request POST \
-            "http://localhost:8086/api/v2/authorizations" \
-            --header "Authorization: Token INFLUX_API_TOKEN" \
-            --header 'Content-Type: application/json' \
-            --data @- << EOF
-              {
-                "orgID": "INFLUX_ORG_ID",
-                "description": "iot_users read buckets",
-                "permissions": [
-                  {"action": "read", "resource": {"type": "buckets"}}
-                ]
-              }
-            EOF
-        - lang: Shell
-          label: 'cURL: Create auth scoped to a user'
-          source: |
-            curl --request POST \
-            "http://localhost:8086/api/v2/authorizations" \
-            --header "Authorization: Token INFLUX_API_TOKEN" \
-            --header 'Content-Type: application/json' \
-            --data @- << EOF
-              {
-                "orgID": "INFLUX_ORG_ID",
-                "userID": "INFLUX_USER_ID",
-                "description": "iot_user write to bucket",
-                "permissions": [
-                  {"action": "write", "resource": {"type": "buckets", "id: "INFLUX_BUCKET_ID"}}
-                ]
-              }
-            EOF
   '/authorizations/{authID}':
     get:
       operationId: GetAuthorizationsID
@@ -11559,6 +11526,41 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Authorization'
+    AuthorizationPostRequest:
+      required:
+        - orgID
+        - permissions
+      allOf:
+        - $ref: '#/components/schemas/AuthorizationUpdateRequest'
+        - type: object
+          properties:
+            orgID:
+              type: string
+              description: |
+                An organization ID.
+                Specifies the organization that owns the authorization.
+            userID:
+              type: string
+              description: |
+                A user ID.
+                Specifies the user that the authorization is scoped to.
+
+                When a user authenticates with username and password,
+                InfluxDB generates a _user session_ with all the permissions
+                specified by all the user's authorizations.
+            permissions:
+              type: array
+              minItems: 1
+              description: |
+                A list of permissions for an authorization.
+                In the list, provide at least one `permission` object.
+
+                In a `permission`, the `resource.type` property grants access to all
+                resources of the specified type.
+                To grant access to only a specific resource, specify the
+                `resource.id` property.
+              items:
+                $ref: '#/components/schemas/Permission'
     AuthorizationUpdateRequest:
       properties:
         status:
@@ -13154,6 +13156,63 @@ components:
     Flags:
       type: object
       additionalProperties: true
+    Resource:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - authorizations
+            - buckets
+            - dashboards
+            - orgs
+            - tasks
+            - telegrafs
+            - users
+            - variables
+            - secrets
+            - labels
+            - views
+            - documents
+            - notificationRules
+            - notificationEndpoints
+            - checks
+            - dbrp
+            - annotations
+            - sources
+            - scrapers
+            - notebooks
+            - remotes
+            - replications
+            - instance
+            - flows
+            - functions
+            - subscriptions
+          description: |
+            A resource type.
+            Identifies the API resource's type (or _kind_).
+        id:
+          type: string
+          description: |
+            A resource ID.
+            Identifies a specific resource.
+        name:
+          type: string
+          description: |
+            The name of the resource.
+            _Note: not all resource types have a `name` property_.
+        orgID:
+          type: string
+          description: |
+            An organization ID.
+            Identifies the organization that owns the resource.
+        org:
+          type: string
+          description: |
+            An organization name.
+            The organization that owns the resource.
     ResourceMember:
       allOf:
         - $ref: '#/components/schemas/UserResponse'
@@ -16203,30 +16262,6 @@ components:
         series_id_2: '#edf529'
         measurement_birdmigration_europe: '#663cd0'
         configcat_deployments-autopromotionblocker: '#663cd0'
-    AuthorizationPostRequest:
-      required:
-        - orgID
-        - permissions
-      allOf:
-        - $ref: '#/components/schemas/AuthorizationUpdateRequest'
-        - type: object
-          properties:
-            orgID:
-              type: string
-              description: |
-                The ID of the organization that owns the authorization.
-            userID:
-              type: string
-              description: |
-                The ID of the user that the authorization is scoped to.
-            permissions:
-              type: array
-              minItems: 1
-              description: |
-                A list of permissions for an authorization.
-                An authorization must have at least one permission.
-              items:
-                $ref: '#/components/schemas/Permission'
     Permission:
       required:
         - action
@@ -16239,62 +16274,6 @@ components:
             - write
         resource:
           $ref: '#/components/schemas/Resource'
-    Resource:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - authorizations
-            - buckets
-            - dashboards
-            - orgs
-            - tasks
-            - telegrafs
-            - users
-            - variables
-            - secrets
-            - labels
-            - views
-            - documents
-            - notificationRules
-            - notificationEndpoints
-            - checks
-            - dbrp
-            - annotations
-            - sources
-            - scrapers
-            - notebooks
-            - remotes
-            - replications
-            - instance
-            - flows
-            - functions
-            - subscriptions
-          description: |
-            The type of resource.
-            In a `permission`, applies the permission to all resources of this type.
-        id:
-          type: string
-          description: |
-            The ID of a specific resource.
-            In a `permission`, applies the permission to only the resource with this ID.
-        name:
-          type: string
-          description: |
-            Optional: A name for the resource.
-            Not all resource types have a name field.
-        orgID:
-          type: string
-          description: |
-            The ID of the organization that owns the resource.
-            In a `permission`, applies the permission to all resources of `type` owned by this organization.
-        org:
-          type: string
-          description: |
-            Optional: The name of the organization with `orgID`.
     User:
       properties:
         id:
@@ -17056,6 +17035,61 @@ components:
               value:
                 code: not found
                 message: organization not found
+  examples:
+    AuthorizationPostRequest:
+      summary: An authorization for a resource type
+      description: Creates an authorization.
+      value:
+        orgID: INFLUX_ORG_ID
+        description: iot_users read buckets
+        permissions:
+          - action: read
+            resource:
+              type: buckets
+    AuthorizationWithResourcePostRequest:
+      summary: An authorization for a resource
+      description: Creates an authorization for access to a specific resource.
+      value:
+        orgID: INFLUX_ORG_ID
+        description: iot_users read buckets
+        permissions:
+          - action: read
+            resource:
+              type: buckets
+              id: INFLUX_BUCKET_ID
+    AuthorizationWithUserPostRequest:
+      summary: An authorization scoped to a user
+      description: Creates an authorization scoped to a specific user.
+      value:
+        orgID: INFLUX_ORG_ID
+        userID: INFLUX_USER_ID
+        description: iot_user write to bucket
+        permissions:
+          - action: write
+            resource:
+              type: buckets
+              id: INFLUX_BUCKET_ID
+    TaskWithFluxRequest:
+      summary: A task with Flux
+      description: Sets the `flux` property with Flux task options and a query.
+      value:
+        flux: "option task = {name: \"CPU Total 1 Hour New\", every: 1h}from(bucket: \"telegraf\") |> range(start: -1h) |> filter(fn: (r) => (r._measurement == \"cpu\")) |> filter(fn: (r) =>\n\t\t(r._field == \"usage_system\")) |> filter(fn: (r) => (r.cpu == \"cpu-total\")) |> aggregateWindow(every: 1h, fn: max) |> to(bucket: \"cpu_usage_user_total_1h\", org: \"INFLUX_ORG\")"
+        status: active
+        description: This task contains Flux that configures the task schedule and downsamples CPU data every hour.
+    TaskWithScriptRequest:
+      summary: A task with an invokable script
+      description: |
+        Sets properties for a task that runs an _invokable script_.
+      value:
+        name: CPU Total 1 Hour New
+        every: 1h
+        scriptID: SCRIPT_ID
+        scriptParameters:
+          rangeStart: '-1h'
+          bucket: telegraf
+          filterField: cpu-total
+        status: active
+        description: This task runs an invokable script every hour with the defined parameters.
   securitySchemes:
     TokenAuthentication:
       type: apiKey

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -9360,71 +9360,7 @@ components:
                 The list of permissions.
                 An authorization must have at least one permission.
               items:
-                required:
-                  - action
-                  - resource
-                properties:
-                  action:
-                    type: string
-                    enum:
-                      - read
-                      - write
-                  resource:
-                    type: object
-                    required:
-                      - type
-                    properties:
-                      type:
-                        type: string
-                        enum:
-                          - authorizations
-                          - buckets
-                          - dashboards
-                          - orgs
-                          - tasks
-                          - telegrafs
-                          - users
-                          - variables
-                          - secrets
-                          - labels
-                          - views
-                          - documents
-                          - notificationRules
-                          - notificationEndpoints
-                          - checks
-                          - dbrp
-                          - annotations
-                          - sources
-                          - scrapers
-                          - notebooks
-                          - remotes
-                          - replications
-                          - instance
-                          - flows
-                          - functions
-                          - subscriptions
-                        description: |
-                          The type of resource.
-                          In a `permission`, applies the permission to all resources of this type.
-                      id:
-                        type: string
-                        description: |
-                          The ID of a specific resource.
-                          In a `permission`, applies the permission to only the resource with this ID.
-                      name:
-                        type: string
-                        description: |
-                          Optional: A name for the resource.
-                          Not all resource types have a name field.
-                      orgID:
-                        type: string
-                        description: |
-                          The ID of the organization that owns the resource.
-                          In a `permission`, applies the permission to all resources of `type` owned by this organization.
-                      org:
-                        type: string
-                        description: |
-                          Optional: The name of the organization with `orgID`.
+                $ref: '#/components/schemas/Permission'
             id:
               readOnly: true
               type: string
@@ -9481,6 +9417,41 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Authorization'
+    AuthorizationPostRequest:
+      required:
+        - orgID
+        - permissions
+      allOf:
+        - $ref: '#/components/schemas/AuthorizationUpdateRequest'
+        - type: object
+          properties:
+            orgID:
+              type: string
+              description: |
+                An organization ID.
+                Specifies the organization that owns the authorization.
+            userID:
+              type: string
+              description: |
+                A user ID.
+                Specifies the user that the authorization is scoped to.
+
+                When a user authenticates with username and password,
+                InfluxDB generates a _user session_ with all the permissions
+                specified by all the user's authorizations.
+            permissions:
+              type: array
+              minItems: 1
+              description: |
+                A list of permissions for an authorization.
+                In the list, provide at least one `permission` object.
+
+                In a `permission`, the `resource.type` property grants access to all
+                resources of the specified type.
+                To grant access to only a specific resource, specify the
+                `resource.id` property.
+              items:
+                $ref: '#/components/schemas/Permission'
     AuthorizationUpdateRequest:
       properties:
         status:
@@ -11076,6 +11047,63 @@ components:
     Flags:
       type: object
       additionalProperties: true
+    Resource:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - authorizations
+            - buckets
+            - dashboards
+            - orgs
+            - tasks
+            - telegrafs
+            - users
+            - variables
+            - secrets
+            - labels
+            - views
+            - documents
+            - notificationRules
+            - notificationEndpoints
+            - checks
+            - dbrp
+            - annotations
+            - sources
+            - scrapers
+            - notebooks
+            - remotes
+            - replications
+            - instance
+            - flows
+            - functions
+            - subscriptions
+          description: |
+            A resource type.
+            Identifies the API resource's type (or _kind_).
+        id:
+          type: string
+          description: |
+            A resource ID.
+            Identifies a specific resource.
+        name:
+          type: string
+          description: |
+            The name of the resource.
+            _Note: not all resource types have a `name` property_.
+        orgID:
+          type: string
+          description: |
+            An organization ID.
+            Identifies the organization that owns the resource.
+        org:
+          type: string
+          description: |
+            An organization name.
+            The organization that owns the resource.
     ResourceMember:
       allOf:
         - $ref: '#/components/schemas/UserResponse'
@@ -14125,6 +14153,18 @@ components:
         series_id_2: '#edf529'
         measurement_birdmigration_europe: '#663cd0'
         configcat_deployments-autopromotionblocker: '#663cd0'
+    Permission:
+      required:
+        - action
+        - resource
+      properties:
+        action:
+          type: string
+          enum:
+            - read
+            - write
+        resource:
+          $ref: '#/components/schemas/Resource'
   responses:
     AuthorizationError:
       description: |

--- a/contracts/legacy.yml
+++ b/contracts/legacy.yml
@@ -707,27 +707,28 @@ components:
                 - functions
                 - subscriptions
               description: |
-                The type of resource.
-                In a `permission`, applies the permission to all resources of this type.
+                A resource type.
+                Identifies the API resource's type (or _kind_).
             id:
               type: string
               description: |
-                The ID of a specific resource.
-                In a `permission`, applies the permission to only the resource with this ID.
+                A resource ID.
+                Identifies a specific resource.
             name:
               type: string
               description: |
-                Optional: A name for the resource.
-                Not all resource types have a name field.
+                The name of the resource.
+                _Note: not all resource types have a `name` property_.
             orgID:
               type: string
               description: |
-                The ID of the organization that owns the resource.
-                In a `permission`, applies the permission to all resources of `type` owned by this organization.
+                An organization ID.
+                Identifies the organization that owns the resource.
             org:
               type: string
               description: |
-                Optional: The name of the organization with `orgID`.
+                An organization name.
+                The organization that owns the resource.
     Links:
       type: object
       description: |

--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -1335,21 +1335,21 @@ paths:
         - Security and access endpoints
       summary: List authorizations
       description: |
-        Retrieves a list of authorizations.
+        Lists authorizations.
 
         To limit which authorizations are returned, pass query parameters in your request.
         If no query parameters are passed, InfluxDB returns all authorizations.
 
         #### InfluxDB OSS
 
-        - Returns
+        - InfluxDB OSS returns
           [API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token) values in authorizations.
         - If the request uses an  _[operator token](https://docs.influxdata.com/influxdb/latest/security/tokens/#operator-token)_,
           InfluxDB OSS returns authorizations for all organizations in the instance.
 
         #### Required permissions
 
-        - InfluxDB OSS requires an _[operator token](https://docs.influxdata.com/influxdb/latest/security/tokens/#operator-token)_.
+        - An _[operator token](https://docs.influxdata.com/influxdb/latest/security/tokens/#operator-token)_.
 
         #### Related guides
 
@@ -1413,25 +1413,24 @@ paths:
         - Authorizations
       summary: Create an authorization
       description: |
-        Creates an authorization.
+        Creates an authorization and returns the authorization with the
+        generated API [token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token).
 
         Use this endpoint to create an authorization, which generates an API token
         with permissions to `read` or `write` to a specific resource or `type` of resource.
         The response contains the new authorization with the generated API token.
 
-        Keep the following in mind when creating and updating authorizations:
-
-        - To apply a permission to a specific resource, specify the resource `id` field.
-        - To apply a permission to all resources with the type, omit the resource `id`.
-        - To scope an authorization to a specific user, provide the `userID` property.
-
         #### Limitations
+
+        To follow best practices for secure API token generation and retrieval,
+        InfluxDB enforces access restrictions on API tokens.
 
         - In InfluxDB OSS, API tokens are visible to the user who created the authorization and to any
           user with an _[operator token]({{% INFLUXDB_DOCS_URL %}}/security/tokens/#operator-token)_.
+        - You can't update an authorization's permissions.
         - Even if an API token has `read-authorizations` permission, the
           token can't be used to view its authorization details.
-        - Tokens stop working when the user who created the token is deleted.
+        - A token stops working when the user who created the authorization is deleted.
 
         We recommend creating a generic user to create and manage tokens for writing data.
 
@@ -1446,10 +1445,116 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AuthorizationPostRequest'
+              required:
+                - orgID
+                - permissions
+              allOf:
+                - $ref: '#/paths/~1authorizations~1%7BauthID%7D/patch/requestBody/content/application~1json/schema'
+                - type: object
+                  properties:
+                    orgID:
+                      type: string
+                      description: |
+                        An organization ID.
+                        Specifies the organization that owns the authorization.
+                    userID:
+                      type: string
+                      description: |
+                        A user ID.
+                        Specifies the user that the authorization is scoped to.
+
+                        When a user authenticates with username and password,
+                        InfluxDB generates a _user session_ with all the permissions
+                        specified by all the user's authorizations.
+                    permissions:
+                      type: array
+                      minItems: 1
+                      description: |
+                        A list of permissions for an authorization.
+                        In the list, provide at least one `permission` object.
+
+                        In a `permission`, the `resource.type` property grants access to all
+                        resources of the specified type.
+                        To grant access to only a specific resource, specify the
+                        `resource.id` property.
+                      items:
+                        required:
+                          - action
+                          - resource
+                        properties:
+                          action:
+                            type: string
+                            enum:
+                              - read
+                              - write
+                          resource:
+                            type: object
+                            required:
+                              - type
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  - authorizations
+                                  - buckets
+                                  - dashboards
+                                  - orgs
+                                  - tasks
+                                  - telegrafs
+                                  - users
+                                  - variables
+                                  - secrets
+                                  - labels
+                                  - views
+                                  - documents
+                                  - notificationRules
+                                  - notificationEndpoints
+                                  - checks
+                                  - dbrp
+                                  - annotations
+                                  - sources
+                                  - scrapers
+                                  - notebooks
+                                  - remotes
+                                  - replications
+                                  - instance
+                                  - flows
+                                  - functions
+                                  - subscriptions
+                                description: |
+                                  A resource type.
+                                  Identifies the API resource's type (or _kind_).
+                              id:
+                                type: string
+                                description: |
+                                  A resource ID.
+                                  Identifies a specific resource.
+                              name:
+                                type: string
+                                description: |
+                                  The name of the resource.
+                                  _Note: not all resource types have a `name` property_.
+                              orgID:
+                                type: string
+                                description: |
+                                  An organization ID.
+                                  Identifies the organization that owns the resource.
+                              org:
+                                type: string
+                                description: |
+                                  An organization name.
+                                  The organization that owns the resource.
+            examples:
+              AuthorizationPostRequest:
+                $ref: '#/components/examples/AuthorizationPostRequest'
+              AuthorizationWithResourcePostRequest:
+                $ref: '#/components/examples/AuthorizationWithResourcePostRequest'
+              AuthorizationWithUserPostRequest:
+                $ref: '#/components/examples/AuthorizationWithUserPostRequest'
       responses:
         '201':
-          description: Created. The response body contains the newly created authorization.
+          description: |
+            Success. The authorization is created. The response body contains the authorization.
           content:
             application/json:
               schema:
@@ -1464,40 +1569,6 @@ paths:
         default:
           description: Unexpected error
           $ref: '#/paths/~1config/get/responses/401'
-      x-codeSample:
-        - lang: Shell
-          label: 'cURL: Create auth to read all buckets'
-          source: |
-            curl --request POST \
-            "http://localhost:8086/api/v2/authorizations" \
-            --header "Authorization: Token INFLUX_TOKEN" \
-            --header 'Content-Type: application/json' \
-            --data @- << EOF
-              {
-                "orgID": "INFLUX_ORG_ID",
-                "description": "iot_users read buckets",
-                "permissions": [
-                  {"action": "read", "resource": {"type": "buckets"}}
-                ]
-              }
-            EOF
-        - lang: Shell
-        - label: 'cURL: Create auth scoped to a user'
-        - source: |
-            curl --request POST \
-            "http://localhost:8086/api/v2/authorizations" \
-            --header "Authorization: Token INFLUX_TOKEN" \
-            --header 'Content-Type: application/json' \
-            --data @- << EOF
-              {
-                "orgID": "INFLUX_ORG_ID",
-                "userID": "INFLUX_USER_ID",
-                "description": "iot_user write to bucket",
-                "permissions": [
-                  {"action": "write", "resource": {"type": "buckets", "id: "INFLUX_BUCKET_ID"}}
-                ]
-              }
-            EOF
   '/authorizations/{authID}':
     get:
       operationId: GetAuthorizationsID
@@ -1534,7 +1605,17 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AuthorizationPostRequest/allOf/0'
+              properties:
+                status:
+                  description: 'Status of the token. If `inactive`, requests using the token will be rejected.'
+                  default: active
+                  type: string
+                  enum:
+                    - active
+                    - inactive
+                description:
+                  type: string
+                  description: A description of the token.
       parameters:
         - $ref: '#/paths/~1ready/get/parameters/0'
         - in: path
@@ -5381,108 +5462,6 @@ paths:
 components:
   parameters: null
   schemas:
-    AuthorizationPostRequest:
-      required:
-        - orgID
-        - permissions
-      allOf:
-        - properties:
-            status:
-              description: 'Status of the token. If `inactive`, requests using the token will be rejected.'
-              default: active
-              type: string
-              enum:
-                - active
-                - inactive
-            description:
-              type: string
-              description: A description of the token.
-        - type: object
-          properties:
-            orgID:
-              type: string
-              description: |
-                The ID of the organization that owns the authorization.
-            userID:
-              type: string
-              description: |
-                The ID of the user that the authorization is scoped to.
-            permissions:
-              type: array
-              minItems: 1
-              description: |
-                A list of permissions for an authorization.
-                An authorization must have at least one permission.
-              items:
-                $ref: '#/components/schemas/Permission'
-    Permission:
-      required:
-        - action
-        - resource
-      properties:
-        action:
-          type: string
-          enum:
-            - read
-            - write
-        resource:
-          $ref: '#/components/schemas/Resource'
-    Resource:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - authorizations
-            - buckets
-            - dashboards
-            - orgs
-            - tasks
-            - telegrafs
-            - users
-            - variables
-            - secrets
-            - labels
-            - views
-            - documents
-            - notificationRules
-            - notificationEndpoints
-            - checks
-            - dbrp
-            - annotations
-            - sources
-            - scrapers
-            - notebooks
-            - remotes
-            - replications
-            - instance
-            - flows
-            - functions
-            - subscriptions
-          description: |
-            The type of resource.
-            In a `permission`, applies the permission to all resources of this type.
-        id:
-          type: string
-          description: |
-            The ID of a specific resource.
-            In a `permission`, applies the permission to only the resource with this ID.
-        name:
-          type: string
-          description: |
-            Optional: A name for the resource.
-            Not all resource types have a name field.
-        orgID:
-          type: string
-          description: |
-            The ID of the organization that owns the resource.
-            In a `permission`, applies the permission to all resources of `type` owned by this organization.
-        org:
-          type: string
-          description: |
-            Optional: The name of the organization with `orgID`.
     User:
       properties:
         id:
@@ -5756,7 +5735,7 @@ components:
             - orgID
             - permissions
           allOf:
-            - $ref: '#/components/schemas/AuthorizationPostRequest/allOf/0'
+            - $ref: '#/paths/~1authorizations~1%7BauthID%7D/patch/requestBody/content/application~1json/schema'
             - type: object
               properties:
                 createdAt:
@@ -5779,7 +5758,7 @@ components:
                     The list of permissions.
                     An authorization must have at least one permission.
                   items:
-                    $ref: '#/components/schemas/Permission'
+                    $ref: '#/paths/~1authorizations/post/requestBody/content/application~1json/schema/allOf/1/properties/permissions/items'
                 id:
                   readOnly: true
                   type: string
@@ -6610,6 +6589,47 @@ components:
           description: Update the description of the task.
           type: string
   responses: null
+  examples:
+    AuthorizationPostRequest:
+      summary: An authorization for a resource type
+      description: Creates an authorization.
+      value:
+        orgID: INFLUX_ORG_ID
+        description: iot_users read buckets
+        permissions:
+          - action: read
+            resource:
+              type: buckets
+    AuthorizationWithResourcePostRequest:
+      summary: An authorization for a resource
+      description: Creates an authorization for access to a specific resource.
+      value:
+        orgID: INFLUX_ORG_ID
+        description: iot_users read buckets
+        permissions:
+          - action: read
+            resource:
+              type: buckets
+              id: INFLUX_BUCKET_ID
+    AuthorizationWithUserPostRequest:
+      summary: An authorization scoped to a user
+      description: Creates an authorization scoped to a specific user.
+      value:
+        orgID: INFLUX_ORG_ID
+        userID: INFLUX_USER_ID
+        description: iot_user write to bucket
+        permissions:
+          - action: write
+            resource:
+              type: buckets
+              id: INFLUX_BUCKET_ID
+    TaskWithFluxRequest:
+      summary: A task with Flux
+      description: Sets the `flux` property with Flux task options and a query.
+      value:
+        flux: "option task = {name: \"CPU Total 1 Hour New\", every: 1h}from(bucket: \"telegraf\") |> range(start: -1h) |> filter(fn: (r) => (r._measurement == \"cpu\")) |> filter(fn: (r) =>\n\t\t(r._field == \"usage_system\")) |> filter(fn: (r) => (r.cpu == \"cpu-total\")) |> aggregateWindow(every: 1h, fn: max) |> to(bucket: \"cpu_usage_user_total_1h\", org: \"INFLUX_ORG\")"
+        status: active
+        description: This task contains Flux that configures the task schedule and downsamples CPU data every hour.
   securitySchemes:
     TokenAuthentication:
       type: apiKey

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -12456,7 +12456,7 @@
           "Security and access endpoints"
         ],
         "summary": "List authorizations",
-        "description": "Retrieves a list of authorizations.\n\nTo limit which authorizations are returned, pass query parameters in your request.\nIf no query parameters are passed, InfluxDB returns all authorizations.\n\n#### InfluxDB OSS\n\n- Returns\n  [API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token) values in authorizations.\n- If the request uses an  _[operator token](https://docs.influxdata.com/influxdb/latest/security/tokens/#operator-token)_,\n  InfluxDB OSS returns authorizations for all organizations in the instance.\n\n#### Required permissions\n\n- InfluxDB OSS requires an _[operator token](https://docs.influxdata.com/influxdb/latest/security/tokens/#operator-token)_.\n\n#### Related guides\n\n- [View tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens/view-tokens/)\n",
+        "description": "Lists authorizations.\n\nTo limit which authorizations are returned, pass query parameters in your request.\nIf no query parameters are passed, InfluxDB returns all authorizations.\n\n#### InfluxDB OSS\n\n- InfluxDB OSS returns\n  [API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token) values in authorizations.\n- If the request uses an  _[operator token](https://docs.influxdata.com/influxdb/latest/security/tokens/#operator-token)_,\n  InfluxDB OSS returns authorizations for all organizations in the instance.\n\n#### Required permissions\n\n- An _[operator token](https://docs.influxdata.com/influxdb/latest/security/tokens/#operator-token)_.\n\n#### Related guides\n\n- [View tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens/view-tokens/)\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -12527,7 +12527,7 @@
           "Authorizations"
         ],
         "summary": "Create an authorization",
-        "description": "Creates an authorization.\n\nUse this endpoint to create an authorization, which generates an API token\nwith permissions to `read` or `write` to a specific resource or `type` of resource.\nThe response contains the new authorization with the generated API token.\n\nKeep the following in mind when creating and updating authorizations:\n\n- To apply a permission to a specific resource, specify the resource `id` field.\n- To apply a permission to all resources with the type, omit the resource `id`.\n- To scope an authorization to a specific user, provide the `userID` property.\n\n#### Limitations\n\n- In InfluxDB OSS, API tokens are visible to the user who created the authorization and to any\n  user with an _[operator token]({{% INFLUXDB_DOCS_URL %}}/security/tokens/#operator-token)_.\n- Even if an API token has `read-authorizations` permission, the\n  token can't be used to view its authorization details.\n- Tokens stop working when the user who created the token is deleted.\n\nWe recommend creating a generic user to create and manage tokens for writing data.\n\n#### Related guides\n\n- [Create a token]({{% INFLUXDB_DOCS_URL %}}/security/tokens/create-token/)\n",
+        "description": "Creates an authorization and returns the authorization with the\ngenerated API [token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token).\n\nUse this endpoint to create an authorization, which generates an API token\nwith permissions to `read` or `write` to a specific resource or `type` of resource.\nThe response contains the new authorization with the generated API token.\n\n#### Limitations\n\nTo follow best practices for secure API token generation and retrieval,\nInfluxDB enforces access restrictions on API tokens.\n\n- In InfluxDB OSS, API tokens are visible to the user who created the authorization and to any\n  user with an _[operator token]({{% INFLUXDB_DOCS_URL %}}/security/tokens/#operator-token)_.\n- You can't update an authorization's permissions.\n- Even if an API token has `read-authorizations` permission, the\n  token can't be used to view its authorization details.\n- A token stops working when the user who created the authorization is deleted.\n\nWe recommend creating a generic user to create and manage tokens for writing data.\n\n#### Related guides\n\n- [Create a token]({{% INFLUXDB_DOCS_URL %}}/security/tokens/create-token/)\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -12540,13 +12540,24 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/AuthorizationPostRequest"
+              },
+              "examples": {
+                "AuthorizationPostRequest": {
+                  "$ref": "#/components/examples/AuthorizationPostRequest"
+                },
+                "AuthorizationWithResourcePostRequest": {
+                  "$ref": "#/components/examples/AuthorizationWithResourcePostRequest"
+                },
+                "AuthorizationWithUserPostRequest": {
+                  "$ref": "#/components/examples/AuthorizationWithUserPostRequest"
+                }
               }
             }
           }
         },
         "responses": {
           "201": {
-            "description": "Created. The response body contains the newly created authorization.",
+            "description": "Success. The authorization is created. The response body contains the authorization.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -12569,23 +12580,7 @@
             "description": "Unexpected error",
             "$ref": "#/components/responses/GeneralServerError"
           }
-        },
-        "x-codeSample": [
-          {
-            "lang": "Shell",
-            "label": "cURL: Create auth to read all buckets",
-            "source": "curl --request POST \\\n\"http://localhost:8086/api/v2/authorizations\" \\\n--header \"Authorization: Token INFLUX_TOKEN\" \\\n--header 'Content-Type: application/json' \\\n--data @- << EOF\n  {\n    \"orgID\": \"INFLUX_ORG_ID\",\n    \"description\": \"iot_users read buckets\",\n    \"permissions\": [\n      {\"action\": \"read\", \"resource\": {\"type\": \"buckets\"}}\n    ]\n  }\nEOF\n"
-          },
-          {
-            "lang": "Shell"
-          },
-          {
-            "label": "cURL: Create auth scoped to a user"
-          },
-          {
-            "source": "curl --request POST \\\n\"http://localhost:8086/api/v2/authorizations\" \\\n--header \"Authorization: Token INFLUX_TOKEN\" \\\n--header 'Content-Type: application/json' \\\n--data @- << EOF\n  {\n    \"orgID\": \"INFLUX_ORG_ID\",\n    \"userID\": \"INFLUX_USER_ID\",\n    \"description\": \"iot_user write to bucket\",\n    \"permissions\": [\n      {\"action\": \"write\", \"resource\": {\"type\": \"buckets\", \"id: \"INFLUX_BUCKET_ID\"}}\n    ]\n  }\nEOF\n"
-          }
-        ]
+        }
       }
     },
     "/authorizations/{authID}": {
@@ -16622,6 +16617,38 @@
           }
         }
       },
+      "AuthorizationPostRequest": {
+        "required": [
+          "orgID",
+          "permissions"
+        ],
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AuthorizationUpdateRequest"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "orgID": {
+                "type": "string",
+                "description": "An organization ID.\nSpecifies the organization that owns the authorization.\n"
+              },
+              "userID": {
+                "type": "string",
+                "description": "A user ID.\nSpecifies the user that the authorization is scoped to.\n\nWhen a user authenticates with username and password,\nInfluxDB generates a _user session_ with all the permissions\nspecified by all the user's authorizations.\n"
+              },
+              "permissions": {
+                "type": "array",
+                "minItems": 1,
+                "description": "A list of permissions for an authorization.\nIn the list, provide at least one `permission` object.\n\nIn a `permission`, the `resource.type` property grants access to all\nresources of the specified type.\nTo grant access to only a specific resource, specify the\n`resource.id` property.\n",
+                "items": {
+                  "$ref": "#/components/schemas/Permission"
+                }
+              }
+            }
+          }
+        ]
+      },
       "AuthorizationUpdateRequest": {
         "properties": {
           "status": {
@@ -18676,6 +18703,62 @@
       "Flags": {
         "type": "object",
         "additionalProperties": true
+      },
+      "Resource": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "authorizations",
+              "buckets",
+              "dashboards",
+              "orgs",
+              "tasks",
+              "telegrafs",
+              "users",
+              "variables",
+              "secrets",
+              "labels",
+              "views",
+              "documents",
+              "notificationRules",
+              "notificationEndpoints",
+              "checks",
+              "dbrp",
+              "annotations",
+              "sources",
+              "scrapers",
+              "notebooks",
+              "remotes",
+              "replications",
+              "instance",
+              "flows",
+              "functions",
+              "subscriptions"
+            ],
+            "description": "A resource type.\nIdentifies the API resource's type (or _kind_).\n"
+          },
+          "id": {
+            "type": "string",
+            "description": "A resource ID.\nIdentifies a specific resource.\n"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the resource.\n_Note: not all resource types have a `name` property_.\n"
+          },
+          "orgID": {
+            "type": "string",
+            "description": "An organization ID.\nIdentifies the organization that owns the resource.\n"
+          },
+          "org": {
+            "type": "string",
+            "description": "An organization name.\nThe organization that owns the resource.\n"
+          }
+        }
       },
       "ResourceMember": {
         "allOf": [
@@ -23151,38 +23234,6 @@
           "configcat_deployments-autopromotionblocker": "#663cd0"
         }
       },
-      "AuthorizationPostRequest": {
-        "required": [
-          "orgID",
-          "permissions"
-        ],
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/AuthorizationUpdateRequest"
-          },
-          {
-            "type": "object",
-            "properties": {
-              "orgID": {
-                "type": "string",
-                "description": "The ID of the organization that owns the authorization.\n"
-              },
-              "userID": {
-                "type": "string",
-                "description": "The ID of the user that the authorization is scoped to.\n"
-              },
-              "permissions": {
-                "type": "array",
-                "minItems": 1,
-                "description": "A list of permissions for an authorization.\nAn authorization must have at least one permission.\n",
-                "items": {
-                  "$ref": "#/components/schemas/Permission"
-                }
-              }
-            }
-          }
-        ]
-      },
       "Permission": {
         "required": [
           "action",
@@ -23198,62 +23249,6 @@
           },
           "resource": {
             "$ref": "#/components/schemas/Resource"
-          }
-        }
-      },
-      "Resource": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "authorizations",
-              "buckets",
-              "dashboards",
-              "orgs",
-              "tasks",
-              "telegrafs",
-              "users",
-              "variables",
-              "secrets",
-              "labels",
-              "views",
-              "documents",
-              "notificationRules",
-              "notificationEndpoints",
-              "checks",
-              "dbrp",
-              "annotations",
-              "sources",
-              "scrapers",
-              "notebooks",
-              "remotes",
-              "replications",
-              "instance",
-              "flows",
-              "functions",
-              "subscriptions"
-            ],
-            "description": "The type of resource.\nIn a `permission`, applies the permission to all resources of this type.\n"
-          },
-          "id": {
-            "type": "string",
-            "description": "The ID of a specific resource.\nIn a `permission`, applies the permission to only the resource with this ID.\n"
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional: A name for the resource.\nNot all resource types have a name field.\n"
-          },
-          "orgID": {
-            "type": "string",
-            "description": "The ID of the organization that owns the resource.\nIn a `permission`, applies the permission to all resources of `type` owned by this organization.\n"
-          },
-          "org": {
-            "type": "string",
-            "description": "Optional: The name of the organization with `orgID`.\n"
           }
         }
       },
@@ -24497,6 +24492,68 @@
               }
             }
           }
+        }
+      }
+    },
+    "examples": {
+      "AuthorizationPostRequest": {
+        "summary": "An authorization for a resource type",
+        "description": "Creates an authorization.",
+        "value": {
+          "orgID": "INFLUX_ORG_ID",
+          "description": "iot_users read buckets",
+          "permissions": [
+            {
+              "action": "read",
+              "resource": {
+                "type": "buckets"
+              }
+            }
+          ]
+        }
+      },
+      "AuthorizationWithResourcePostRequest": {
+        "summary": "An authorization for a resource",
+        "description": "Creates an authorization for access to a specific resource.",
+        "value": {
+          "orgID": "INFLUX_ORG_ID",
+          "description": "iot_users read buckets",
+          "permissions": [
+            {
+              "action": "read",
+              "resource": {
+                "type": "buckets",
+                "id": "INFLUX_BUCKET_ID"
+              }
+            }
+          ]
+        }
+      },
+      "AuthorizationWithUserPostRequest": {
+        "summary": "An authorization scoped to a user",
+        "description": "Creates an authorization scoped to a specific user.",
+        "value": {
+          "orgID": "INFLUX_ORG_ID",
+          "userID": "INFLUX_USER_ID",
+          "description": "iot_user write to bucket",
+          "permissions": [
+            {
+              "action": "write",
+              "resource": {
+                "type": "buckets",
+                "id": "INFLUX_BUCKET_ID"
+              }
+            }
+          ]
+        }
+      },
+      "TaskWithFluxRequest": {
+        "summary": "A task with Flux",
+        "description": "Sets the `flux` property with Flux task options and a query.",
+        "value": {
+          "flux": "option task = {name: \"CPU Total 1 Hour New\", every: 1h}from(bucket: \"telegraf\") |> range(start: -1h) |> filter(fn: (r) => (r._measurement == \"cpu\")) |> filter(fn: (r) =>\n\t\t(r._field == \"usage_system\")) |> filter(fn: (r) => (r.cpu == \"cpu-total\")) |> aggregateWindow(every: 1h, fn: max) |> to(bucket: \"cpu_usage_user_total_1h\", org: \"INFLUX_ORG\")",
+          "status": "active",
+          "description": "This task contains Flux that configures the task schedule and downsamples CPU data every hour."
         }
       }
     },

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -10150,21 +10150,21 @@ paths:
         - Security and access endpoints
       summary: List authorizations
       description: |
-        Retrieves a list of authorizations.
+        Lists authorizations.
 
         To limit which authorizations are returned, pass query parameters in your request.
         If no query parameters are passed, InfluxDB returns all authorizations.
 
         #### InfluxDB OSS
 
-        - Returns
+        - InfluxDB OSS returns
           [API token](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#token) values in authorizations.
         - If the request uses an  _[operator token](https://docs.influxdata.com/influxdb/latest/security/tokens/#operator-token)_,
           InfluxDB OSS returns authorizations for all organizations in the instance.
 
         #### Required permissions
 
-        - InfluxDB OSS requires an _[operator token](https://docs.influxdata.com/influxdb/latest/security/tokens/#operator-token)_.
+        - An _[operator token](https://docs.influxdata.com/influxdb/latest/security/tokens/#operator-token)_.
 
         #### Related guides
 
@@ -10220,25 +10220,24 @@ paths:
         - Authorizations
       summary: Create an authorization
       description: |
-        Creates an authorization.
+        Creates an authorization and returns the authorization with the
+        generated API [token](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#token).
 
         Use this endpoint to create an authorization, which generates an API token
         with permissions to `read` or `write` to a specific resource or `type` of resource.
         The response contains the new authorization with the generated API token.
 
-        Keep the following in mind when creating and updating authorizations:
-
-        - To apply a permission to a specific resource, specify the resource `id` field.
-        - To apply a permission to all resources with the type, omit the resource `id`.
-        - To scope an authorization to a specific user, provide the `userID` property.
-
         #### Limitations
+
+        To follow best practices for secure API token generation and retrieval,
+        InfluxDB enforces access restrictions on API tokens.
 
         - In InfluxDB OSS, API tokens are visible to the user who created the authorization and to any
           user with an _[operator token](https://docs.influxdata.com/influxdb/v2.3/security/tokens/#operator-token)_.
+        - You can't update an authorization's permissions.
         - Even if an API token has `read-authorizations` permission, the
           token can't be used to view its authorization details.
-        - Tokens stop working when the user who created the token is deleted.
+        - A token stops working when the user who created the authorization is deleted.
 
         We recommend creating a generic user to create and manage tokens for writing data.
 
@@ -10254,9 +10253,17 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/AuthorizationPostRequest'
+            examples:
+              AuthorizationPostRequest:
+                $ref: '#/components/examples/AuthorizationPostRequest'
+              AuthorizationWithResourcePostRequest:
+                $ref: '#/components/examples/AuthorizationWithResourcePostRequest'
+              AuthorizationWithUserPostRequest:
+                $ref: '#/components/examples/AuthorizationWithUserPostRequest'
       responses:
         '201':
-          description: Created. The response body contains the newly created authorization.
+          description: |
+            Success. The authorization is created. The response body contains the authorization.
           content:
             application/json:
               schema:
@@ -10271,40 +10278,6 @@ paths:
         default:
           description: Unexpected error
           $ref: '#/components/responses/GeneralServerError'
-      x-codeSample:
-        - lang: Shell
-          label: 'cURL: Create auth to read all buckets'
-          source: |
-            curl --request POST \
-            "http://localhost:8086/api/v2/authorizations" \
-            --header "Authorization: Token INFLUX_TOKEN" \
-            --header 'Content-Type: application/json' \
-            --data @- << EOF
-              {
-                "orgID": "INFLUX_ORG_ID",
-                "description": "iot_users read buckets",
-                "permissions": [
-                  {"action": "read", "resource": {"type": "buckets"}}
-                ]
-              }
-            EOF
-        - lang: Shell
-        - label: 'cURL: Create auth scoped to a user'
-        - source: |
-            curl --request POST \
-            "http://localhost:8086/api/v2/authorizations" \
-            --header "Authorization: Token INFLUX_TOKEN" \
-            --header 'Content-Type: application/json' \
-            --data @- << EOF
-              {
-                "orgID": "INFLUX_ORG_ID",
-                "userID": "INFLUX_USER_ID",
-                "description": "iot_user write to bucket",
-                "permissions": [
-                  {"action": "write", "resource": {"type": "buckets", "id: "INFLUX_BUCKET_ID"}}
-                ]
-              }
-            EOF
   '/authorizations/{authID}':
     get:
       operationId: GetAuthorizationsID
@@ -13041,6 +13014,41 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Authorization'
+    AuthorizationPostRequest:
+      required:
+        - orgID
+        - permissions
+      allOf:
+        - $ref: '#/components/schemas/AuthorizationUpdateRequest'
+        - type: object
+          properties:
+            orgID:
+              type: string
+              description: |
+                An organization ID.
+                Specifies the organization that owns the authorization.
+            userID:
+              type: string
+              description: |
+                A user ID.
+                Specifies the user that the authorization is scoped to.
+
+                When a user authenticates with username and password,
+                InfluxDB generates a _user session_ with all the permissions
+                specified by all the user's authorizations.
+            permissions:
+              type: array
+              minItems: 1
+              description: |
+                A list of permissions for an authorization.
+                In the list, provide at least one `permission` object.
+
+                In a `permission`, the `resource.type` property grants access to all
+                resources of the specified type.
+                To grant access to only a specific resource, specify the
+                `resource.id` property.
+              items:
+                $ref: '#/components/schemas/Permission'
     AuthorizationUpdateRequest:
       properties:
         status:
@@ -14636,6 +14644,63 @@ components:
     Flags:
       type: object
       additionalProperties: true
+    Resource:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - authorizations
+            - buckets
+            - dashboards
+            - orgs
+            - tasks
+            - telegrafs
+            - users
+            - variables
+            - secrets
+            - labels
+            - views
+            - documents
+            - notificationRules
+            - notificationEndpoints
+            - checks
+            - dbrp
+            - annotations
+            - sources
+            - scrapers
+            - notebooks
+            - remotes
+            - replications
+            - instance
+            - flows
+            - functions
+            - subscriptions
+          description: |
+            A resource type.
+            Identifies the API resource's type (or _kind_).
+        id:
+          type: string
+          description: |
+            A resource ID.
+            Identifies a specific resource.
+        name:
+          type: string
+          description: |
+            The name of the resource.
+            _Note: not all resource types have a `name` property_.
+        orgID:
+          type: string
+          description: |
+            An organization ID.
+            Identifies the organization that owns the resource.
+        org:
+          type: string
+          description: |
+            An organization name.
+            The organization that owns the resource.
     ResourceMember:
       allOf:
         - $ref: '#/components/schemas/UserResponse'
@@ -17685,30 +17750,6 @@ components:
         series_id_2: '#edf529'
         measurement_birdmigration_europe: '#663cd0'
         configcat_deployments-autopromotionblocker: '#663cd0'
-    AuthorizationPostRequest:
-      required:
-        - orgID
-        - permissions
-      allOf:
-        - $ref: '#/components/schemas/AuthorizationUpdateRequest'
-        - type: object
-          properties:
-            orgID:
-              type: string
-              description: |
-                The ID of the organization that owns the authorization.
-            userID:
-              type: string
-              description: |
-                The ID of the user that the authorization is scoped to.
-            permissions:
-              type: array
-              minItems: 1
-              description: |
-                A list of permissions for an authorization.
-                An authorization must have at least one permission.
-              items:
-                $ref: '#/components/schemas/Permission'
     Permission:
       required:
         - action
@@ -17721,62 +17762,6 @@ components:
             - write
         resource:
           $ref: '#/components/schemas/Resource'
-    Resource:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - authorizations
-            - buckets
-            - dashboards
-            - orgs
-            - tasks
-            - telegrafs
-            - users
-            - variables
-            - secrets
-            - labels
-            - views
-            - documents
-            - notificationRules
-            - notificationEndpoints
-            - checks
-            - dbrp
-            - annotations
-            - sources
-            - scrapers
-            - notebooks
-            - remotes
-            - replications
-            - instance
-            - flows
-            - functions
-            - subscriptions
-          description: |
-            The type of resource.
-            In a `permission`, applies the permission to all resources of this type.
-        id:
-          type: string
-          description: |
-            The ID of a specific resource.
-            In a `permission`, applies the permission to only the resource with this ID.
-        name:
-          type: string
-          description: |
-            Optional: A name for the resource.
-            Not all resource types have a name field.
-        orgID:
-          type: string
-          description: |
-            The ID of the organization that owns the resource.
-            In a `permission`, applies the permission to all resources of `type` owned by this organization.
-        org:
-          type: string
-          description: |
-            Optional: The name of the organization with `orgID`.
     User:
       properties:
         id:
@@ -18684,6 +18669,47 @@ components:
               value:
                 code: not found
                 message: organization not found
+  examples:
+    AuthorizationPostRequest:
+      summary: An authorization for a resource type
+      description: Creates an authorization.
+      value:
+        orgID: INFLUX_ORG_ID
+        description: iot_users read buckets
+        permissions:
+          - action: read
+            resource:
+              type: buckets
+    AuthorizationWithResourcePostRequest:
+      summary: An authorization for a resource
+      description: Creates an authorization for access to a specific resource.
+      value:
+        orgID: INFLUX_ORG_ID
+        description: iot_users read buckets
+        permissions:
+          - action: read
+            resource:
+              type: buckets
+              id: INFLUX_BUCKET_ID
+    AuthorizationWithUserPostRequest:
+      summary: An authorization scoped to a user
+      description: Creates an authorization scoped to a specific user.
+      value:
+        orgID: INFLUX_ORG_ID
+        userID: INFLUX_USER_ID
+        description: iot_user write to bucket
+        permissions:
+          - action: write
+            resource:
+              type: buckets
+              id: INFLUX_BUCKET_ID
+    TaskWithFluxRequest:
+      summary: A task with Flux
+      description: Sets the `flux` property with Flux task options and a query.
+      value:
+        flux: "option task = {name: \"CPU Total 1 Hour New\", every: 1h}from(bucket: \"telegraf\") |> range(start: -1h) |> filter(fn: (r) => (r._measurement == \"cpu\")) |> filter(fn: (r) =>\n\t\t(r._field == \"usage_system\")) |> filter(fn: (r) => (r.cpu == \"cpu-total\")) |> aggregateWindow(every: 1h, fn: max) |> to(bucket: \"cpu_usage_user_total_1h\", org: \"INFLUX_ORG\")"
+        status: active
+        description: This task contains Flux that configures the task schedule and downsamples CPU data every hour.
   securitySchemes:
     TokenAuthentication:
       type: apiKey

--- a/contracts/priv/cloud-priv.yml
+++ b/contracts/priv/cloud-priv.yml
@@ -958,27 +958,28 @@ components:
                               - functions
                               - subscriptions
                             description: |
-                              The type of resource.
-                              In a `permission`, applies the permission to all resources of this type.
+                              A resource type.
+                              Identifies the API resource's type (or _kind_).
                           id:
                             type: string
                             description: |
-                              The ID of a specific resource.
-                              In a `permission`, applies the permission to only the resource with this ID.
+                              A resource ID.
+                              Identifies a specific resource.
                           name:
                             type: string
                             description: |
-                              Optional: A name for the resource.
-                              Not all resource types have a name field.
+                              The name of the resource.
+                              _Note: not all resource types have a `name` property_.
                           orgID:
                             type: string
                             description: |
-                              The ID of the organization that owns the resource.
-                              In a `permission`, applies the permission to all resources of `type` owned by this organization.
+                              An organization ID.
+                              Identifies the organization that owns the resource.
                           org:
                             type: string
                             description: |
-                              Optional: The name of the organization with `orgID`.
+                              An organization name.
+                              The organization that owns the resource.
                 id:
                   readOnly: true
                   type: string

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -1,4 +1,65 @@
 components:
+  examples:
+    AuthorizationPostRequest:
+      description: Creates an authorization.
+      summary: An authorization for a resource type
+      value:
+        description: iot_users read buckets
+        orgID: INFLUX_ORG_ID
+        permissions:
+        - action: read
+          resource:
+            type: buckets
+    AuthorizationWithResourcePostRequest:
+      description: Creates an authorization for access to a specific resource.
+      summary: An authorization for a resource
+      value:
+        description: iot_users read buckets
+        orgID: INFLUX_ORG_ID
+        permissions:
+        - action: read
+          resource:
+            id: INFLUX_BUCKET_ID
+            type: buckets
+    AuthorizationWithUserPostRequest:
+      description: Creates an authorization scoped to a specific user.
+      summary: An authorization scoped to a user
+      value:
+        description: iot_user write to bucket
+        orgID: INFLUX_ORG_ID
+        permissions:
+        - action: write
+          resource:
+            id: INFLUX_BUCKET_ID
+            type: buckets
+        userID: INFLUX_USER_ID
+    TaskWithFluxRequest:
+      description: Sets the `flux` property with Flux task options and a query.
+      summary: A task with Flux
+      value:
+        description: This task contains Flux that configures the task schedule and
+          downsamples CPU data every hour.
+        flux: "option task = {name: \"CPU Total 1 Hour New\", every: 1h}from(bucket:
+          \"telegraf\") |> range(start: -1h) |> filter(fn: (r) => (r._measurement
+          == \"cpu\")) |> filter(fn: (r) =>\n\t\t(r._field == \"usage_system\")) |>
+          filter(fn: (r) => (r.cpu == \"cpu-total\")) |> aggregateWindow(every: 1h,
+          fn: max) |> to(bucket: \"cpu_usage_user_total_1h\", org: \"INFLUX_ORG\")"
+        status: active
+    TaskWithScriptRequest:
+      description: |
+        Sets properties for a task that runs an _invokable script_.
+      summary: A task with an invokable script
+      value:
+        description: This task runs an invokable script every hour with the defined
+          parameters.
+        every: 1h
+        name: CPU Total 1 Hour New
+        scriptID: SCRIPT_ID
+        scriptParameters:
+          bucket: telegraf
+          filterField: cpu-total
+          rangeStart: -1h
+        status: active
   parameters:
     After:
       description: |
@@ -290,19 +351,30 @@ components:
       - properties:
           orgID:
             description: |
-              The ID of the organization that owns the authorization.
+              An organization ID.
+              Specifies the organization that owns the authorization.
             type: string
           permissions:
             description: |
               A list of permissions for an authorization.
-              An authorization must have at least one permission.
+              In the list, provide at least one `permission` object.
+
+              In a `permission`, the `resource.type` property grants access to all
+              resources of the specified type.
+              To grant access to only a specific resource, specify the
+              `resource.id` property.
             items:
               $ref: '#/components/schemas/Permission'
             minItems: 1
             type: array
           userID:
             description: |
-              The ID of the user that the authorization is scoped to.
+              A user ID.
+              Specifies the user that the authorization is scoped to.
+
+              When a user authenticates with username and password,
+              InfluxDB generates a _user session_ with all the permissions
+              specified by all the user's authorizations.
             type: string
         type: object
       required:
@@ -3503,27 +3575,28 @@ components:
           properties:
             id:
               description: |
-                The ID of a specific resource.
-                In a `permission`, applies the permission to only the resource with this ID.
+                A resource ID.
+                Identifies a specific resource.
               type: string
             name:
               description: |
-                Optional: A name for the resource.
-                Not all resource types have a name field.
+                The name of the resource.
+                _Note: not all resource types have a `name` property_.
               type: string
             org:
               description: |
-                Optional: The name of the organization with `orgID`.
+                An organization name.
+                The organization that owns the resource.
               type: string
             orgID:
               description: |
-                The ID of the organization that owns the resource.
-                In a `permission`, applies the permission to all resources of `type` owned by this organization.
+                An organization ID.
+                Identifies the organization that owns the resource.
               type: string
             type:
               description: |
-                The type of resource.
-                In a `permission`, applies the permission to all resources of this type.
+                A resource type.
+                Identifies the API resource's type (or _kind_).
               enum:
               - authorizations
               - buckets
@@ -3793,27 +3866,28 @@ components:
       properties:
         id:
           description: |
-            The ID of a specific resource.
-            In a `permission`, applies the permission to only the resource with this ID.
+            A resource ID.
+            Identifies a specific resource.
           type: string
         name:
           description: |
-            Optional: A name for the resource.
-            Not all resource types have a name field.
+            The name of the resource.
+            _Note: not all resource types have a `name` property_.
           type: string
         org:
           description: |
-            Optional: The name of the organization with `orgID`.
+            An organization name.
+            The organization that owns the resource.
           type: string
         orgID:
           description: |
-            The ID of the organization that owns the resource.
-            In a `permission`, applies the permission to all resources of `type` owned by this organization.
+            An organization ID.
+            Identifies the organization that owns the resource.
           type: string
         type:
           description: |
-            The type of resource.
-            In a `permission`, applies the permission to all resources of this type.
+            A resource type.
+            Identifies the API resource's type (or _kind_).
           enum:
           - authorizations
           - buckets
@@ -6688,7 +6762,7 @@ paths:
   /api/v2/authorizations:
     get:
       description: |
-        Retrieves a list of authorizations.
+        Lists authorizations.
 
         To limit which authorizations are returned, pass query parameters in your request.
         If no query parameters are passed, InfluxDB returns all authorizations for the organization.
@@ -6699,7 +6773,7 @@ paths:
           values in `GET /api/v2/authorizations` responses;
           returns `token: redacted` for all authorizations.
 
-        #### Required permissions for InfluxDB Cloud
+        #### Required permissions
 
         - `read-authorizations`
 
@@ -6776,20 +6850,14 @@ paths:
         Use this endpoint to create an authorization, which generates an API token
         with permissions to `read` or `write` to a specific resource or `type` of resource.
 
-        Keep the following in mind when creating and updating authorizations:
-
-        - To apply a permission to a specific resource, specify the resource `id` field.
-        - To apply a permission to all resources with the type, omit the resource `id`.
-        - To scope an authorization to a specific user, provide the `userID` property.
-
         #### Limitations
 
         To follow best practices for secure API token generation and retrieval,
         InfluxDB Cloud enforces access restrictions on API tokens.
 
-        - InfluxDB Cloud only allows access to the API token value immediately after the authorization is created.
-        - You can’t change access (read/write) permissions for an API token after it’s created.
-        - Tokens stop working when the user who created the token is deleted.
+        - InfluxDB only allows access to the API token value immediately after the authorization is created.
+        - You can't update an authorization's permissions.
+        - A token stops working when the user who created the authorization is deleted.
 
         We recommend the following for managing your tokens:
 
@@ -6805,6 +6873,13 @@ paths:
       requestBody:
         content:
           application/json:
+            examples:
+              AuthorizationPostRequest:
+                $ref: '#/components/examples/AuthorizationPostRequest'
+              AuthorizationWithResourcePostRequest:
+                $ref: '#/components/examples/AuthorizationWithResourcePostRequest'
+              AuthorizationWithUserPostRequest:
+                $ref: '#/components/examples/AuthorizationWithUserPostRequest'
             schema:
               $ref: '#/components/schemas/AuthorizationPostRequest'
         description: The authorization to create.
@@ -6830,40 +6905,6 @@ paths:
       summary: Create an authorization
       tags:
       - Authorizations
-      x-codeSample:
-      - label: 'cURL: Create auth to read all buckets'
-        lang: Shell
-        source: |
-          curl --request POST \
-          "http://localhost:8086/api/v2/authorizations" \
-          --header "Authorization: Token INFLUX_API_TOKEN" \
-          --header 'Content-Type: application/json' \
-          --data @- << EOF
-            {
-              "orgID": "INFLUX_ORG_ID",
-              "description": "iot_users read buckets",
-              "permissions": [
-                {"action": "read", "resource": {"type": "buckets"}}
-              ]
-            }
-          EOF
-      - label: 'cURL: Create auth scoped to a user'
-        lang: Shell
-        source: |
-          curl --request POST \
-          "http://localhost:8086/api/v2/authorizations" \
-          --header "Authorization: Token INFLUX_API_TOKEN" \
-          --header 'Content-Type: application/json' \
-          --data @- << EOF
-            {
-              "orgID": "INFLUX_ORG_ID",
-              "userID": "INFLUX_USER_ID",
-              "description": "iot_user write to bucket",
-              "permissions": [
-                {"action": "write", "resource": {"type": "buckets", "id: "INFLUX_BUCKET_ID"}}
-              ]
-            }
-          EOF
   /api/v2/authorizations/{authID}:
     delete:
       operationId: DeleteAuthorizationsID

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -1,4 +1,50 @@
 components:
+  examples:
+    AuthorizationPostRequest:
+      description: Creates an authorization.
+      summary: An authorization for a resource type
+      value:
+        description: iot_users read buckets
+        orgID: INFLUX_ORG_ID
+        permissions:
+        - action: read
+          resource:
+            type: buckets
+    AuthorizationWithResourcePostRequest:
+      description: Creates an authorization for access to a specific resource.
+      summary: An authorization for a resource
+      value:
+        description: iot_users read buckets
+        orgID: INFLUX_ORG_ID
+        permissions:
+        - action: read
+          resource:
+            id: INFLUX_BUCKET_ID
+            type: buckets
+    AuthorizationWithUserPostRequest:
+      description: Creates an authorization scoped to a specific user.
+      summary: An authorization scoped to a user
+      value:
+        description: iot_user write to bucket
+        orgID: INFLUX_ORG_ID
+        permissions:
+        - action: write
+          resource:
+            id: INFLUX_BUCKET_ID
+            type: buckets
+        userID: INFLUX_USER_ID
+    TaskWithFluxRequest:
+      description: Sets the `flux` property with Flux task options and a query.
+      summary: A task with Flux
+      value:
+        description: This task contains Flux that configures the task schedule and
+          downsamples CPU data every hour.
+        flux: "option task = {name: \"CPU Total 1 Hour New\", every: 1h}from(bucket:
+          \"telegraf\") |> range(start: -1h) |> filter(fn: (r) => (r._measurement
+          == \"cpu\")) |> filter(fn: (r) =>\n\t\t(r._field == \"usage_system\")) |>
+          filter(fn: (r) => (r.cpu == \"cpu-total\")) |> aggregateWindow(every: 1h,
+          fn: max) |> to(bucket: \"cpu_usage_user_total_1h\", org: \"INFLUX_ORG\")"
+        status: active
   parameters:
     After:
       description: |
@@ -290,19 +336,30 @@ components:
       - properties:
           orgID:
             description: |
-              The ID of the organization that owns the authorization.
+              An organization ID.
+              Specifies the organization that owns the authorization.
             type: string
           permissions:
             description: |
               A list of permissions for an authorization.
-              An authorization must have at least one permission.
+              In the list, provide at least one `permission` object.
+
+              In a `permission`, the `resource.type` property grants access to all
+              resources of the specified type.
+              To grant access to only a specific resource, specify the
+              `resource.id` property.
             items:
               $ref: '#/components/schemas/Permission'
             minItems: 1
             type: array
           userID:
             description: |
-              The ID of the user that the authorization is scoped to.
+              A user ID.
+              Specifies the user that the authorization is scoped to.
+
+              When a user authenticates with username and password,
+              InfluxDB generates a _user session_ with all the permissions
+              specified by all the user's authorizations.
             type: string
         type: object
       required:
@@ -3287,27 +3344,28 @@ components:
           properties:
             id:
               description: |
-                The ID of a specific resource.
-                In a `permission`, applies the permission to only the resource with this ID.
+                A resource ID.
+                Identifies a specific resource.
               type: string
             name:
               description: |
-                Optional: A name for the resource.
-                Not all resource types have a name field.
+                The name of the resource.
+                _Note: not all resource types have a `name` property_.
               type: string
             org:
               description: |
-                Optional: The name of the organization with `orgID`.
+                An organization name.
+                The organization that owns the resource.
               type: string
             orgID:
               description: |
-                The ID of the organization that owns the resource.
-                In a `permission`, applies the permission to all resources of `type` owned by this organization.
+                An organization ID.
+                Identifies the organization that owns the resource.
               type: string
             type:
               description: |
-                The type of resource.
-                In a `permission`, applies the permission to all resources of this type.
+                A resource type.
+                Identifies the API resource's type (or _kind_).
               enum:
               - authorizations
               - buckets
@@ -3757,27 +3815,28 @@ components:
       properties:
         id:
           description: |
-            The ID of a specific resource.
-            In a `permission`, applies the permission to only the resource with this ID.
+            A resource ID.
+            Identifies a specific resource.
           type: string
         name:
           description: |
-            Optional: A name for the resource.
-            Not all resource types have a name field.
+            The name of the resource.
+            _Note: not all resource types have a `name` property_.
           type: string
         org:
           description: |
-            Optional: The name of the organization with `orgID`.
+            An organization name.
+            The organization that owns the resource.
           type: string
         orgID:
           description: |
-            The ID of the organization that owns the resource.
-            In a `permission`, applies the permission to all resources of `type` owned by this organization.
+            An organization ID.
+            Identifies the organization that owns the resource.
           type: string
         type:
           description: |
-            The type of resource.
-            In a `permission`, applies the permission to all resources of this type.
+            A resource type.
+            Identifies the API resource's type (or _kind_).
           enum:
           - authorizations
           - buckets
@@ -6734,21 +6793,21 @@ paths:
   /api/v2/authorizations:
     get:
       description: |
-        Retrieves a list of authorizations.
+        Lists authorizations.
 
         To limit which authorizations are returned, pass query parameters in your request.
         If no query parameters are passed, InfluxDB returns all authorizations.
 
         #### InfluxDB OSS
 
-        - Returns
+        - InfluxDB OSS returns
           [API token](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#token) values in authorizations.
         - If the request uses an  _[operator token](https://docs.influxdata.com/influxdb/latest/security/tokens/#operator-token)_,
           InfluxDB OSS returns authorizations for all organizations in the instance.
 
         #### Required permissions
 
-        - InfluxDB OSS requires an _[operator token](https://docs.influxdata.com/influxdb/latest/security/tokens/#operator-token)_.
+        - An _[operator token](https://docs.influxdata.com/influxdb/latest/security/tokens/#operator-token)_.
 
         #### Related guides
 
@@ -6806,25 +6865,24 @@ paths:
       - Security and access endpoints
     post:
       description: |
-        Creates an authorization.
+        Creates an authorization and returns the authorization with the
+        generated API [token](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#token).
 
         Use this endpoint to create an authorization, which generates an API token
         with permissions to `read` or `write` to a specific resource or `type` of resource.
         The response contains the new authorization with the generated API token.
 
-        Keep the following in mind when creating and updating authorizations:
-
-        - To apply a permission to a specific resource, specify the resource `id` field.
-        - To apply a permission to all resources with the type, omit the resource `id`.
-        - To scope an authorization to a specific user, provide the `userID` property.
-
         #### Limitations
+
+        To follow best practices for secure API token generation and retrieval,
+        InfluxDB enforces access restrictions on API tokens.
 
         - In InfluxDB OSS, API tokens are visible to the user who created the authorization and to any
           user with an _[operator token](https://docs.influxdata.com/influxdb/v2.3/security/tokens/#operator-token)_.
+        - You can't update an authorization's permissions.
         - Even if an API token has `read-authorizations` permission, the
           token can't be used to view its authorization details.
-        - Tokens stop working when the user who created the token is deleted.
+        - A token stops working when the user who created the authorization is deleted.
 
         We recommend creating a generic user to create and manage tokens for writing data.
 
@@ -6837,6 +6895,13 @@ paths:
       requestBody:
         content:
           application/json:
+            examples:
+              AuthorizationPostRequest:
+                $ref: '#/components/examples/AuthorizationPostRequest'
+              AuthorizationWithResourcePostRequest:
+                $ref: '#/components/examples/AuthorizationWithResourcePostRequest'
+              AuthorizationWithUserPostRequest:
+                $ref: '#/components/examples/AuthorizationWithUserPostRequest'
             schema:
               $ref: '#/components/schemas/AuthorizationPostRequest'
         description: The authorization to create.
@@ -6847,7 +6912,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Authorization'
-          description: Created. The response body contains the newly created authorization.
+          description: |
+            Success. The authorization is created. The response body contains the authorization.
         "400":
           $ref: '#/components/responses/GeneralServerError'
           description: Invalid request
@@ -6861,40 +6927,6 @@ paths:
       summary: Create an authorization
       tags:
       - Authorizations
-      x-codeSample:
-      - label: 'cURL: Create auth to read all buckets'
-        lang: Shell
-        source: |
-          curl --request POST \
-          "http://localhost:8086/api/v2/authorizations" \
-          --header "Authorization: Token INFLUX_TOKEN" \
-          --header 'Content-Type: application/json' \
-          --data @- << EOF
-            {
-              "orgID": "INFLUX_ORG_ID",
-              "description": "iot_users read buckets",
-              "permissions": [
-                {"action": "read", "resource": {"type": "buckets"}}
-              ]
-            }
-          EOF
-      - lang: Shell
-      - label: 'cURL: Create auth scoped to a user'
-      - source: |
-          curl --request POST \
-          "http://localhost:8086/api/v2/authorizations" \
-          --header "Authorization: Token INFLUX_TOKEN" \
-          --header 'Content-Type: application/json' \
-          --data @- << EOF
-            {
-              "orgID": "INFLUX_ORG_ID",
-              "userID": "INFLUX_USER_ID",
-              "description": "iot_user write to bucket",
-              "permissions": [
-                {"action": "write", "resource": {"type": "buckets", "id: "INFLUX_BUCKET_ID"}}
-              ]
-            }
-          EOF
   /api/v2/authorizations/{authID}:
     delete:
       operationId: DeleteAuthorizationsID

--- a/src/cloud.yml
+++ b/src/cloud.yml
@@ -48,12 +48,6 @@ components:
   #REF_COMMON_PARAMETERS
   schemas:
     #REF_COMMON_SCHEMAS
-    AuthorizationPostRequest:
-      $ref: './common/schemas/AuthorizationPostRequest.yml'
-    Permission:
-      $ref: './common/schemas/Permission.yml'
-    Resource:
-      $ref: './common/schemas/Resource.yml'
     User:
       $ref: './cloud/schemas/User.yml'
     Users:
@@ -92,6 +86,17 @@ components:
       $ref: "./cloud/schemas/TaskUpdateRequest.yml"
   responses:
     #REF_COMMON_RESPONSES
+  examples:
+    AuthorizationPostRequest:
+      $ref: "./common/requestBody/examples/AuthorizationRequestExamples.yml#/AuthorizationPostRequest"
+    AuthorizationWithResourcePostRequest:
+      $ref: "./common/requestBody/examples/AuthorizationRequestExamples.yml#/AuthorizationWithResourcePostRequest"
+    AuthorizationWithUserPostRequest:
+      $ref: "./common/requestBody/examples/AuthorizationRequestExamples.yml#/AuthorizationWithUserPostRequest"
+    TaskWithFluxRequest:
+      $ref: "./common/requestBody/examples/TaskRequestExamples.yml#/TaskWithFluxRequest"
+    TaskWithScriptRequest:
+      $ref: "./common/requestBody/examples/TaskRequestExamples.yml#/TaskWithScriptRequest"
   securitySchemes:
     TokenAuthentication:
       type: apiKey

--- a/src/cloud/paths/authorizations.yml
+++ b/src/cloud/paths/authorizations.yml
@@ -4,7 +4,7 @@ get:
     - Authorizations
   summary: List authorizations
   description: |
-    Retrieves a list of authorizations.
+    Lists authorizations.
 
     To limit which authorizations are returned, pass query parameters in your request.
     If no query parameters are passed, InfluxDB returns all authorizations for the organization.
@@ -15,7 +15,7 @@ get:
       values in `GET /api/v2/authorizations` responses;
       returns `token: redacted` for all authorizations.
 
-    #### Required permissions for InfluxDB Cloud
+    #### Required permissions
 
     - `read-authorizations`
 
@@ -92,20 +92,14 @@ post:
     Use this endpoint to create an authorization, which generates an API token
     with permissions to `read` or `write` to a specific resource or `type` of resource.
 
-    Keep the following in mind when creating and updating authorizations:
-
-    - To apply a permission to a specific resource, specify the resource `id` field.
-    - To apply a permission to all resources with the type, omit the resource `id`.
-    - To scope an authorization to a specific user, provide the `userID` property.
-
     #### Limitations
 
     To follow best practices for secure API token generation and retrieval,
     InfluxDB Cloud enforces access restrictions on API tokens.
 
-    - InfluxDB Cloud only allows access to the API token value immediately after the authorization is created.
-    - You can’t change access (read/write) permissions for an API token after it’s created.
-    - Tokens stop working when the user who created the token is deleted.
+    - InfluxDB only allows access to the API token value immediately after the authorization is created.
+    - You can't update an authorization's permissions.
+    - A token stops working when the user who created the authorization is deleted.
 
     We recommend the following for managing your tokens:
 
@@ -124,6 +118,13 @@ post:
       application/json:
         schema:
           $ref: "../../common/schemas/AuthorizationPostRequest.yml"
+        examples:
+          AuthorizationPostRequest:
+            $ref: "../../common/requestBody/examples/AuthorizationRequestExamples.yml#/AuthorizationPostRequest"
+          AuthorizationWithResourcePostRequest:
+            $ref: "../../common/requestBody/examples/AuthorizationRequestExamples.yml#/AuthorizationWithResourcePostRequest"
+          AuthorizationWithUserPostRequest:
+            $ref: "../../common/requestBody/examples/AuthorizationRequestExamples.yml#/AuthorizationWithUserPostRequest"
   responses:
     "201":
       description: |
@@ -142,37 +143,3 @@ post:
     default:
       description: Unexpected error
       $ref: '../../common/responses/ServerError.yml'
-  x-codeSample:
-    - lang: Shell
-      label: "cURL: Create auth to read all buckets"
-      source: |
-        curl --request POST \
-        "http://localhost:8086/api/v2/authorizations" \
-        --header "Authorization: Token INFLUX_API_TOKEN" \
-        --header 'Content-Type: application/json' \
-        --data @- << EOF
-          {
-            "orgID": "INFLUX_ORG_ID",
-            "description": "iot_users read buckets",
-            "permissions": [
-              {"action": "read", "resource": {"type": "buckets"}}
-            ]
-          }
-        EOF
-    - lang: Shell
-      label: "cURL: Create auth scoped to a user"
-      source: |
-        curl --request POST \
-        "http://localhost:8086/api/v2/authorizations" \
-        --header "Authorization: Token INFLUX_API_TOKEN" \
-        --header 'Content-Type: application/json' \
-        --data @- << EOF
-          {
-            "orgID": "INFLUX_ORG_ID",
-            "userID": "INFLUX_USER_ID",
-            "description": "iot_user write to bucket",
-            "permissions": [
-              {"action": "write", "resource": {"type": "buckets", "id: "INFLUX_BUCKET_ID"}}
-            ]
-          }
-        EOF

--- a/src/common/_schemas.yml
+++ b/src/common/_schemas.yml
@@ -98,6 +98,8 @@
       $ref: "./common/schemas/Authorization.yml"
     Authorizations:
       $ref: "./common/schemas/Authorizations.yml"
+    AuthorizationPostRequest:
+      $ref: './common/schemas/AuthorizationPostRequest.yml'
     AuthorizationUpdateRequest:
       $ref: "./common/schemas/AuthorizationUpdateRequest.yml"
     PostBucketRequest:
@@ -164,6 +166,8 @@
       $ref: "./common/schemas/UserResponse.yml"
     Flags:
       $ref: "./common/schemas/Flags.yml"
+    Resource:
+      $ref: './common/schemas/Resource.yml'
     ResourceMember:
       $ref: "./common/schemas/ResourceMember.yml"
     ResourceMembers:
@@ -446,3 +450,5 @@
       $ref: "./common/schemas/SchemaType.yml"
     ColorMapping:
       $ref: "./common/schemas/ColorMapping.yml"
+    Permission:
+      $ref: './common/schemas/Permission.yml'

--- a/src/common/paths/authorizations.yml
+++ b/src/common/paths/authorizations.yml
@@ -5,21 +5,21 @@ get:
     - Security and access endpoints
   summary: List authorizations
   description: |
-    Retrieves a list of authorizations.
+    Lists authorizations.
 
     To limit which authorizations are returned, pass query parameters in your request.
     If no query parameters are passed, InfluxDB returns all authorizations.
 
     #### InfluxDB OSS
 
-    - Returns
+    - InfluxDB OSS returns
       [API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token) values in authorizations.
     - If the request uses an  _[operator token](https://docs.influxdata.com/influxdb/latest/security/tokens/#operator-token)_,
       InfluxDB OSS returns authorizations for all organizations in the instance.
 
     #### Required permissions
 
-    - InfluxDB OSS requires an _[operator token](https://docs.influxdata.com/influxdb/latest/security/tokens/#operator-token)_.
+    - An _[operator token](https://docs.influxdata.com/influxdb/latest/security/tokens/#operator-token)_.
 
     #### Related guides
 
@@ -77,25 +77,24 @@ post:
     - Authorizations
   summary: Create an authorization
   description: |
-    Creates an authorization.
+    Creates an authorization and returns the authorization with the
+    generated API [token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token).
 
     Use this endpoint to create an authorization, which generates an API token
     with permissions to `read` or `write` to a specific resource or `type` of resource.
     The response contains the new authorization with the generated API token.
 
-    Keep the following in mind when creating and updating authorizations:
-
-    - To apply a permission to a specific resource, specify the resource `id` field.
-    - To apply a permission to all resources with the type, omit the resource `id`.
-    - To scope an authorization to a specific user, provide the `userID` property.
-
     #### Limitations
+
+    To follow best practices for secure API token generation and retrieval,
+    InfluxDB enforces access restrictions on API tokens.
 
     - In InfluxDB OSS, API tokens are visible to the user who created the authorization and to any
       user with an _[operator token]({{% INFLUXDB_DOCS_URL %}}/security/tokens/#operator-token)_.
+    - You can't update an authorization's permissions.
     - Even if an API token has `read-authorizations` permission, the
       token can't be used to view its authorization details.
-    - Tokens stop working when the user who created the token is deleted.
+    - A token stops working when the user who created the authorization is deleted.
 
     We recommend creating a generic user to create and manage tokens for writing data.
 
@@ -111,9 +110,17 @@ post:
       application/json:
         schema:
           $ref: "../../common/schemas/AuthorizationPostRequest.yml"
+        examples:
+          AuthorizationPostRequest:
+            $ref: "../../common/requestBody/examples/AuthorizationRequestExamples.yml#/AuthorizationPostRequest"
+          AuthorizationWithResourcePostRequest:
+            $ref: "../../common/requestBody/examples/AuthorizationRequestExamples.yml#/AuthorizationWithResourcePostRequest"
+          AuthorizationWithUserPostRequest:
+            $ref: "../../common/requestBody/examples/AuthorizationRequestExamples.yml#/AuthorizationWithUserPostRequest"
   responses:
     "201":
-      description: Created. The response body contains the newly created authorization.
+      description: |
+        Success. The authorization is created. The response body contains the authorization.
       content:
         application/json:
           schema:
@@ -128,37 +135,3 @@ post:
     default:
       description: Unexpected error
       $ref: '../../common/responses/ServerError.yml'
-  x-codeSample:
-    - lang: Shell
-      label: "cURL: Create auth to read all buckets"
-      source: |
-        curl --request POST \
-        "http://localhost:8086/api/v2/authorizations" \
-        --header "Authorization: Token INFLUX_TOKEN" \
-        --header 'Content-Type: application/json' \
-        --data @- << EOF
-          {
-            "orgID": "INFLUX_ORG_ID",
-            "description": "iot_users read buckets",
-            "permissions": [
-              {"action": "read", "resource": {"type": "buckets"}}
-            ]
-          }
-        EOF
-    - lang: Shell
-    - label: "cURL: Create auth scoped to a user"
-    - source: |
-        curl --request POST \
-        "http://localhost:8086/api/v2/authorizations" \
-        --header "Authorization: Token INFLUX_TOKEN" \
-        --header 'Content-Type: application/json' \
-        --data @- << EOF
-          {
-            "orgID": "INFLUX_ORG_ID",
-            "userID": "INFLUX_USER_ID",
-            "description": "iot_user write to bucket",
-            "permissions": [
-              {"action": "write", "resource": {"type": "buckets", "id: "INFLUX_BUCKET_ID"}}
-            ]
-          }
-        EOF

--- a/src/common/requestBody/examples/AuthorizationRequestExamples.yml
+++ b/src/common/requestBody/examples/AuthorizationRequestExamples.yml
@@ -1,0 +1,48 @@
+AuthorizationPostRequest:
+    summary: An authorization for a resource type
+    description: Creates an authorization.
+    value: {
+      "orgID": "INFLUX_ORG_ID",
+      "description": "iot_users read buckets",
+      "permissions": [
+        {
+          "action": "read",
+          "resource": {
+            "type": "buckets"
+            }
+        }
+      ]
+    }
+AuthorizationWithResourcePostRequest:
+    summary: An authorization for a resource
+    description: Creates an authorization for access to a specific resource.
+    value: {
+      "orgID": "INFLUX_ORG_ID",
+      "description": "iot_users read buckets",
+      "permissions": [
+        {
+          "action": "read",
+          "resource": {
+            "type": "buckets",
+            "id": "INFLUX_BUCKET_ID"
+          }
+        }
+      ]
+    }
+AuthorizationWithUserPostRequest:
+    summary: An authorization scoped to a user
+    description: Creates an authorization scoped to a specific user.
+    value: {
+      "orgID": "INFLUX_ORG_ID",
+      "userID": "INFLUX_USER_ID",
+      "description": "iot_user write to bucket",
+      "permissions": [
+        {
+          "action": "write",
+            "resource": {
+              "type": "buckets",
+              "id": "INFLUX_BUCKET_ID"
+            }
+        }
+      ]
+    }

--- a/src/common/requestBody/examples/TaskRequestExamples.yml
+++ b/src/common/requestBody/examples/TaskRequestExamples.yml
@@ -1,0 +1,34 @@
+TaskWithFluxRequest:
+  summary: A task with Flux
+  description:
+    Sets the `flux` property with Flux task options and a query.
+  value: {
+    "flux": "option task = {name: \"CPU Total 1 Hour New\", every: 1h}\
+     from(bucket: \"telegraf\")
+      |> range(start: -1h)
+      |> filter(fn: (r) => (r._measurement == \"cpu\"))
+      |> filter(fn: (r) =>\n\t\t(r._field == \"usage_system\"))
+      |> filter(fn: (r) => (r.cpu == \"cpu-total\"))
+      |> aggregateWindow(every: 1h, fn: max)
+      |> to(bucket: \"cpu_usage_user_total_1h\", org: \"INFLUX_ORG\")",
+    "status": "active",
+    "description": "This task contains Flux that configures the task schedule
+    and downsamples CPU data every hour."
+  }
+TaskWithScriptRequest:
+  summary: A task with an invokable script
+  description: |
+    Sets properties for a task that runs an _invokable script_.
+  value: {
+    "name": "CPU Total 1 Hour New",
+    "every": "1h",
+    "scriptID": "SCRIPT_ID",
+    "scriptParameters":
+      {
+        "rangeStart": "-1h",
+        "bucket": "telegraf",
+        "filterField": "cpu-total"
+      },
+    "status": "active",
+    "description": "This task runs an invokable script every hour with the defined parameters."
+  }

--- a/src/common/schemas/AuthorizationPostRequest.yml
+++ b/src/common/schemas/AuthorizationPostRequest.yml
@@ -6,16 +6,27 @@
         orgID:
           type: string
           description: |
-            The ID of the organization that owns the authorization.
+            An organization ID.
+            Specifies the organization that owns the authorization.
         userID:
           type: string
           description: |
-            The ID of the user that the authorization is scoped to.
+            A user ID.
+            Specifies the user that the authorization is scoped to.
+
+            When a user authenticates with username and password,
+            InfluxDB generates a _user session_ with all the permissions
+            specified by all the user's authorizations.
         permissions:
           type: array
           minItems: 1
           description: |
             A list of permissions for an authorization.
-            An authorization must have at least one permission.
+            In the list, provide at least one `permission` object.
+
+            In a `permission`, the `resource.type` property grants access to all
+            resources of the specified type.
+            To grant access to only a specific resource, specify the
+            `resource.id` property.
           items:
             $ref: "./Permission.yml"

--- a/src/common/schemas/Resource.yml
+++ b/src/common/schemas/Resource.yml
@@ -37,24 +37,25 @@
         - subscriptions
 
       description: |
-        The type of resource.
-        In a `permission`, applies the permission to all resources of this type.
+        A resource type.
+        Identifies the API resource's type (or _kind_).
     id:
       type: string
       description: |
-        The ID of a specific resource.
-        In a `permission`, applies the permission to only the resource with this ID.
+        A resource ID.
+        Identifies a specific resource.
     name:
       type: string
       description: |
-        Optional: A name for the resource.
-        Not all resource types have a name field.
+        The name of the resource.
+        _Note: not all resource types have a `name` property_.
     orgID:
       type: string
       description: |
-        The ID of the organization that owns the resource.
-        In a `permission`, applies the permission to all resources of `type` owned by this organization.
+        An organization ID.
+        Identifies the organization that owns the resource.
     org:
       type: string
       description: |
-        Optional: The name of the organization with `orgID`.
+        An organization name.
+        The organization that owns the resource.

--- a/src/oss.yml
+++ b/src/oss.yml
@@ -116,12 +116,6 @@ components:
   #REF_COMMON_PARAMETERS
   schemas:
   #REF_COMMON_SCHEMAS
-    AuthorizationPostRequest:
-      $ref: "./common/schemas/AuthorizationPostRequest.yml"
-    Permission:
-      $ref: "./common/schemas/Permission.yml"
-    Resource:
-      $ref: "./common/schemas/Resource.yml"
     User:
       $ref: "./common/schemas/User.yml"
     Users:
@@ -204,6 +198,15 @@ components:
       $ref: "./common/schemas/TaskUpdateRequest.yml"
   responses:
     #REF_COMMON_RESPONSES
+  examples:
+    AuthorizationPostRequest:
+      $ref: "./common/requestBody/examples/AuthorizationRequestExamples.yml#/AuthorizationPostRequest"
+    AuthorizationWithResourcePostRequest:
+      $ref: "./common/requestBody/examples/AuthorizationRequestExamples.yml#/AuthorizationWithResourcePostRequest"
+    AuthorizationWithUserPostRequest:
+      $ref: "./common/requestBody/examples/AuthorizationRequestExamples.yml#/AuthorizationWithUserPostRequest"
+    TaskWithFluxRequest:
+      $ref: "./common/requestBody/examples/TaskRequestExamples.yml#/TaskWithFluxRequest"
   securitySchemes:
     # TODO: Uncomment when Bearer auth is also available in Cloud:
     # BearerAuthentication:


### PR DESCRIPTION
- Move examples out of text and curl shell examples to request body examples. The interesting bits are in the data, not the command. Rapidoc will display the payload schema as well as examples we define, though Redoc doesn't for now.
- Style cleanup.
- Improve descriptions.

Split out of #574.