### PR TITLE
chore(aim): Replace 405s with 403s

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -23,7 +23,7 @@ paths:
         '401':
           description: Unauthorized/Account doesn't exist
           $ref: '#/components/responses/ServerError'
-        '405':
+        '403':
           description: Account is not deletable
           $ref: '#/components/responses/ServerError'
         default:
@@ -942,8 +942,8 @@ paths:
         '400':
           description: User trying to remove self
           $ref: '#/components/responses/ServerError'
-        '401':
-          description: Unauthorized
+        '403':
+          description: Cannot remove last user
           $ref: '#/components/responses/ServerError'
         '404':
           description: Session user not owner or User/Org not found
@@ -1147,6 +1147,9 @@ paths:
           $ref: '#/components/responses/ServerError'
         '401':
           description: Unauthorized
+          $ref: '#/components/responses/ServerError'
+        '403':
+          description: Account is not deletable
           $ref: '#/components/responses/ServerError'
         default:
           description: Unexpected error

--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -942,6 +942,9 @@ paths:
         '400':
           description: User trying to remove self
           $ref: '#/components/responses/ServerError'
+        '401':
+          description: Unauthorized
+          $ref: '#/components/responses/ServerError'
         '403':
           description: Cannot remove last user
           $ref: '#/components/responses/ServerError'

--- a/src/unity/paths/account.yml
+++ b/src/unity/paths/account.yml
@@ -12,7 +12,7 @@ delete:
     '401':
       description: Unauthorized/Account doesn't exist
       $ref: '../../common/responses/ServerError.yml'
-    '405':
+    '403':
       description: Account is not deletable
       $ref: '../../common/responses/ServerError.yml'
     default:

--- a/src/unity/paths/operator_accounts_accountId.yml
+++ b/src/unity/paths/operator_accounts_accountId.yml
@@ -62,6 +62,9 @@ delete:
     '401':
       description: Unauthorized
       $ref: '../../common/responses/ServerError.yml'
+    '403':
+      description: Account is not deletable
+      $ref: '../../common/responses/ServerError.yml'
     default:
       description: Unexpected error
       $ref: '../../common/responses/ServerError.yml'

--- a/src/unity/paths/orgs_orgId_users_userId.yml
+++ b/src/unity/paths/orgs_orgId_users_userId.yml
@@ -29,6 +29,9 @@ delete:
     '400':
       description: User trying to remove self
       $ref: '../../common/responses/ServerError.yml'
+    '401':
+      description: Unauthorized
+      $ref: '../../common/responses/ServerError.yml'
     '403':
       description: Cannot remove last user
       $ref: '../../common/responses/ServerError.yml'

--- a/src/unity/paths/orgs_orgId_users_userId.yml
+++ b/src/unity/paths/orgs_orgId_users_userId.yml
@@ -29,8 +29,8 @@ delete:
     '400':
       description: User trying to remove self
       $ref: '../../common/responses/ServerError.yml'
-    '401':
-      description: Unauthorized
+    '403':
+      description: Cannot remove last user
       $ref: '../../common/responses/ServerError.yml'
     '404':
       description: Session user not owner or User/Org not found


### PR DESCRIPTION
This updates some Quartz endpoints that return 405 errors to return 403 errors instead.

We were using `Method Not Allowed 405` responses for when a resource is not able to acted upon. I think these errors are better suited at `Forbidden 403`, because the HTTP method is accepted, but the action is not allowed for an internal reason.