### PR TITLE
docs: cleanup misc descriptions:

### DIFF
--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -18,7 +18,7 @@ paths:
         - Users
       summary: List users
       description: |
-        Retrieves a list of [users]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user).
+        Lists [users]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user).
 
         To limit which users are returned, pass query parameters in your request.
 
@@ -38,7 +38,7 @@ paths:
 
         #### Related guides
 
-        - [Manage users]({{% INFLUXDB_DOCS_URL %}}/organizations/users/)
+        - [Manage users](https://docs.influxdata.com/influxdb/cloud/organizations/users/)
       parameters:
         - in: header
           name: Zap-Trace-Span
@@ -928,7 +928,7 @@ paths:
     get:
       summary: List measurement schemas of a bucket
       description: |
-        Retrieves a list of _explicit_
+        Lists _explicit_
         [schemas]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#schema)
         (`"schemaType": "explicit"`) for a bucket.
 
@@ -1119,7 +1119,7 @@ paths:
         - lang: Shell
           label: cURL
           source: |
-            curl --request POST "https://cloud2.influxdata.com/api/v2/buckets/BUCKET_ID/schema/measurements \
+            curl --request POST "INFLUX_URL/api/v2/buckets/BUCKET_ID/schema/measurements \
               --header "Authorization: Token INFLUX_API_TOKEN" \
               --header "Accept: application/json" \
               --header "Content-Type: application/json" \
@@ -1287,7 +1287,7 @@ paths:
         - lang: Shell
           label: cURL
           source: |
-            curl --request PATCH "https://cloud2.influxdata.com/api/v2/buckets/BUCKET_ID/schema/measurements \
+            curl --request PATCH "INFLUX_URL/api/v2/buckets/BUCKET_ID/schema/measurements \
               --header "Authorization: Token INFLUX_API_TOKEN" \
               --header "Accept: application/json" \
               --header "Content-Type: application/json" \
@@ -1426,7 +1426,7 @@ paths:
                 - name
       responses:
         '201':
-          description: Added dashboard
+          description: Success. The dashboard is created.
           content:
             application/json:
               schema:
@@ -2277,19 +2277,19 @@ paths:
                                                                 query: /api/v2/checks/1/query
                                                               properties:
                                                                 self:
-                                                                  description: URL for this check
+                                                                  description: The URL for this check.
                                                                   $ref: '#/components/schemas/Task/properties/links/properties/self'
                                                                 labels:
-                                                                  description: URL to retrieve labels for this check
+                                                                  description: The URL to retrieve labels for this check.
                                                                   $ref: '#/components/schemas/Task/properties/links/properties/self'
                                                                 members:
-                                                                  description: URL to retrieve members for this check
+                                                                  description: The URL to retrieve members for this check.
                                                                   $ref: '#/components/schemas/Task/properties/links/properties/self'
                                                                 owners:
-                                                                  description: URL to retrieve owners for this check
+                                                                  description: The URL to retrieve owners for this check.
                                                                   $ref: '#/components/schemas/Task/properties/links/properties/self'
                                                                 query:
-                                                                  description: URL to retrieve flux script for this check
+                                                                  description: The URL to retrieve the Flux script for this check.
                                                                   $ref: '#/components/schemas/Task/properties/links/properties/self'
                                                           required:
                                                             - name
@@ -3120,7 +3120,13 @@ paths:
       operationId: GetDashboards
       tags:
         - Dashboards
-      summary: List all dashboards
+      summary: List dashboards
+      description: |
+        Lists [dashboards]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#dashboard).
+
+        #### Related guides
+
+        - [Manage dashboards]({{% INFLUXDB_DOCS_URL %}}/visualize-data/dashboards/).
       parameters:
         - $ref: '#/paths/~1users/get/parameters/0'
         - in: query
@@ -3147,10 +3153,13 @@ paths:
             minimum: -1
             maximum: 100
             default: 20
-          description: The non-zero number of dashboards to return
+          description: |
+            The maximum number of [dashboards]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#dashboard) to return.
+            Default is `20`.
+            The minimum is `-1` and the maximum is `100`.
         - in: query
           name: owner
-          description: A user identifier. Returns only dashboards where this user has the `owner` role.
+          description: 'A user ID. Only returns [dashboards]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#dashboard) where the specified user has the `owner` role.'
           schema:
             type: string
         - in: query
@@ -3164,24 +3173,33 @@ paths:
               - UpdatedAt
         - in: query
           name: id
-          description: 'A list of dashboard identifiers. Returns only the listed dashboards. If both `id` and `owner` are specified, only `id` is used.'
+          description: |
+            A list of dashboard IDs.
+            Returns only the specified [dashboards]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#dashboard).
+            If you specify `id` and `owner`, only `id` is used.
           schema:
             type: array
             items:
               type: string
         - in: query
           name: orgID
-          description: The identifier of the organization.
+          description: |
+            An organization ID.
+            Only returns [dashboards]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#dashboard) that belong to the specified
+            [organization]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#organization).
           schema:
             type: string
         - in: query
           name: org
-          description: The name of the organization.
+          description: |
+            An organization name.
+            Only returns [dashboards]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#dashboard) that belong to the specified
+            [organization]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#organization).
           schema:
             type: string
       responses:
         '200':
-          description: All dashboards
+          description: Success. The response body contains dashboards.
           content:
             application/json:
               schema:
@@ -3445,7 +3463,7 @@ paths:
         - lang: Shell
           label: 'cURL: all tasks, basic output'
           source: |
-            curl https://cloud2.influxdata.com/api/v2/tasks/?limit=-1&type=basic \
+            curl INFLUX_URL/api/v2/tasks/?limit=-1&type=basic \
               --header 'Content-Type: application/json' \
               --header 'Authorization: Token INFLUX_API_TOKEN'
     post:
@@ -3564,7 +3582,7 @@ paths:
         - lang: Shell
           label: 'cURL: create a Flux script task'
           source: |
-            curl https://cloud2.influxdata.com/api/v2/tasks \
+            curl INFLUX_URL/api/v2/tasks \
             --header "Content-type: application/json" \
             --header "Authorization: Token INFLUX_API_TOKEN" \
             --data-binary @- << EOF
@@ -3581,7 +3599,7 @@ paths:
         - lang: Shell
           label: 'cURL: create a Flux script reference task'
           source: |
-            curl https://cloud2.influxdata.com/api/v2/tasks \
+            curl INFLUX_URL/api/v2/tasks \
             --header "Content-type: application/json" \
             --header "Authorization: Token INFLUX_API_TOKEN" \
             --data-binary @- << EOF

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -3757,8 +3757,8 @@
         "tags": [
           "Query"
         ],
-        "summary": "Retrieve Flux query suggestions",
-        "description": "Retrieves a list of Flux query suggestions. Each suggestion contains a\n[Flux function](https://docs.influxdata.com/flux/v0.x/stdlib/all-functions/)\nname and parameters.\n\nUse this endpoint to retrieve a list of Flux query suggestions used in the\nInfluxDB Flux Query Builder. Helper function names have an underscore (`_`)\nprefix and aren't meant to be used directly in queries--for example:\n\n- **Recommended**:  Use `top(n, columns=[\"_value\"], tables=<-)` to sort\n  on a column and keep the top n records instead of `_sortLimit_`.\n  `top` uses the `_sortLimit` helper function.\n\n#### Limitations\n\n- Using `/api/v2/query/suggestions/` (note the trailing slash) with cURL\nwill result in a HTTP `301 Moved Permanently` status code. Please use\n`/api/v2/query/suggestions` without a trailing slash.\n\n- When writing a query, avoid using `_functionName()` helper functions\nexposed by this endpoint.\n\n#### Related Guides\n\n- [List of all Flux functions]({{% INFLUXDB_DOCS_URL %}}/flux/v0.x/stdlib/all-functions/)\n",
+        "summary": "List Flux query suggestions",
+        "description": "Lists Flux query suggestions. Each suggestion contains a\n[Flux function](https://docs.influxdata.com/flux/v0.x/stdlib/all-functions/)\nname and parameters.\n\nUse this endpoint to retrieve a list of Flux query suggestions used in the\nInfluxDB Flux Query Builder.\n\n#### Limitations\n\n- When writing a query, avoid using `_functionName()` helper functions\nexposed by this endpoint.  Helper function names have an underscore (`_`)\nprefix and aren't meant to be used directly in queries--for example:\n\n  - To sort on a column and keep the top n records, use the\n    `top(n, columns=[\"_value\"], tables=<-)` function instead of the `_sortLimit`\n    helper function. `top` uses `_sortLimit`.\n\n#### Related Guides\n\n- [List of all Flux functions](https://docs.influxdata.com/flux/v0.x/stdlib/all-functions/)\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -4701,7 +4701,7 @@
             }
           },
           "301": {
-            "description": "Moved Permanently.\nInfluxData has moved the URL of the endpoint.\nUse `/api/v2/query/suggestions`.\n",
+            "description": "Moved Permanently.\nInfluxData has moved the URL of the endpoint.\nUse `/api/v2/query/suggestions` (without a trailing slash).\n",
             "content": {
               "text/html": {
                 "schema": {
@@ -4738,7 +4738,7 @@
           {
             "lang": "Shell",
             "label": "cURL",
-            "source": "curl --request GET \"https://cloud2.influxdata.com/api/v2/query/suggestions\" \\\n  --header \"Accept: application/json\" \\\n  --header \"Authorization: Token INFLUX_API_TOKEN\"\n"
+            "source": "curl --request GET \"INFLUX_URL/api/v2/query/suggestions\" \\\n  --header \"Accept: application/json\" \\\n  --header \"Authorization: Token INFLUX_API_TOKEN\"\n"
           }
         ]
       }
@@ -4750,7 +4750,7 @@
           "Query"
         ],
         "summary": "Retrieve a query suggestion for a branching suggestion",
-        "description": "Retrieves a query suggestion that contains the name and parameters of the\nrequested function.\n\nUse this endpoint to pass a branching suggestion (a Flux function name) and\nretrieve the parameters of the requested function.\n\n#### Limitations\n\n- Use `/api/v2/query/suggestions/{name}` (without a trailing slash).\n`/api/v2/query/suggestions/{name}/` (note the trailing slash) results in a\nHTTP `301 Moved Permanently` status.\n\n- The function `name` must exist and must be spelled correctly.\n\n#### Related Guides\n\n- [List of all Flux functions]({{% INFLUXDB_DOCS_URL %}}/flux/v0.x/stdlib/all-functions/)\n",
+        "description": "Retrieves a query suggestion that contains the name and parameters of the\nrequested function.\n\nUse this endpoint to pass a branching suggestion (a Flux function name) and\nretrieve the parameters of the requested function.\n\n#### Limitations\n\n- Use `/api/v2/query/suggestions/{name}` (without a trailing slash).\n`/api/v2/query/suggestions/{name}/` (note the trailing slash) results in a\nHTTP `301 Moved Permanently` status.\n\n- The function `name` must exist and must be spelled correctly.\n\n#### Related Guides\n\n- [List of all Flux functions](https://docs.influxdata.com/flux/v0.x/stdlib/all-functions/)\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -4762,7 +4762,7 @@
               "type": "string"
             },
             "required": true,
-            "description": "A Flux Function name.\nOnly returns functions with this name.\n"
+            "description": "A [Flux function](https://docs.influxdata.com/flux/v0.x/stdlib/all-functions/) name.\n"
           }
         ],
         "responses": {
@@ -4812,7 +4812,7 @@
           {
             "lang": "Shell",
             "label": "cURL",
-            "source": "curl --request GET \"https://cloud2.influxdata.com/api/v2/query/suggestions/sum/\" \\\n  --header \"Accept: application/json\" \\\n  --header \"Authorization: Token INFLUX_API_TOKEN\"\n"
+            "source": "curl --request GET \"INFLUX_URL/api/v2/query/suggestions/sum/\" \\\n  --header \"Accept: application/json\" \\\n  --header \"Authorization: Token INFLUX_API_TOKEN\"\n"
           }
         ]
       }
@@ -5121,7 +5121,7 @@
           "Buckets"
         ],
         "summary": "List buckets",
-        "description": "Retrieves a list of [buckets]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#bucket).\n\nInfluxDB retrieves buckets owned by the\n[organization]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#organization)\nassociated with the authorization\n([API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token)).\nTo limit which buckets are returned, pass query parameters in your request.\nIf no query parameters are passed, InfluxDB returns all buckets up to the\ndefault `limit`.\n\n#### InfluxDB OSS\n\n- If you use an _[operator token]({{% INFLUXDB_DOCS_URL %}}/security/tokens/#operator-token)_\n  to authenticate your request, InfluxDB retrieves resources for _all\n  organizations_ in the instance.\n  To retrieve resources for only a specific organization, use the\n  `org` parameter or the `orgID` parameter to specify the organization.\n\n#### Required permissions\n\n| Action                    | Permission required |\n|:--------------------------|:--------------------|\n| Retrieve _user buckets_   | `read-buckets`      |\n| Retrieve [_system buckets_]({{% INFLUXDB_DOCS_URL %}}/reference/internals/system-buckets/) | `read-orgs`         |\n\n#### Related Guides\n\n- [Manage buckets]({{% INFLUXDB_DOCS_URL %}}/organizations/buckets/)\n",
+        "description": "Lists [buckets]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#bucket).\n\nInfluxDB retrieves buckets owned by the\n[organization]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#organization)\nassociated with the authorization\n([API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token)).\nTo limit which buckets are returned, pass query parameters in your request.\nIf no query parameters are passed, InfluxDB returns all buckets up to the\ndefault `limit`.\n\n#### InfluxDB OSS\n\n- If you use an _[operator token]({{% INFLUXDB_DOCS_URL %}}/security/tokens/#operator-token)_\n  to authenticate your request, InfluxDB retrieves resources for _all\n  organizations_ in the instance.\n  To retrieve resources for only a specific organization, use the\n  `org` parameter or the `orgID` parameter to specify the organization.\n\n#### Required permissions\n\n| Action                    | Permission required |\n|:--------------------------|:--------------------|\n| Retrieve _user buckets_   | `read-buckets`      |\n| Retrieve [_system buckets_]({{% INFLUXDB_DOCS_URL %}}/reference/internals/system-buckets/) | `read-orgs`         |\n\n#### Related Guides\n\n- [Manage buckets]({{% INFLUXDB_DOCS_URL %}}/organizations/buckets/)\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -7561,7 +7561,7 @@
           "Templates"
         ],
         "summary": "List installed stacks",
-        "description": "Retrieves a list of installed InfluxDB stacks.\n\nTo limit stacks in the response, pass query parameters in your request.\nIf no query parameters are passed, InfluxDB returns all installed stacks\nfor the organization.\n",
+        "description": "Lists installed InfluxDB stacks.\n\nTo limit stacks in the response, pass query parameters in your request.\nIf no query parameters are passed, InfluxDB returns all installed stacks\nfor the organization.\n\n#### Related guides\n\n- [View InfluxDB stacks]({{% INFLUXDB_DOCS_URL %}}/influxdb-templates/stacks/).\n",
         "parameters": [
           {
             "in": "query",
@@ -7570,7 +7570,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "The ID of the organization that owns the stacks.\nOnly returns stacks owned by this organization.\n\n#### InfluxDB Cloud\n\n- Doesn't require this parameter;\n  InfluxDB only returns resources allowed by the API token.\n"
+            "description": "An organization ID.\nOnly returns stacks owned by the specified [organization]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#organization).\n\n#### InfluxDB Cloud\n\n- Doesn't require this parameter;\n  InfluxDB only returns resources allowed by the API token.\n"
           },
           {
             "in": "query",
@@ -7578,7 +7578,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "The stack name.\nFinds stack `events` with this name and returns the stacks.\n\nRepeatable.\nTo filter for more than one stack name,\nrepeat this parameter with each name--for example:\n\n- `http://localhost:8086/api/v2/stacks?&orgID=INFLUX_ORG_ID&name=project-stack-0&name=project-stack-1`\n",
+            "description": "A stack name.\nFinds stack `events` with this name and returns the stacks.\n\nRepeatable.\nTo filter for more than one stack name,\nrepeat this parameter with each name--for example:\n\n- `INFLUX_URL/api/v2/stacks?&orgID=INFLUX_ORG_ID&name=project-stack-0&name=project-stack-1`\n",
             "examples": {
               "findStackByName": {
                 "summary": "Find stacks with the event name",
@@ -7592,7 +7592,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "The stack ID.\nOnly returns stacks with this ID.\n\nRepeatable.\nTo filter for more than one stack ID,\nrepeat this parameter with each ID--for example:\n\n- `http://localhost:8086/api/v2/stacks?&orgID=INFLUX_ORG_ID&stackID=09bd87cd33be3000&stackID=09bef35081fe3000`\n",
+            "description": "A stack ID.\nOnly returns the specified stack.\n\nRepeatable.\nTo filter for more than one stack ID,\nrepeat this parameter with each ID--for example:\n\n- `INFLUX_URL/api/v2/stacks?&orgID=INFLUX_ORG_ID&stackID=09bd87cd33be3000&stackID=09bef35081fe3000`\n",
             "examples": {
               "findStackByID": {
                 "summary": "Find a stack with the ID",
@@ -7670,7 +7670,7 @@
           "Templates"
         ],
         "summary": "Create a stack",
-        "description": "Creates or initializes a stack.\n\nUse this endpoint to _manually_ initialize a new stack with the following\noptional information:\n\n  - Stack name\n  - Stack description\n  - URLs for template manifest files\n\nTo automatically create a stack when applying templates,\nuse the [/api/v2/templates/apply endpoint](#operation/ApplyTemplate).\n\n#### Required permissions\n\n- `write` permission for the organization\n\n#### Related guides\n\n- [InfluxDB stacks]({{% INFLUXDB_DOCS_URL %}}/influxdb-templates/stacks/)\n- [Use InfluxDB templates]({{% INFLUXDB_DOCS_URL %}}/influxdb-templates/use/#apply-templates-to-an-influxdb-instance)\n",
+        "description": "Creates or initializes a stack.\n\nUse this endpoint to _manually_ initialize a new stack with the following\noptional information:\n\n  - Stack name\n  - Stack description\n  - URLs for template manifest files\n\nTo automatically create a stack when applying templates,\nuse the [/api/v2/templates/apply endpoint](#operation/ApplyTemplate).\n\n#### Required permissions\n\n- `write` permission for the organization\n\n#### Related guides\n\n- [Initialize an InfluxDB stack]({{% INFLUXDB_DOCS_URL %}}/influxdb-templates/stacks/init/).\n- [Use InfluxDB templates]({{% INFLUXDB_DOCS_URL %}}/influxdb-templates/use/#apply-templates-to-an-influxdb-instance).\n",
         "requestBody": {
           "description": "The stack to create.",
           "required": true,
@@ -11195,7 +11195,7 @@
           "Users"
         ],
         "summary": "List users",
-        "description": "Retrieves a list of [users]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user).\n\nTo limit which users are returned, pass query parameters in your request.\n\n#### InfluxDB Cloud\n\n- InfluxDB Cloud doesn't allow listing all users through the API.\n  Use the InfluxDB Cloud user interface (UI) to manage account information.\n\n#### Required permissions for InfluxDB Cloud\n\n| Action | Permission required | Restriction |\n|:-------|:--------------------|:------------|\n| List all users | Operator token | InfluxData internal use only |\n| List a specific user | `read-users` or `read-user USER_ID` |\n\n*`USER_ID`* is the ID of the user that you want to retrieve.\n\n#### Related guides\n\n- [Manage users]({{% INFLUXDB_DOCS_URL %}}/organizations/users/)\n",
+        "description": "Lists [users]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user).\n\nTo limit which users are returned, pass query parameters in your request.\n\n#### InfluxDB Cloud\n\n- InfluxDB Cloud doesn't allow listing all users through the API.\n  Use the InfluxDB Cloud user interface (UI) to manage account information.\n\n#### Required permissions for InfluxDB Cloud\n\n| Action | Permission required | Restriction |\n|:-------|:--------------------|:------------|\n| List all users | Operator token | InfluxData internal use only |\n| List a specific user | `read-users` or `read-user USER_ID` |\n\n*`USER_ID`* is the ID of the user that you want to retrieve.\n\n#### Related guides\n\n- [Manage users](https://docs.influxdata.com/influxdb/cloud/organizations/users/)\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -12089,7 +12089,7 @@
       "summary": "Bucket schemas",
       "get": {
         "summary": "List measurement schemas of a bucket",
-        "description": "Retrieves a list of _explicit_\n[schemas]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#schema)\n(`\"schemaType\": \"explicit\"`) for a bucket.\n\n_Explicit_ schemas are used to enforce column names, tags, fields, and data\ntypes for your data.\n\nBy default, buckets have an _implicit_ schema-type (`\"schemaType\": \"implicit\"`)\nthat conforms to your data.\n\n#### Related guides\n\n- [Using bucket schemas](https://www.influxdata.com/blog/new-bucket-schema-option-protect-from-unwanted-schema-changes/)\n",
+        "description": "Lists _explicit_\n[schemas]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#schema)\n(`\"schemaType\": \"explicit\"`) for a bucket.\n\n_Explicit_ schemas are used to enforce column names, tags, fields, and data\ntypes for your data.\n\nBy default, buckets have an _implicit_ schema-type (`\"schemaType\": \"implicit\"`)\nthat conforms to your data.\n\n#### Related guides\n\n- [Using bucket schemas](https://www.influxdata.com/blog/new-bucket-schema-option-protect-from-unwanted-schema-changes/)\n",
         "operationId": "getMeasurementSchemas",
         "parameters": [
           {
@@ -12306,7 +12306,7 @@
           {
             "lang": "Shell",
             "label": "cURL",
-            "source": "curl --request POST \"https://cloud2.influxdata.com/api/v2/buckets/BUCKET_ID/schema/measurements \\\n  --header \"Authorization: Token INFLUX_API_TOKEN\" \\\n  --header \"Accept: application/json\" \\\n  --header \"Content-Type: application/json\" \\\n  --data '{\n      \"name\": \"temperature\",\n      \"column\": [\n        {\n          \"type\": \"tag\",\n          \"name\": \"location\"\n        },\n        {\n          \"type\": \"field\",\n          \"name\": \"value\",\n          \"dataType\": \"float\"\n        },\n        {\n          \"type\": \"timestamp\",\n          \"name\": \"time\"\n        }\n      ]\n    }'\n"
+            "source": "curl --request POST \"INFLUX_URL/api/v2/buckets/BUCKET_ID/schema/measurements \\\n  --header \"Authorization: Token INFLUX_API_TOKEN\" \\\n  --header \"Accept: application/json\" \\\n  --header \"Content-Type: application/json\" \\\n  --data '{\n      \"name\": \"temperature\",\n      \"column\": [\n        {\n          \"type\": \"tag\",\n          \"name\": \"location\"\n        },\n        {\n          \"type\": \"field\",\n          \"name\": \"value\",\n          \"dataType\": \"float\"\n        },\n        {\n          \"type\": \"timestamp\",\n          \"name\": \"time\"\n        }\n      ]\n    }'\n"
           }
         ]
       }
@@ -12483,7 +12483,7 @@
           {
             "lang": "Shell",
             "label": "cURL",
-            "source": "curl --request PATCH \"https://cloud2.influxdata.com/api/v2/buckets/BUCKET_ID/schema/measurements \\\n  --header \"Authorization: Token INFLUX_API_TOKEN\" \\\n  --header \"Accept: application/json\" \\\n  --header \"Content-Type: application/json\" \\\n  --data '{\n      \"column\": [\n        {\n          \"type\": \"tag\",\n          \"name\": \"location\"\n        },\n        {\n          \"type\": \"field\",\n          \"name\": \"value\",\n          \"dataType\": \"float\"\n        },\n        {\n          \"type\": \"timestamp\",\n          \"name\": \"time\"\n        }\n      ]\n    }'\n"
+            "source": "curl --request PATCH \"INFLUX_URL/api/v2/buckets/BUCKET_ID/schema/measurements \\\n  --header \"Authorization: Token INFLUX_API_TOKEN\" \\\n  --header \"Accept: application/json\" \\\n  --header \"Content-Type: application/json\" \\\n  --data '{\n      \"column\": [\n        {\n          \"type\": \"tag\",\n          \"name\": \"location\"\n        },\n        {\n          \"type\": \"field\",\n          \"name\": \"value\",\n          \"dataType\": \"float\"\n        },\n        {\n          \"type\": \"timestamp\",\n          \"name\": \"time\"\n        }\n      ]\n    }'\n"
           }
         ]
       }
@@ -12639,7 +12639,7 @@
         },
         "responses": {
           "201": {
-            "description": "Added dashboard",
+            "description": "Success. The dashboard is created.",
             "content": {
               "application/json": {
                 "schema": {
@@ -12672,7 +12672,8 @@
         "tags": [
           "Dashboards"
         ],
-        "summary": "List all dashboards",
+        "summary": "List dashboards",
+        "description": "Lists [dashboards]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#dashboard).\n\n#### Related guides\n\n- [Manage dashboards]({{% INFLUXDB_DOCS_URL %}}/visualize-data/dashboards/).\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -12692,12 +12693,12 @@
               "maximum": 100,
               "default": 20
             },
-            "description": "The non-zero number of dashboards to return"
+            "description": "The maximum number of [dashboards]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#dashboard) to return.\nDefault is `20`.\nThe minimum is `-1` and the maximum is `100`.\n"
           },
           {
             "in": "query",
             "name": "owner",
-            "description": "A user identifier. Returns only dashboards where this user has the `owner` role.",
+            "description": "A user ID. Only returns [dashboards]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#dashboard) where the specified user has the `owner` role.",
             "schema": {
               "type": "string"
             }
@@ -12718,7 +12719,7 @@
           {
             "in": "query",
             "name": "id",
-            "description": "A list of dashboard identifiers. Returns only the listed dashboards. If both `id` and `owner` are specified, only `id` is used.",
+            "description": "A list of dashboard IDs.\nReturns only the specified [dashboards]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#dashboard).\nIf you specify `id` and `owner`, only `id` is used.\n",
             "schema": {
               "type": "array",
               "items": {
@@ -12729,7 +12730,7 @@
           {
             "in": "query",
             "name": "orgID",
-            "description": "The identifier of the organization.",
+            "description": "An organization ID.\nOnly returns [dashboards]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#dashboard) that belong to the specified\n[organization]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#organization).\n",
             "schema": {
               "type": "string"
             }
@@ -12737,7 +12738,7 @@
           {
             "in": "query",
             "name": "org",
-            "description": "The name of the organization.",
+            "description": "An organization name.\nOnly returns [dashboards]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#dashboard) that belong to the specified\n[organization]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#organization).\n",
             "schema": {
               "type": "string"
             }
@@ -12745,7 +12746,7 @@
         ],
         "responses": {
           "200": {
-            "description": "All dashboards",
+            "description": "Success. The response body contains dashboards.",
             "content": {
               "application/json": {
                 "schema": {
@@ -12993,7 +12994,7 @@
           {
             "lang": "Shell",
             "label": "cURL: all tasks, basic output",
-            "source": "curl https://cloud2.influxdata.com/api/v2/tasks/?limit=-1&type=basic \\\n  --header 'Content-Type: application/json' \\\n  --header 'Authorization: Token INFLUX_API_TOKEN'\n"
+            "source": "curl INFLUX_URL/api/v2/tasks/?limit=-1&type=basic \\\n  --header 'Content-Type: application/json' \\\n  --header 'Authorization: Token INFLUX_API_TOKEN'\n"
           }
         ]
       },
@@ -13079,12 +13080,12 @@
           {
             "lang": "Shell",
             "label": "cURL: create a Flux script task",
-            "source": "curl https://cloud2.influxdata.com/api/v2/tasks \\\n--header \"Content-type: application/json\" \\\n--header \"Authorization: Token INFLUX_API_TOKEN\" \\\n--data-binary @- << EOF\n  {\n    \"orgID\": \"INFLUX_ORG_ID\",\n    \"description\": \"IoT Center 30d environment average.\",\n    \"flux\": \"option task = {name: \\\"iot-center-task-1\\\", every: 30m}\\\n            from(bucket: \\\"iot_center\\\")\\\n              |> range(start: -30d)\\\n              |> filter(fn: (r) => r._measurement == \\\"environment\\\")\\\n              |> aggregateWindow(every: 1h, fn: mean)\"\n  }\nEOF\n"
+            "source": "curl INFLUX_URL/api/v2/tasks \\\n--header \"Content-type: application/json\" \\\n--header \"Authorization: Token INFLUX_API_TOKEN\" \\\n--data-binary @- << EOF\n  {\n    \"orgID\": \"INFLUX_ORG_ID\",\n    \"description\": \"IoT Center 30d environment average.\",\n    \"flux\": \"option task = {name: \\\"iot-center-task-1\\\", every: 30m}\\\n            from(bucket: \\\"iot_center\\\")\\\n              |> range(start: -30d)\\\n              |> filter(fn: (r) => r._measurement == \\\"environment\\\")\\\n              |> aggregateWindow(every: 1h, fn: mean)\"\n  }\nEOF\n"
           },
           {
             "lang": "Shell",
             "label": "cURL: create a Flux script reference task",
-            "source": "curl https://cloud2.influxdata.com/api/v2/tasks \\\n--header \"Content-type: application/json\" \\\n--header \"Authorization: Token INFLUX_API_TOKEN\" \\\n--data-binary @- << EOF\n  {\n    \"orgID\": \"INFLUX_ORG_ID\",\n    \"description\": \"IoT Center 30d environment average.\",\n    \"scriptID\": \"085138a111448000\",\n    \"scriptParameters\":\n      {\n        \"rangeStart\": \"-30d\",\n        \"bucket\": \"air_sensor\",\n        \"filterField\": \"temperature\",\n        \"groupColumn\": \"_time\"\n      }\n  }\nEOF\n"
+            "source": "curl INFLUX_URL/api/v2/tasks \\\n--header \"Content-type: application/json\" \\\n--header \"Authorization: Token INFLUX_API_TOKEN\" \\\n--data-binary @- << EOF\n  {\n    \"orgID\": \"INFLUX_ORG_ID\",\n    \"description\": \"IoT Center 30d environment average.\",\n    \"scriptID\": \"085138a111448000\",\n    \"scriptParameters\":\n      {\n        \"rangeStart\": \"-30d\",\n        \"bucket\": \"air_sensor\",\n        \"filterField\": \"temperature\",\n        \"groupColumn\": \"_time\"\n      }\n  }\nEOF\n"
           }
         ]
       }
@@ -19521,12 +19522,16 @@
       },
       "LabelMapping": {
         "type": "object",
+        "description": "A _label mapping_ contains a `label` ID to attach to a resource.",
         "properties": {
           "labelID": {
-            "description": "Label ID.\nThe ID of the label to attach.\n",
+            "description": "A label ID.\nSpecifies the label to attach.\n",
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "labelID"
+        ]
       },
       "LabelsResponse": {
         "type": "object",
@@ -19718,23 +19723,23 @@
             },
             "properties": {
               "self": {
-                "description": "URL for this check",
+                "description": "The URL for this check.",
                 "$ref": "#/components/schemas/Link"
               },
               "labels": {
-                "description": "URL to retrieve labels for this check",
+                "description": "The URL to retrieve labels for this check.",
                 "$ref": "#/components/schemas/Link"
               },
               "members": {
-                "description": "URL to retrieve members for this check",
+                "description": "The URL to retrieve members for this check.",
                 "$ref": "#/components/schemas/Link"
               },
               "owners": {
-                "description": "URL to retrieve owners for this check",
+                "description": "The URL to retrieve owners for this check.",
                 "$ref": "#/components/schemas/Link"
               },
               "query": {
-                "description": "URL to retrieve flux script for this check",
+                "description": "The URL to retrieve the Flux script for this check.",
                 "$ref": "#/components/schemas/Link"
               }
             }
@@ -20222,23 +20227,23 @@
             },
             "properties": {
               "self": {
-                "description": "URL for this endpoint.",
+                "description": "The URL for this endpoint.",
                 "$ref": "#/components/schemas/Link"
               },
               "labels": {
-                "description": "URL to retrieve labels for this notification rule.",
+                "description": "The URL to retrieve labels for this notification rule.",
                 "$ref": "#/components/schemas/Link"
               },
               "members": {
-                "description": "URL to retrieve members for this notification rule.",
+                "description": "The URL to retrieve members for this notification rule.",
                 "$ref": "#/components/schemas/Link"
               },
               "owners": {
-                "description": "URL to retrieve owners for this notification rule.",
+                "description": "The URL to retrieve owners for this notification rule.",
                 "$ref": "#/components/schemas/Link"
               },
               "query": {
-                "description": "URL to retrieve flux script for this notification rule.",
+                "description": "The URL to retrieve the Flux script for this notification rule.",
                 "$ref": "#/components/schemas/Link"
               }
             }
@@ -20573,19 +20578,19 @@
             },
             "properties": {
               "self": {
-                "description": "URL for this endpoint.",
+                "description": "The URL for this endpoint.",
                 "$ref": "#/components/schemas/Link"
               },
               "labels": {
-                "description": "URL to retrieve labels for this endpoint.",
+                "description": "The URL to retrieve labels for this endpoint.",
                 "$ref": "#/components/schemas/Link"
               },
               "members": {
-                "description": "URL to retrieve members for this endpoint.",
+                "description": "The URL to retrieve members for this endpoint.",
                 "$ref": "#/components/schemas/Link"
               },
               "owners": {
-                "description": "URL to retrieve owners for this endpoint.",
+                "description": "The URL to retrieve owners for this endpoint.",
                 "$ref": "#/components/schemas/Link"
               }
             }

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -3015,32 +3015,28 @@ paths:
       operationId: GetQuerySuggestions
       tags:
         - Query
-      summary: Retrieve Flux query suggestions
+      summary: List Flux query suggestions
       description: |
-        Retrieves a list of Flux query suggestions. Each suggestion contains a
+        Lists Flux query suggestions. Each suggestion contains a
         [Flux function](https://docs.influxdata.com/flux/v0.x/stdlib/all-functions/)
         name and parameters.
 
         Use this endpoint to retrieve a list of Flux query suggestions used in the
-        InfluxDB Flux Query Builder. Helper function names have an underscore (`_`)
-        prefix and aren't meant to be used directly in queries--for example:
-
-        - **Recommended**:  Use `top(n, columns=["_value"], tables=<-)` to sort
-          on a column and keep the top n records instead of `_sortLimit_`.
-          `top` uses the `_sortLimit` helper function.
+        InfluxDB Flux Query Builder.
 
         #### Limitations
 
-        - Using `/api/v2/query/suggestions/` (note the trailing slash) with cURL
-        will result in a HTTP `301 Moved Permanently` status code. Please use
-        `/api/v2/query/suggestions` without a trailing slash.
-
         - When writing a query, avoid using `_functionName()` helper functions
-        exposed by this endpoint.
+        exposed by this endpoint.  Helper function names have an underscore (`_`)
+        prefix and aren't meant to be used directly in queries--for example:
+
+          - To sort on a column and keep the top n records, use the
+            `top(n, columns=["_value"], tables=<-)` function instead of the `_sortLimit`
+            helper function. `top` uses `_sortLimit`.
 
         #### Related Guides
 
-        - [List of all Flux functions](https://docs.influxdata.com/influxdb/cloud/flux/v0.x/stdlib/all-functions/)
+        - [List of all Flux functions](https://docs.influxdata.com/flux/v0.x/stdlib/all-functions/)
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
       responses:
@@ -3641,7 +3637,7 @@ paths:
           description: |
             Moved Permanently.
             InfluxData has moved the URL of the endpoint.
-            Use `/api/v2/query/suggestions`.
+            Use `/api/v2/query/suggestions` (without a trailing slash).
           content:
             text/html:
               schema:
@@ -3667,7 +3663,7 @@ paths:
         - lang: Shell
           label: cURL
           source: |
-            curl --request GET "https://cloud2.influxdata.com/api/v2/query/suggestions" \
+            curl --request GET "INFLUX_URL/api/v2/query/suggestions" \
               --header "Accept: application/json" \
               --header "Authorization: Token INFLUX_API_TOKEN"
   '/query/suggestions/{name}':
@@ -3693,7 +3689,7 @@ paths:
 
         #### Related Guides
 
-        - [List of all Flux functions](https://docs.influxdata.com/influxdb/cloud/flux/v0.x/stdlib/all-functions/)
+        - [List of all Flux functions](https://docs.influxdata.com/flux/v0.x/stdlib/all-functions/)
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -3702,8 +3698,7 @@ paths:
             type: string
           required: true
           description: |
-            A Flux Function name.
-            Only returns functions with this name.
+            A [Flux function](https://docs.influxdata.com/flux/v0.x/stdlib/all-functions/) name.
       responses:
         '200':
           description: |
@@ -3740,7 +3735,7 @@ paths:
         - lang: Shell
           label: cURL
           source: |
-            curl --request GET "https://cloud2.influxdata.com/api/v2/query/suggestions/sum/" \
+            curl --request GET "INFLUX_URL/api/v2/query/suggestions/sum/" \
               --header "Accept: application/json" \
               --header "Authorization: Token INFLUX_API_TOKEN"
   /query/analyze:
@@ -4067,7 +4062,7 @@ paths:
         - Buckets
       summary: List buckets
       description: |
-        Retrieves a list of [buckets](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#bucket).
+        Lists [buckets](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#bucket).
 
         InfluxDB retrieves buckets owned by the
         [organization](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#organization)
@@ -6283,11 +6278,15 @@ paths:
         - Templates
       summary: List installed stacks
       description: |
-        Retrieves a list of installed InfluxDB stacks.
+        Lists installed InfluxDB stacks.
 
         To limit stacks in the response, pass query parameters in your request.
         If no query parameters are passed, InfluxDB returns all installed stacks
         for the organization.
+
+        #### Related guides
+
+        - [View InfluxDB stacks](https://docs.influxdata.com/influxdb/cloud/influxdb-templates/stacks/).
       parameters:
         - in: query
           name: orgID
@@ -6295,8 +6294,8 @@ paths:
           schema:
             type: string
           description: |
-            The ID of the organization that owns the stacks.
-            Only returns stacks owned by this organization.
+            An organization ID.
+            Only returns stacks owned by the specified [organization](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#organization).
 
             #### InfluxDB Cloud
 
@@ -6307,14 +6306,14 @@ paths:
           schema:
             type: string
           description: |
-            The stack name.
+            A stack name.
             Finds stack `events` with this name and returns the stacks.
 
             Repeatable.
             To filter for more than one stack name,
             repeat this parameter with each name--for example:
 
-            - `http://localhost:8086/api/v2/stacks?&orgID=INFLUX_ORG_ID&name=project-stack-0&name=project-stack-1`
+            - `INFLUX_URL/api/v2/stacks?&orgID=INFLUX_ORG_ID&name=project-stack-0&name=project-stack-1`
           examples:
             findStackByName:
               summary: Find stacks with the event name
@@ -6324,14 +6323,14 @@ paths:
           schema:
             type: string
           description: |
-            The stack ID.
-            Only returns stacks with this ID.
+            A stack ID.
+            Only returns the specified stack.
 
             Repeatable.
             To filter for more than one stack ID,
             repeat this parameter with each ID--for example:
 
-            - `http://localhost:8086/api/v2/stacks?&orgID=INFLUX_ORG_ID&stackID=09bd87cd33be3000&stackID=09bef35081fe3000`
+            - `INFLUX_URL/api/v2/stacks?&orgID=INFLUX_ORG_ID&stackID=09bd87cd33be3000&stackID=09bef35081fe3000`
           examples:
             findStackByID:
               summary: Find a stack with the ID
@@ -6405,8 +6404,8 @@ paths:
 
         #### Related guides
 
-        - [InfluxDB stacks](https://docs.influxdata.com/influxdb/cloud/influxdb-templates/stacks/)
-        - [Use InfluxDB templates](https://docs.influxdata.com/influxdb/cloud/influxdb-templates/use/#apply-templates-to-an-influxdb-instance)
+        - [Initialize an InfluxDB stack](https://docs.influxdata.com/influxdb/cloud/influxdb-templates/stacks/init/).
+        - [Use InfluxDB templates](https://docs.influxdata.com/influxdb/cloud/influxdb-templates/use/#apply-templates-to-an-influxdb-instance).
       requestBody:
         description: The stack to create.
         required: true
@@ -8994,7 +8993,7 @@ paths:
         - Users
       summary: List users
       description: |
-        Retrieves a list of [users](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#user).
+        Lists [users](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#user).
 
         To limit which users are returned, pass query parameters in your request.
 
@@ -9734,7 +9733,7 @@ paths:
     get:
       summary: List measurement schemas of a bucket
       description: |
-        Retrieves a list of _explicit_
+        Lists _explicit_
         [schemas](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#schema)
         (`"schemaType": "explicit"`) for a bucket.
 
@@ -9925,7 +9924,7 @@ paths:
         - lang: Shell
           label: cURL
           source: |
-            curl --request POST "https://cloud2.influxdata.com/api/v2/buckets/BUCKET_ID/schema/measurements \
+            curl --request POST "INFLUX_URL/api/v2/buckets/BUCKET_ID/schema/measurements \
               --header "Authorization: Token INFLUX_API_TOKEN" \
               --header "Accept: application/json" \
               --header "Content-Type: application/json" \
@@ -10093,7 +10092,7 @@ paths:
         - lang: Shell
           label: cURL
           source: |
-            curl --request PATCH "https://cloud2.influxdata.com/api/v2/buckets/BUCKET_ID/schema/measurements \
+            curl --request PATCH "INFLUX_URL/api/v2/buckets/BUCKET_ID/schema/measurements \
               --header "Authorization: Token INFLUX_API_TOKEN" \
               --header "Accept: application/json" \
               --header "Content-Type: application/json" \
@@ -10220,7 +10219,7 @@ paths:
               $ref: '#/components/schemas/CreateDashboardRequest'
       responses:
         '201':
-          description: Added dashboard
+          description: Success. The dashboard is created.
           content:
             application/json:
               schema:
@@ -10237,7 +10236,13 @@ paths:
       operationId: GetDashboards
       tags:
         - Dashboards
-      summary: List all dashboards
+      summary: List dashboards
+      description: |
+        Lists [dashboards](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#dashboard).
+
+        #### Related guides
+
+        - [Manage dashboards](https://docs.influxdata.com/influxdb/cloud/visualize-data/dashboards/).
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - $ref: '#/components/parameters/Offset'
@@ -10249,10 +10254,13 @@ paths:
             minimum: -1
             maximum: 100
             default: 20
-          description: The non-zero number of dashboards to return
+          description: |
+            The maximum number of [dashboards](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#dashboard) to return.
+            Default is `20`.
+            The minimum is `-1` and the maximum is `100`.
         - in: query
           name: owner
-          description: A user identifier. Returns only dashboards where this user has the `owner` role.
+          description: 'A user ID. Only returns [dashboards](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#dashboard) where the specified user has the `owner` role.'
           schema:
             type: string
         - in: query
@@ -10266,24 +10274,33 @@ paths:
               - UpdatedAt
         - in: query
           name: id
-          description: 'A list of dashboard identifiers. Returns only the listed dashboards. If both `id` and `owner` are specified, only `id` is used.'
+          description: |
+            A list of dashboard IDs.
+            Returns only the specified [dashboards](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#dashboard).
+            If you specify `id` and `owner`, only `id` is used.
           schema:
             type: array
             items:
               type: string
         - in: query
           name: orgID
-          description: The identifier of the organization.
+          description: |
+            An organization ID.
+            Only returns [dashboards](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#dashboard) that belong to the specified
+            [organization](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#organization).
           schema:
             type: string
         - in: query
           name: org
-          description: The name of the organization.
+          description: |
+            An organization name.
+            Only returns [dashboards](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#dashboard) that belong to the specified
+            [organization](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#organization).
           schema:
             type: string
       responses:
         '200':
-          description: All dashboards
+          description: Success. The response body contains dashboards.
           content:
             application/json:
               schema:
@@ -10499,7 +10516,7 @@ paths:
         - lang: Shell
           label: 'cURL: all tasks, basic output'
           source: |
-            curl https://cloud2.influxdata.com/api/v2/tasks/?limit=-1&type=basic \
+            curl INFLUX_URL/api/v2/tasks/?limit=-1&type=basic \
               --header 'Content-Type: application/json' \
               --header 'Authorization: Token INFLUX_API_TOKEN'
     post:
@@ -10618,7 +10635,7 @@ paths:
         - lang: Shell
           label: 'cURL: create a Flux script task'
           source: |
-            curl https://cloud2.influxdata.com/api/v2/tasks \
+            curl INFLUX_URL/api/v2/tasks \
             --header "Content-type: application/json" \
             --header "Authorization: Token INFLUX_API_TOKEN" \
             --data-binary @- << EOF
@@ -10635,7 +10652,7 @@ paths:
         - lang: Shell
           label: 'cURL: create a Flux script reference task'
           source: |
-            curl https://cloud2.influxdata.com/api/v2/tasks \
+            curl INFLUX_URL/api/v2/tasks \
             --header "Content-type: application/json" \
             --header "Authorization: Token INFLUX_API_TOKEN" \
             --data-binary @- << EOF
@@ -15411,12 +15428,15 @@ components:
             description: this is a description
     LabelMapping:
       type: object
+      description: A _label mapping_ contains a `label` ID to attach to a resource.
       properties:
         labelID:
           description: |
-            Label ID.
-            The ID of the label to attach.
+            A label ID.
+            Specifies the label to attach.
           type: string
+      required:
+        - labelID
     LabelsResponse:
       type: object
       properties:
@@ -15546,19 +15566,19 @@ components:
             query: /api/v2/checks/1/query
           properties:
             self:
-              description: URL for this check
+              description: The URL for this check.
               $ref: '#/components/schemas/Link'
             labels:
-              description: URL to retrieve labels for this check
+              description: The URL to retrieve labels for this check.
               $ref: '#/components/schemas/Link'
             members:
-              description: URL to retrieve members for this check
+              description: The URL to retrieve members for this check.
               $ref: '#/components/schemas/Link'
             owners:
-              description: URL to retrieve owners for this check
+              description: The URL to retrieve owners for this check.
               $ref: '#/components/schemas/Link'
             query:
-              description: URL to retrieve flux script for this check
+              description: The URL to retrieve the Flux script for this check.
               $ref: '#/components/schemas/Link'
       required:
         - name
@@ -15875,19 +15895,19 @@ components:
             query: /api/v2/notificationRules/1/query
           properties:
             self:
-              description: URL for this endpoint.
+              description: The URL for this endpoint.
               $ref: '#/components/schemas/Link'
             labels:
-              description: URL to retrieve labels for this notification rule.
+              description: The URL to retrieve labels for this notification rule.
               $ref: '#/components/schemas/Link'
             members:
-              description: URL to retrieve members for this notification rule.
+              description: The URL to retrieve members for this notification rule.
               $ref: '#/components/schemas/Link'
             owners:
-              description: URL to retrieve owners for this notification rule.
+              description: The URL to retrieve owners for this notification rule.
               $ref: '#/components/schemas/Link'
             query:
-              description: URL to retrieve flux script for this notification rule.
+              description: The URL to retrieve the Flux script for this notification rule.
               $ref: '#/components/schemas/Link'
     TagRule:
       type: object
@@ -16096,16 +16116,16 @@ components:
             owners: /api/v2/notificationEndpoints/1/owners
           properties:
             self:
-              description: URL for this endpoint.
+              description: The URL for this endpoint.
               $ref: '#/components/schemas/Link'
             labels:
-              description: URL to retrieve labels for this endpoint.
+              description: The URL to retrieve labels for this endpoint.
               $ref: '#/components/schemas/Link'
             members:
-              description: URL to retrieve members for this endpoint.
+              description: The URL to retrieve members for this endpoint.
               $ref: '#/components/schemas/Link'
             owners:
-              description: URL to retrieve owners for this endpoint.
+              description: The URL to retrieve owners for this endpoint.
               $ref: '#/components/schemas/Link'
         type:
           $ref: '#/components/schemas/NotificationEndpointType'

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -2725,32 +2725,28 @@ paths:
       operationId: GetQuerySuggestions
       tags:
         - Query
-      summary: Retrieve Flux query suggestions
+      summary: List Flux query suggestions
       description: |
-        Retrieves a list of Flux query suggestions. Each suggestion contains a
+        Lists Flux query suggestions. Each suggestion contains a
         [Flux function](https://docs.influxdata.com/flux/v0.x/stdlib/all-functions/)
         name and parameters.
 
         Use this endpoint to retrieve a list of Flux query suggestions used in the
-        InfluxDB Flux Query Builder. Helper function names have an underscore (`_`)
-        prefix and aren't meant to be used directly in queries--for example:
-
-        - **Recommended**:  Use `top(n, columns=["_value"], tables=<-)` to sort
-          on a column and keep the top n records instead of `_sortLimit_`.
-          `top` uses the `_sortLimit` helper function.
+        InfluxDB Flux Query Builder.
 
         #### Limitations
 
-        - Using `/api/v2/query/suggestions/` (note the trailing slash) with cURL
-        will result in a HTTP `301 Moved Permanently` status code. Please use
-        `/api/v2/query/suggestions` without a trailing slash.
-
         - When writing a query, avoid using `_functionName()` helper functions
-        exposed by this endpoint.
+        exposed by this endpoint.  Helper function names have an underscore (`_`)
+        prefix and aren't meant to be used directly in queries--for example:
+
+          - To sort on a column and keep the top n records, use the
+            `top(n, columns=["_value"], tables=<-)` function instead of the `_sortLimit`
+            helper function. `top` uses `_sortLimit`.
 
         #### Related Guides
 
-        - [List of all Flux functions](https://docs.influxdata.com/influxdb/v2.3/flux/v0.x/stdlib/all-functions/)
+        - [List of all Flux functions](https://docs.influxdata.com/flux/v0.x/stdlib/all-functions/)
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
       responses:
@@ -3351,7 +3347,7 @@ paths:
           description: |
             Moved Permanently.
             InfluxData has moved the URL of the endpoint.
-            Use `/api/v2/query/suggestions`.
+            Use `/api/v2/query/suggestions` (without a trailing slash).
           content:
             text/html:
               schema:
@@ -3377,7 +3373,7 @@ paths:
         - lang: Shell
           label: cURL
           source: |
-            curl --request GET "https://cloud2.influxdata.com/api/v2/query/suggestions" \
+            curl --request GET "INFLUX_URL/api/v2/query/suggestions" \
               --header "Accept: application/json" \
               --header "Authorization: Token INFLUX_API_TOKEN"
   '/query/suggestions/{name}':
@@ -3403,7 +3399,7 @@ paths:
 
         #### Related Guides
 
-        - [List of all Flux functions](https://docs.influxdata.com/influxdb/v2.3/flux/v0.x/stdlib/all-functions/)
+        - [List of all Flux functions](https://docs.influxdata.com/flux/v0.x/stdlib/all-functions/)
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -3412,8 +3408,7 @@ paths:
             type: string
           required: true
           description: |
-            A Flux Function name.
-            Only returns functions with this name.
+            A [Flux function](https://docs.influxdata.com/flux/v0.x/stdlib/all-functions/) name.
       responses:
         '200':
           description: |
@@ -3450,7 +3445,7 @@ paths:
         - lang: Shell
           label: cURL
           source: |
-            curl --request GET "https://cloud2.influxdata.com/api/v2/query/suggestions/sum/" \
+            curl --request GET "INFLUX_URL/api/v2/query/suggestions/sum/" \
               --header "Accept: application/json" \
               --header "Authorization: Token INFLUX_API_TOKEN"
   /query/analyze:
@@ -3777,7 +3772,7 @@ paths:
         - Buckets
       summary: List buckets
       description: |
-        Retrieves a list of [buckets](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#bucket).
+        Lists [buckets](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#bucket).
 
         InfluxDB retrieves buckets owned by the
         [organization](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#organization)
@@ -5993,11 +5988,15 @@ paths:
         - Templates
       summary: List installed stacks
       description: |
-        Retrieves a list of installed InfluxDB stacks.
+        Lists installed InfluxDB stacks.
 
         To limit stacks in the response, pass query parameters in your request.
         If no query parameters are passed, InfluxDB returns all installed stacks
         for the organization.
+
+        #### Related guides
+
+        - [View InfluxDB stacks](https://docs.influxdata.com/influxdb/v2.3/influxdb-templates/stacks/).
       parameters:
         - in: query
           name: orgID
@@ -6005,8 +6004,8 @@ paths:
           schema:
             type: string
           description: |
-            The ID of the organization that owns the stacks.
-            Only returns stacks owned by this organization.
+            An organization ID.
+            Only returns stacks owned by the specified [organization](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#organization).
 
             #### InfluxDB Cloud
 
@@ -6017,14 +6016,14 @@ paths:
           schema:
             type: string
           description: |
-            The stack name.
+            A stack name.
             Finds stack `events` with this name and returns the stacks.
 
             Repeatable.
             To filter for more than one stack name,
             repeat this parameter with each name--for example:
 
-            - `http://localhost:8086/api/v2/stacks?&orgID=INFLUX_ORG_ID&name=project-stack-0&name=project-stack-1`
+            - `INFLUX_URL/api/v2/stacks?&orgID=INFLUX_ORG_ID&name=project-stack-0&name=project-stack-1`
           examples:
             findStackByName:
               summary: Find stacks with the event name
@@ -6034,14 +6033,14 @@ paths:
           schema:
             type: string
           description: |
-            The stack ID.
-            Only returns stacks with this ID.
+            A stack ID.
+            Only returns the specified stack.
 
             Repeatable.
             To filter for more than one stack ID,
             repeat this parameter with each ID--for example:
 
-            - `http://localhost:8086/api/v2/stacks?&orgID=INFLUX_ORG_ID&stackID=09bd87cd33be3000&stackID=09bef35081fe3000`
+            - `INFLUX_URL/api/v2/stacks?&orgID=INFLUX_ORG_ID&stackID=09bd87cd33be3000&stackID=09bef35081fe3000`
           examples:
             findStackByID:
               summary: Find a stack with the ID
@@ -6115,8 +6114,8 @@ paths:
 
         #### Related guides
 
-        - [InfluxDB stacks](https://docs.influxdata.com/influxdb/v2.3/influxdb-templates/stacks/)
-        - [Use InfluxDB templates](https://docs.influxdata.com/influxdb/v2.3/influxdb-templates/use/#apply-templates-to-an-influxdb-instance)
+        - [Initialize an InfluxDB stack](https://docs.influxdata.com/influxdb/v2.3/influxdb-templates/stacks/init/).
+        - [Use InfluxDB templates](https://docs.influxdata.com/influxdb/v2.3/influxdb-templates/use/#apply-templates-to-an-influxdb-instance).
       requestBody:
         description: The stack to create.
         required: true
@@ -13292,12 +13291,15 @@ components:
             description: this is a description
     LabelMapping:
       type: object
+      description: A _label mapping_ contains a `label` ID to attach to a resource.
       properties:
         labelID:
           description: |
-            Label ID.
-            The ID of the label to attach.
+            A label ID.
+            Specifies the label to attach.
           type: string
+      required:
+        - labelID
     LabelsResponse:
       type: object
       properties:
@@ -13427,19 +13429,19 @@ components:
             query: /api/v2/checks/1/query
           properties:
             self:
-              description: URL for this check
+              description: The URL for this check.
               $ref: '#/components/schemas/Link'
             labels:
-              description: URL to retrieve labels for this check
+              description: The URL to retrieve labels for this check.
               $ref: '#/components/schemas/Link'
             members:
-              description: URL to retrieve members for this check
+              description: The URL to retrieve members for this check.
               $ref: '#/components/schemas/Link'
             owners:
-              description: URL to retrieve owners for this check
+              description: The URL to retrieve owners for this check.
               $ref: '#/components/schemas/Link'
             query:
-              description: URL to retrieve flux script for this check
+              description: The URL to retrieve the Flux script for this check.
               $ref: '#/components/schemas/Link'
       required:
         - name
@@ -13756,19 +13758,19 @@ components:
             query: /api/v2/notificationRules/1/query
           properties:
             self:
-              description: URL for this endpoint.
+              description: The URL for this endpoint.
               $ref: '#/components/schemas/Link'
             labels:
-              description: URL to retrieve labels for this notification rule.
+              description: The URL to retrieve labels for this notification rule.
               $ref: '#/components/schemas/Link'
             members:
-              description: URL to retrieve members for this notification rule.
+              description: The URL to retrieve members for this notification rule.
               $ref: '#/components/schemas/Link'
             owners:
-              description: URL to retrieve owners for this notification rule.
+              description: The URL to retrieve owners for this notification rule.
               $ref: '#/components/schemas/Link'
             query:
-              description: URL to retrieve flux script for this notification rule.
+              description: The URL to retrieve the Flux script for this notification rule.
               $ref: '#/components/schemas/Link'
     TagRule:
       type: object
@@ -13977,16 +13979,16 @@ components:
             owners: /api/v2/notificationEndpoints/1/owners
           properties:
             self:
-              description: URL for this endpoint.
+              description: The URL for this endpoint.
               $ref: '#/components/schemas/Link'
             labels:
-              description: URL to retrieve labels for this endpoint.
+              description: The URL to retrieve labels for this endpoint.
               $ref: '#/components/schemas/Link'
             members:
-              description: URL to retrieve members for this endpoint.
+              description: The URL to retrieve members for this endpoint.
               $ref: '#/components/schemas/Link'
             owners:
-              description: URL to retrieve owners for this endpoint.
+              description: The URL to retrieve owners for this endpoint.
               $ref: '#/components/schemas/Link'
         type:
           $ref: '#/components/schemas/NotificationEndpointType'

--- a/contracts/invocable-scripts.yml
+++ b/contracts/invocable-scripts.yml
@@ -27,7 +27,7 @@ paths:
         - Invokable Scripts
       summary: List scripts
       description: |
-        Retrieves a list of [scripts](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/).
+        Lists [scripts](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/).
 
         #### Related guides
 
@@ -139,7 +139,7 @@ paths:
         - lang: Shell
           label: 'cURL: retrieves the first 100 scripts.'
           source: |
-            curl --request GET "https://cloud2.influxdata.com/api/v2/scripts?limit=100&offset=0" \
+            curl --request GET "INFLUX_URL/api/v2/scripts?limit=100&offset=0" \
               --header "Authorization: Token INFLUX_API_TOKEN" \
               --header "Accept: application/json" \
               --header "Content-Type: application/json"
@@ -213,7 +213,7 @@ paths:
         - lang: Shell
           label: cURL
           source: |
-            curl --request POST "https://cloud2.influxdata.com/api/v2/scripts" \
+            curl --request POST "INFLUX_URL/api/v2/scripts" \
               --header "Authorization: Token INFLUX_API_TOKEN" \
               --header "Accept: application/json" \
               --header "Content-Type: application/json" \
@@ -449,7 +449,7 @@ paths:
         - lang: Shell
           label: cURL
           source: |
-            curl --request POST "https://cloud2.influxdata.com/api/v2/scripts/SCRIPT_ID/invoke" \
+            curl --request POST "INFLUX_URL/api/v2/scripts/SCRIPT_ID/invoke" \
                       --header "Authorization: Token INFLUX_TOKEN" \
                       --header 'Accept: application/csv' \
                       --header 'Content-Type: application/json' \

--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -903,7 +903,7 @@ paths:
         - Users
       summary: List users
       description: |
-        Retrieves a list of [users]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user).
+        Lists [users]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user).
         Default limit is `20`.
 
         To limit which users are returned, pass query parameters in your request.
@@ -916,6 +916,10 @@ paths:
         | List a specific user | `read-users` or `read-user USER_ID` | |
 
         *`USER_ID`* is the ID of the user that you want to retrieve.
+
+        #### Related guides
+
+        - [View users](https://docs.influxdata.com/influxdb/latest/users/view-users/).
       parameters:
         - $ref: '#/paths/~1ready/get/parameters/0'
         - in: query
@@ -1060,8 +1064,8 @@ paths:
         This endpoint represents the first two steps in a four-step process to allow a user
         to authenticate with a username and password, and then access data in an organization:
 
-          1. Create a user: send a `POST` request to `POST /api/v2/users`. `name` is required.
-          2. Extract the user ID (`id`) value from the API response for _step 1_.
+          1. Create a user: send a `POST` request to `POST /api/v2/users`. The `name` property is required.
+          2. Extract the user ID (`id` property) value from the API response for _step 1_.
           3. Create an authorization (and API token) for the user: send a `POST` request to [`POST /api/v2/authorizations`](#operation/PostAuthorizations), passing the user ID (`id`) from _step 2_.
           4. Create a password for the user: send a `POST` request to [`POST /api/v2/users/USER_ID/password`](#operation/PostUsersIDPassword), passing the user ID from _step 2_.
 
@@ -1127,24 +1131,34 @@ paths:
         - label: 'cURL: create a user and set a password'
           lang: Shell
           source: |
-            # Create the user and assign the user ID to a variable.
-            USER_ID=$(curl --request POST \
-                    "http://localhost:8086/api/v2/users/" \
-                    --header "Authorization: Token INFLUX_OP_TOKEN" \
-                    --header 'Content-type: application/json' \
-                    --data-binary @- << EOF | jq -r '.id'
-                    {
-                      "name": "USER_NAME",
-                      "status": "active"
-                    }
-            EOF
-            )
+            # The following steps show how to create a user and then set
+            # the user's password:
+            #
+            # 1. Send a request to this endpoint to create a user--for example:
 
-            # Pass the user ID and a password to set the password for the user.
-            curl request POST "http://localhost:8086/api/v2/users/$USER_ID/password/" \
-              --header "Authorization: Token INFLUX_OP_TOKEN" \
-              --header 'Content-type: application/json' \
-              --data '{ "password": "USER_PASSWORD" }'
+                  USER=$(curl --request POST \
+                          "INFLUX_URL/api/v2/users/" \
+                          --header "Authorization: Token INFLUX_API_TOKEN" \
+                          --header 'Content-type: application/json' \
+                          --data-binary @- << EOF
+                          {
+                            "name": "USER_NAME",
+                            "status": "active"
+                          }
+                  EOF
+                  )
+
+            # 2. Extract the id property from the response in step 1--for example:
+
+                  USER_ID=`echo $USER | jq -r '.id'`
+
+            # 3. To set the user's password, set the password property in a request
+            #    to the /api/v2/users/USER_ID/password endpoint--for example:
+
+                  curl request POST "INFLUX_URL/api/v2/users/$USER_ID/password/" \
+                    --header "Authorization: Token INFLUX_API_TOKEN" \
+                    --header 'Content-type: application/json' \
+                    --data '{ "password": "USER_PASSWORD" }'
   '/users/{userID}':
     get:
       operationId: GetUsersID
@@ -2245,12 +2259,15 @@ paths:
           application/json:
             schema:
               type: object
+              description: A _label mapping_ contains a `label` ID to attach to a resource.
               properties:
                 labelID:
                   description: |
-                    Label ID.
-                    The ID of the label to attach.
+                    A label ID.
+                    Specifies the label to attach.
                   type: string
+              required:
+                - labelID
       responses:
         '201':
           description: The newly added label
@@ -3247,7 +3264,7 @@ paths:
                 - name
       responses:
         '201':
-          description: Added dashboard
+          description: Success. The dashboard is created.
           content:
             application/json:
               schema:
@@ -4098,19 +4115,19 @@ paths:
                                                                 query: /api/v2/checks/1/query
                                                               properties:
                                                                 self:
-                                                                  description: URL for this check
+                                                                  description: The URL for this check.
                                                                   $ref: '#/components/schemas/Task/properties/links/properties/self'
                                                                 labels:
-                                                                  description: URL to retrieve labels for this check
+                                                                  description: The URL to retrieve labels for this check.
                                                                   $ref: '#/components/schemas/Task/properties/links/properties/self'
                                                                 members:
-                                                                  description: URL to retrieve members for this check
+                                                                  description: The URL to retrieve members for this check.
                                                                   $ref: '#/components/schemas/Task/properties/links/properties/self'
                                                                 owners:
-                                                                  description: URL to retrieve owners for this check
+                                                                  description: The URL to retrieve owners for this check.
                                                                   $ref: '#/components/schemas/Task/properties/links/properties/self'
                                                                 query:
-                                                                  description: URL to retrieve flux script for this check
+                                                                  description: The URL to retrieve the Flux script for this check.
                                                                   $ref: '#/components/schemas/Task/properties/links/properties/self'
                                                           required:
                                                             - name
@@ -4941,7 +4958,13 @@ paths:
       operationId: GetDashboards
       tags:
         - Dashboards
-      summary: List all dashboards
+      summary: List dashboards
+      description: |
+        Lists [dashboards]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#dashboard).
+
+        #### Related guides
+
+        - [Manage dashboards]({{% INFLUXDB_DOCS_URL %}}/visualize-data/dashboards/).
       parameters:
         - $ref: '#/paths/~1ready/get/parameters/0'
         - $ref: '#/paths/~1users/get/parameters/1'
@@ -4954,7 +4977,7 @@ paths:
             default: false
         - in: query
           name: owner
-          description: A user identifier. Returns only dashboards where this user has the `owner` role.
+          description: 'A user ID. Only returns [dashboards]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#dashboard) where the specified user has the `owner` role.'
           schema:
             type: string
         - in: query
@@ -4968,24 +4991,33 @@ paths:
               - UpdatedAt
         - in: query
           name: id
-          description: 'A list of dashboard identifiers. Returns only the listed dashboards. If both `id` and `owner` are specified, only `id` is used.'
+          description: |
+            A list of dashboard IDs.
+            Returns only the specified [dashboards]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#dashboard).
+            If you specify `id` and `owner`, only `id` is used.
           schema:
             type: array
             items:
               type: string
         - in: query
           name: orgID
-          description: The identifier of the organization.
+          description: |
+            An organization ID.
+            Only returns [dashboards]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#dashboard) that belong to the specified
+            [organization]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#organization).
           schema:
             type: string
         - in: query
           name: org
-          description: The name of the organization.
+          description: |
+            An organization name.
+            Only returns [dashboards]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#dashboard) that belong to the specified
+            [organization]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#organization).
           schema:
             type: string
       responses:
         '200':
-          description: All dashboards
+          description: Success. The response body contains dashboards.
           content:
             application/json:
               schema:

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -3758,8 +3758,8 @@
         "tags": [
           "Query"
         ],
-        "summary": "Retrieve Flux query suggestions",
-        "description": "Retrieves a list of Flux query suggestions. Each suggestion contains a\n[Flux function](https://docs.influxdata.com/flux/v0.x/stdlib/all-functions/)\nname and parameters.\n\nUse this endpoint to retrieve a list of Flux query suggestions used in the\nInfluxDB Flux Query Builder. Helper function names have an underscore (`_`)\nprefix and aren't meant to be used directly in queries--for example:\n\n- **Recommended**:  Use `top(n, columns=[\"_value\"], tables=<-)` to sort\n  on a column and keep the top n records instead of `_sortLimit_`.\n  `top` uses the `_sortLimit` helper function.\n\n#### Limitations\n\n- Using `/api/v2/query/suggestions/` (note the trailing slash) with cURL\nwill result in a HTTP `301 Moved Permanently` status code. Please use\n`/api/v2/query/suggestions` without a trailing slash.\n\n- When writing a query, avoid using `_functionName()` helper functions\nexposed by this endpoint.\n\n#### Related Guides\n\n- [List of all Flux functions]({{% INFLUXDB_DOCS_URL %}}/flux/v0.x/stdlib/all-functions/)\n",
+        "summary": "List Flux query suggestions",
+        "description": "Lists Flux query suggestions. Each suggestion contains a\n[Flux function](https://docs.influxdata.com/flux/v0.x/stdlib/all-functions/)\nname and parameters.\n\nUse this endpoint to retrieve a list of Flux query suggestions used in the\nInfluxDB Flux Query Builder.\n\n#### Limitations\n\n- When writing a query, avoid using `_functionName()` helper functions\nexposed by this endpoint.  Helper function names have an underscore (`_`)\nprefix and aren't meant to be used directly in queries--for example:\n\n  - To sort on a column and keep the top n records, use the\n    `top(n, columns=[\"_value\"], tables=<-)` function instead of the `_sortLimit`\n    helper function. `top` uses `_sortLimit`.\n\n#### Related Guides\n\n- [List of all Flux functions](https://docs.influxdata.com/flux/v0.x/stdlib/all-functions/)\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -4702,7 +4702,7 @@
             }
           },
           "301": {
-            "description": "Moved Permanently.\nInfluxData has moved the URL of the endpoint.\nUse `/api/v2/query/suggestions`.\n",
+            "description": "Moved Permanently.\nInfluxData has moved the URL of the endpoint.\nUse `/api/v2/query/suggestions` (without a trailing slash).\n",
             "content": {
               "text/html": {
                 "schema": {
@@ -4739,7 +4739,7 @@
           {
             "lang": "Shell",
             "label": "cURL",
-            "source": "curl --request GET \"https://cloud2.influxdata.com/api/v2/query/suggestions\" \\\n  --header \"Accept: application/json\" \\\n  --header \"Authorization: Token INFLUX_API_TOKEN\"\n"
+            "source": "curl --request GET \"INFLUX_URL/api/v2/query/suggestions\" \\\n  --header \"Accept: application/json\" \\\n  --header \"Authorization: Token INFLUX_API_TOKEN\"\n"
           }
         ]
       }
@@ -4751,7 +4751,7 @@
           "Query"
         ],
         "summary": "Retrieve a query suggestion for a branching suggestion",
-        "description": "Retrieves a query suggestion that contains the name and parameters of the\nrequested function.\n\nUse this endpoint to pass a branching suggestion (a Flux function name) and\nretrieve the parameters of the requested function.\n\n#### Limitations\n\n- Use `/api/v2/query/suggestions/{name}` (without a trailing slash).\n`/api/v2/query/suggestions/{name}/` (note the trailing slash) results in a\nHTTP `301 Moved Permanently` status.\n\n- The function `name` must exist and must be spelled correctly.\n\n#### Related Guides\n\n- [List of all Flux functions]({{% INFLUXDB_DOCS_URL %}}/flux/v0.x/stdlib/all-functions/)\n",
+        "description": "Retrieves a query suggestion that contains the name and parameters of the\nrequested function.\n\nUse this endpoint to pass a branching suggestion (a Flux function name) and\nretrieve the parameters of the requested function.\n\n#### Limitations\n\n- Use `/api/v2/query/suggestions/{name}` (without a trailing slash).\n`/api/v2/query/suggestions/{name}/` (note the trailing slash) results in a\nHTTP `301 Moved Permanently` status.\n\n- The function `name` must exist and must be spelled correctly.\n\n#### Related Guides\n\n- [List of all Flux functions](https://docs.influxdata.com/flux/v0.x/stdlib/all-functions/)\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -4763,7 +4763,7 @@
               "type": "string"
             },
             "required": true,
-            "description": "A Flux Function name.\nOnly returns functions with this name.\n"
+            "description": "A [Flux function](https://docs.influxdata.com/flux/v0.x/stdlib/all-functions/) name.\n"
           }
         ],
         "responses": {
@@ -4813,7 +4813,7 @@
           {
             "lang": "Shell",
             "label": "cURL",
-            "source": "curl --request GET \"https://cloud2.influxdata.com/api/v2/query/suggestions/sum/\" \\\n  --header \"Accept: application/json\" \\\n  --header \"Authorization: Token INFLUX_API_TOKEN\"\n"
+            "source": "curl --request GET \"INFLUX_URL/api/v2/query/suggestions/sum/\" \\\n  --header \"Accept: application/json\" \\\n  --header \"Authorization: Token INFLUX_API_TOKEN\"\n"
           }
         ]
       }
@@ -5122,7 +5122,7 @@
           "Buckets"
         ],
         "summary": "List buckets",
-        "description": "Retrieves a list of [buckets]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#bucket).\n\nInfluxDB retrieves buckets owned by the\n[organization]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#organization)\nassociated with the authorization\n([API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token)).\nTo limit which buckets are returned, pass query parameters in your request.\nIf no query parameters are passed, InfluxDB returns all buckets up to the\ndefault `limit`.\n\n#### InfluxDB OSS\n\n- If you use an _[operator token]({{% INFLUXDB_DOCS_URL %}}/security/tokens/#operator-token)_\n  to authenticate your request, InfluxDB retrieves resources for _all\n  organizations_ in the instance.\n  To retrieve resources for only a specific organization, use the\n  `org` parameter or the `orgID` parameter to specify the organization.\n\n#### Required permissions\n\n| Action                    | Permission required |\n|:--------------------------|:--------------------|\n| Retrieve _user buckets_   | `read-buckets`      |\n| Retrieve [_system buckets_]({{% INFLUXDB_DOCS_URL %}}/reference/internals/system-buckets/) | `read-orgs`         |\n\n#### Related Guides\n\n- [Manage buckets]({{% INFLUXDB_DOCS_URL %}}/organizations/buckets/)\n",
+        "description": "Lists [buckets]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#bucket).\n\nInfluxDB retrieves buckets owned by the\n[organization]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#organization)\nassociated with the authorization\n([API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token)).\nTo limit which buckets are returned, pass query parameters in your request.\nIf no query parameters are passed, InfluxDB returns all buckets up to the\ndefault `limit`.\n\n#### InfluxDB OSS\n\n- If you use an _[operator token]({{% INFLUXDB_DOCS_URL %}}/security/tokens/#operator-token)_\n  to authenticate your request, InfluxDB retrieves resources for _all\n  organizations_ in the instance.\n  To retrieve resources for only a specific organization, use the\n  `org` parameter or the `orgID` parameter to specify the organization.\n\n#### Required permissions\n\n| Action                    | Permission required |\n|:--------------------------|:--------------------|\n| Retrieve _user buckets_   | `read-buckets`      |\n| Retrieve [_system buckets_]({{% INFLUXDB_DOCS_URL %}}/reference/internals/system-buckets/) | `read-orgs`         |\n\n#### Related Guides\n\n- [Manage buckets]({{% INFLUXDB_DOCS_URL %}}/organizations/buckets/)\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -7562,7 +7562,7 @@
           "Templates"
         ],
         "summary": "List installed stacks",
-        "description": "Retrieves a list of installed InfluxDB stacks.\n\nTo limit stacks in the response, pass query parameters in your request.\nIf no query parameters are passed, InfluxDB returns all installed stacks\nfor the organization.\n",
+        "description": "Lists installed InfluxDB stacks.\n\nTo limit stacks in the response, pass query parameters in your request.\nIf no query parameters are passed, InfluxDB returns all installed stacks\nfor the organization.\n\n#### Related guides\n\n- [View InfluxDB stacks]({{% INFLUXDB_DOCS_URL %}}/influxdb-templates/stacks/).\n",
         "parameters": [
           {
             "in": "query",
@@ -7571,7 +7571,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "The ID of the organization that owns the stacks.\nOnly returns stacks owned by this organization.\n\n#### InfluxDB Cloud\n\n- Doesn't require this parameter;\n  InfluxDB only returns resources allowed by the API token.\n"
+            "description": "An organization ID.\nOnly returns stacks owned by the specified [organization]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#organization).\n\n#### InfluxDB Cloud\n\n- Doesn't require this parameter;\n  InfluxDB only returns resources allowed by the API token.\n"
           },
           {
             "in": "query",
@@ -7579,7 +7579,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "The stack name.\nFinds stack `events` with this name and returns the stacks.\n\nRepeatable.\nTo filter for more than one stack name,\nrepeat this parameter with each name--for example:\n\n- `http://localhost:8086/api/v2/stacks?&orgID=INFLUX_ORG_ID&name=project-stack-0&name=project-stack-1`\n",
+            "description": "A stack name.\nFinds stack `events` with this name and returns the stacks.\n\nRepeatable.\nTo filter for more than one stack name,\nrepeat this parameter with each name--for example:\n\n- `INFLUX_URL/api/v2/stacks?&orgID=INFLUX_ORG_ID&name=project-stack-0&name=project-stack-1`\n",
             "examples": {
               "findStackByName": {
                 "summary": "Find stacks with the event name",
@@ -7593,7 +7593,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "The stack ID.\nOnly returns stacks with this ID.\n\nRepeatable.\nTo filter for more than one stack ID,\nrepeat this parameter with each ID--for example:\n\n- `http://localhost:8086/api/v2/stacks?&orgID=INFLUX_ORG_ID&stackID=09bd87cd33be3000&stackID=09bef35081fe3000`\n",
+            "description": "A stack ID.\nOnly returns the specified stack.\n\nRepeatable.\nTo filter for more than one stack ID,\nrepeat this parameter with each ID--for example:\n\n- `INFLUX_URL/api/v2/stacks?&orgID=INFLUX_ORG_ID&stackID=09bd87cd33be3000&stackID=09bef35081fe3000`\n",
             "examples": {
               "findStackByID": {
                 "summary": "Find a stack with the ID",
@@ -7671,7 +7671,7 @@
           "Templates"
         ],
         "summary": "Create a stack",
-        "description": "Creates or initializes a stack.\n\nUse this endpoint to _manually_ initialize a new stack with the following\noptional information:\n\n  - Stack name\n  - Stack description\n  - URLs for template manifest files\n\nTo automatically create a stack when applying templates,\nuse the [/api/v2/templates/apply endpoint](#operation/ApplyTemplate).\n\n#### Required permissions\n\n- `write` permission for the organization\n\n#### Related guides\n\n- [InfluxDB stacks]({{% INFLUXDB_DOCS_URL %}}/influxdb-templates/stacks/)\n- [Use InfluxDB templates]({{% INFLUXDB_DOCS_URL %}}/influxdb-templates/use/#apply-templates-to-an-influxdb-instance)\n",
+        "description": "Creates or initializes a stack.\n\nUse this endpoint to _manually_ initialize a new stack with the following\noptional information:\n\n  - Stack name\n  - Stack description\n  - URLs for template manifest files\n\nTo automatically create a stack when applying templates,\nuse the [/api/v2/templates/apply endpoint](#operation/ApplyTemplate).\n\n#### Required permissions\n\n- `write` permission for the organization\n\n#### Related guides\n\n- [Initialize an InfluxDB stack]({{% INFLUXDB_DOCS_URL %}}/influxdb-templates/stacks/init/).\n- [Use InfluxDB templates]({{% INFLUXDB_DOCS_URL %}}/influxdb-templates/use/#apply-templates-to-an-influxdb-instance).\n",
         "requestBody": {
           "description": "The stack to create.",
           "required": true,
@@ -12073,7 +12073,7 @@
           "Users"
         ],
         "summary": "List users",
-        "description": "Retrieves a list of [users]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user).\nDefault limit is `20`.\n\nTo limit which users are returned, pass query parameters in your request.\n\n#### Required permissions for InfluxDB OSS\n\n| Action | Permission required | Restriction |\n|:-------|:--------------------|:------------|\n| List all users | _[Operator token](https://docs.influxdata.com/influxdb/latest/security/tokens/#operator-token)_  | |\n| List a specific user | `read-users` or `read-user USER_ID` | |\n\n*`USER_ID`* is the ID of the user that you want to retrieve.\n",
+        "description": "Lists [users]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user).\nDefault limit is `20`.\n\nTo limit which users are returned, pass query parameters in your request.\n\n#### Required permissions for InfluxDB OSS\n\n| Action | Permission required | Restriction |\n|:-------|:--------------------|:------------|\n| List all users | _[Operator token](https://docs.influxdata.com/influxdb/latest/security/tokens/#operator-token)_  | |\n| List a specific user | `read-users` or `read-user USER_ID` | |\n\n*`USER_ID`* is the ID of the user that you want to retrieve.\n\n#### Related guides\n\n- [View users](https://docs.influxdata.com/influxdb/latest/users/view-users/).\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -12159,7 +12159,7 @@
           "Users"
         ],
         "summary": "Create a user",
-        "description": "Creates a [user]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user) that can access InfluxDB.\nReturns the user.\n\nUse this endpoint to create a user that can sign in to start a user session\nthrough one of the following interfaces:\n\n  - InfluxDB UI\n  - `/api/v2/signin` InfluxDB API endpoint\n  - InfluxDB CLI\n\nThis endpoint represents the first two steps in a four-step process to allow a user\nto authenticate with a username and password, and then access data in an organization:\n\n  1. Create a user: send a `POST` request to `POST /api/v2/users`. `name` is required.\n  2. Extract the user ID (`id`) value from the API response for _step 1_.\n  3. Create an authorization (and API token) for the user: send a `POST` request to [`POST /api/v2/authorizations`](#operation/PostAuthorizations), passing the user ID (`id`) from _step 2_.\n  4. Create a password for the user: send a `POST` request to [`POST /api/v2/users/USER_ID/password`](#operation/PostUsersIDPassword), passing the user ID from _step 2_.\n\n#### Required permissions\n\n| Action | Permission required | Restriction |\n|:-------|:--------------------|:------------|\n| Create a user | _[Operator token](https://docs.influxdata.com/influxdb/latest/security/tokens/#operator-token)_  | |\n\n#### Related guides\n\n- [Create a user](https://docs.influxdata.com/influxdb/latest/users/create-user/)\n- [Create an API token scoped to a user](https://docs.influxdata.com/influxdb/latest/security/tokens/create-token/#create-a-token-scoped-to-a-user)\n",
+        "description": "Creates a [user]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user) that can access InfluxDB.\nReturns the user.\n\nUse this endpoint to create a user that can sign in to start a user session\nthrough one of the following interfaces:\n\n  - InfluxDB UI\n  - `/api/v2/signin` InfluxDB API endpoint\n  - InfluxDB CLI\n\nThis endpoint represents the first two steps in a four-step process to allow a user\nto authenticate with a username and password, and then access data in an organization:\n\n  1. Create a user: send a `POST` request to `POST /api/v2/users`. The `name` property is required.\n  2. Extract the user ID (`id` property) value from the API response for _step 1_.\n  3. Create an authorization (and API token) for the user: send a `POST` request to [`POST /api/v2/authorizations`](#operation/PostAuthorizations), passing the user ID (`id`) from _step 2_.\n  4. Create a password for the user: send a `POST` request to [`POST /api/v2/users/USER_ID/password`](#operation/PostUsersIDPassword), passing the user ID from _step 2_.\n\n#### Required permissions\n\n| Action | Permission required | Restriction |\n|:-------|:--------------------|:------------|\n| Create a user | _[Operator token](https://docs.influxdata.com/influxdb/latest/security/tokens/#operator-token)_  | |\n\n#### Related guides\n\n- [Create a user](https://docs.influxdata.com/influxdb/latest/users/create-user/)\n- [Create an API token scoped to a user](https://docs.influxdata.com/influxdb/latest/security/tokens/create-token/#create-a-token-scoped-to-a-user)\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -12228,7 +12228,7 @@
           {
             "label": "cURL: create a user and set a password",
             "lang": "Shell",
-            "source": "# Create the user and assign the user ID to a variable.\nUSER_ID=$(curl --request POST \\\n        \"http://localhost:8086/api/v2/users/\" \\\n        --header \"Authorization: Token INFLUX_OP_TOKEN\" \\\n        --header 'Content-type: application/json' \\\n        --data-binary @- << EOF | jq -r '.id'\n        {\n          \"name\": \"USER_NAME\",\n          \"status\": \"active\"\n        }\nEOF\n)\n\n# Pass the user ID and a password to set the password for the user.\ncurl request POST \"http://localhost:8086/api/v2/users/$USER_ID/password/\" \\\n  --header \"Authorization: Token INFLUX_OP_TOKEN\" \\\n  --header 'Content-type: application/json' \\\n  --data '{ \"password\": \"USER_PASSWORD\" }'\n"
+            "source": "# The following steps show how to create a user and then set\n# the user's password:\n#\n# 1. Send a request to this endpoint to create a user--for example:\n\n      USER=$(curl --request POST \\\n              \"INFLUX_URL/api/v2/users/\" \\\n              --header \"Authorization: Token INFLUX_API_TOKEN\" \\\n              --header 'Content-type: application/json' \\\n              --data-binary @- << EOF\n              {\n                \"name\": \"USER_NAME\",\n                \"status\": \"active\"\n              }\n      EOF\n      )\n\n# 2. Extract the id property from the response in step 1--for example:\n\n      USER_ID=`echo $USER | jq -r '.id'`\n\n# 3. To set the user's password, set the password property in a request\n#    to the /api/v2/users/USER_ID/password endpoint--for example:\n\n      curl request POST \"INFLUX_URL/api/v2/users/$USER_ID/password/\" \\\n        --header \"Authorization: Token INFLUX_API_TOKEN\" \\\n        --header 'Content-type: application/json' \\\n        --data '{ \"password\": \"USER_PASSWORD\" }'\n"
           }
         ]
       }
@@ -15070,7 +15070,7 @@
         },
         "responses": {
           "201": {
-            "description": "Added dashboard",
+            "description": "Success. The dashboard is created.",
             "content": {
               "application/json": {
                 "schema": {
@@ -15103,7 +15103,8 @@
         "tags": [
           "Dashboards"
         ],
-        "summary": "List all dashboards",
+        "summary": "List dashboards",
+        "description": "Lists [dashboards]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#dashboard).\n\n#### Related guides\n\n- [Manage dashboards]({{% INFLUXDB_DOCS_URL %}}/visualize-data/dashboards/).\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -15120,7 +15121,7 @@
           {
             "in": "query",
             "name": "owner",
-            "description": "A user identifier. Returns only dashboards where this user has the `owner` role.",
+            "description": "A user ID. Only returns [dashboards]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#dashboard) where the specified user has the `owner` role.",
             "schema": {
               "type": "string"
             }
@@ -15141,7 +15142,7 @@
           {
             "in": "query",
             "name": "id",
-            "description": "A list of dashboard identifiers. Returns only the listed dashboards. If both `id` and `owner` are specified, only `id` is used.",
+            "description": "A list of dashboard IDs.\nReturns only the specified [dashboards]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#dashboard).\nIf you specify `id` and `owner`, only `id` is used.\n",
             "schema": {
               "type": "array",
               "items": {
@@ -15152,7 +15153,7 @@
           {
             "in": "query",
             "name": "orgID",
-            "description": "The identifier of the organization.",
+            "description": "An organization ID.\nOnly returns [dashboards]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#dashboard) that belong to the specified\n[organization]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#organization).\n",
             "schema": {
               "type": "string"
             }
@@ -15160,7 +15161,7 @@
           {
             "in": "query",
             "name": "org",
-            "description": "The name of the organization.",
+            "description": "An organization name.\nOnly returns [dashboards]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#dashboard) that belong to the specified\n[organization]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#organization).\n",
             "schema": {
               "type": "string"
             }
@@ -15168,7 +15169,7 @@
         ],
         "responses": {
           "200": {
-            "description": "All dashboards",
+            "description": "Success. The response body contains dashboards.",
             "content": {
               "application/json": {
                 "schema": {
@@ -21898,12 +21899,16 @@
       },
       "LabelMapping": {
         "type": "object",
+        "description": "A _label mapping_ contains a `label` ID to attach to a resource.",
         "properties": {
           "labelID": {
-            "description": "Label ID.\nThe ID of the label to attach.\n",
+            "description": "A label ID.\nSpecifies the label to attach.\n",
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "labelID"
+        ]
       },
       "LabelsResponse": {
         "type": "object",
@@ -22095,23 +22100,23 @@
             },
             "properties": {
               "self": {
-                "description": "URL for this check",
+                "description": "The URL for this check.",
                 "$ref": "#/components/schemas/Link"
               },
               "labels": {
-                "description": "URL to retrieve labels for this check",
+                "description": "The URL to retrieve labels for this check.",
                 "$ref": "#/components/schemas/Link"
               },
               "members": {
-                "description": "URL to retrieve members for this check",
+                "description": "The URL to retrieve members for this check.",
                 "$ref": "#/components/schemas/Link"
               },
               "owners": {
-                "description": "URL to retrieve owners for this check",
+                "description": "The URL to retrieve owners for this check.",
                 "$ref": "#/components/schemas/Link"
               },
               "query": {
-                "description": "URL to retrieve flux script for this check",
+                "description": "The URL to retrieve the Flux script for this check.",
                 "$ref": "#/components/schemas/Link"
               }
             }
@@ -22599,23 +22604,23 @@
             },
             "properties": {
               "self": {
-                "description": "URL for this endpoint.",
+                "description": "The URL for this endpoint.",
                 "$ref": "#/components/schemas/Link"
               },
               "labels": {
-                "description": "URL to retrieve labels for this notification rule.",
+                "description": "The URL to retrieve labels for this notification rule.",
                 "$ref": "#/components/schemas/Link"
               },
               "members": {
-                "description": "URL to retrieve members for this notification rule.",
+                "description": "The URL to retrieve members for this notification rule.",
                 "$ref": "#/components/schemas/Link"
               },
               "owners": {
-                "description": "URL to retrieve owners for this notification rule.",
+                "description": "The URL to retrieve owners for this notification rule.",
                 "$ref": "#/components/schemas/Link"
               },
               "query": {
-                "description": "URL to retrieve flux script for this notification rule.",
+                "description": "The URL to retrieve the Flux script for this notification rule.",
                 "$ref": "#/components/schemas/Link"
               }
             }
@@ -22950,19 +22955,19 @@
             },
             "properties": {
               "self": {
-                "description": "URL for this endpoint.",
+                "description": "The URL for this endpoint.",
                 "$ref": "#/components/schemas/Link"
               },
               "labels": {
-                "description": "URL to retrieve labels for this endpoint.",
+                "description": "The URL to retrieve labels for this endpoint.",
                 "$ref": "#/components/schemas/Link"
               },
               "members": {
-                "description": "URL to retrieve members for this endpoint.",
+                "description": "The URL to retrieve members for this endpoint.",
                 "$ref": "#/components/schemas/Link"
               },
               "owners": {
-                "description": "URL to retrieve owners for this endpoint.",
+                "description": "The URL to retrieve owners for this endpoint.",
                 "$ref": "#/components/schemas/Link"
               }
             }

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -3005,32 +3005,28 @@ paths:
       operationId: GetQuerySuggestions
       tags:
         - Query
-      summary: Retrieve Flux query suggestions
+      summary: List Flux query suggestions
       description: |
-        Retrieves a list of Flux query suggestions. Each suggestion contains a
+        Lists Flux query suggestions. Each suggestion contains a
         [Flux function](https://docs.influxdata.com/flux/v0.x/stdlib/all-functions/)
         name and parameters.
 
         Use this endpoint to retrieve a list of Flux query suggestions used in the
-        InfluxDB Flux Query Builder. Helper function names have an underscore (`_`)
-        prefix and aren't meant to be used directly in queries--for example:
-
-        - **Recommended**:  Use `top(n, columns=["_value"], tables=<-)` to sort
-          on a column and keep the top n records instead of `_sortLimit_`.
-          `top` uses the `_sortLimit` helper function.
+        InfluxDB Flux Query Builder.
 
         #### Limitations
 
-        - Using `/api/v2/query/suggestions/` (note the trailing slash) with cURL
-        will result in a HTTP `301 Moved Permanently` status code. Please use
-        `/api/v2/query/suggestions` without a trailing slash.
-
         - When writing a query, avoid using `_functionName()` helper functions
-        exposed by this endpoint.
+        exposed by this endpoint.  Helper function names have an underscore (`_`)
+        prefix and aren't meant to be used directly in queries--for example:
+
+          - To sort on a column and keep the top n records, use the
+            `top(n, columns=["_value"], tables=<-)` function instead of the `_sortLimit`
+            helper function. `top` uses `_sortLimit`.
 
         #### Related Guides
 
-        - [List of all Flux functions](https://docs.influxdata.com/influxdb/v2.3/flux/v0.x/stdlib/all-functions/)
+        - [List of all Flux functions](https://docs.influxdata.com/flux/v0.x/stdlib/all-functions/)
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
       responses:
@@ -3631,7 +3627,7 @@ paths:
           description: |
             Moved Permanently.
             InfluxData has moved the URL of the endpoint.
-            Use `/api/v2/query/suggestions`.
+            Use `/api/v2/query/suggestions` (without a trailing slash).
           content:
             text/html:
               schema:
@@ -3657,7 +3653,7 @@ paths:
         - lang: Shell
           label: cURL
           source: |
-            curl --request GET "https://cloud2.influxdata.com/api/v2/query/suggestions" \
+            curl --request GET "INFLUX_URL/api/v2/query/suggestions" \
               --header "Accept: application/json" \
               --header "Authorization: Token INFLUX_API_TOKEN"
   '/query/suggestions/{name}':
@@ -3683,7 +3679,7 @@ paths:
 
         #### Related Guides
 
-        - [List of all Flux functions](https://docs.influxdata.com/influxdb/v2.3/flux/v0.x/stdlib/all-functions/)
+        - [List of all Flux functions](https://docs.influxdata.com/flux/v0.x/stdlib/all-functions/)
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -3692,8 +3688,7 @@ paths:
             type: string
           required: true
           description: |
-            A Flux Function name.
-            Only returns functions with this name.
+            A [Flux function](https://docs.influxdata.com/flux/v0.x/stdlib/all-functions/) name.
       responses:
         '200':
           description: |
@@ -3730,7 +3725,7 @@ paths:
         - lang: Shell
           label: cURL
           source: |
-            curl --request GET "https://cloud2.influxdata.com/api/v2/query/suggestions/sum/" \
+            curl --request GET "INFLUX_URL/api/v2/query/suggestions/sum/" \
               --header "Accept: application/json" \
               --header "Authorization: Token INFLUX_API_TOKEN"
   /query/analyze:
@@ -4057,7 +4052,7 @@ paths:
         - Buckets
       summary: List buckets
       description: |
-        Retrieves a list of [buckets](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#bucket).
+        Lists [buckets](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#bucket).
 
         InfluxDB retrieves buckets owned by the
         [organization](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#organization)
@@ -6273,11 +6268,15 @@ paths:
         - Templates
       summary: List installed stacks
       description: |
-        Retrieves a list of installed InfluxDB stacks.
+        Lists installed InfluxDB stacks.
 
         To limit stacks in the response, pass query parameters in your request.
         If no query parameters are passed, InfluxDB returns all installed stacks
         for the organization.
+
+        #### Related guides
+
+        - [View InfluxDB stacks](https://docs.influxdata.com/influxdb/v2.3/influxdb-templates/stacks/).
       parameters:
         - in: query
           name: orgID
@@ -6285,8 +6284,8 @@ paths:
           schema:
             type: string
           description: |
-            The ID of the organization that owns the stacks.
-            Only returns stacks owned by this organization.
+            An organization ID.
+            Only returns stacks owned by the specified [organization](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#organization).
 
             #### InfluxDB Cloud
 
@@ -6297,14 +6296,14 @@ paths:
           schema:
             type: string
           description: |
-            The stack name.
+            A stack name.
             Finds stack `events` with this name and returns the stacks.
 
             Repeatable.
             To filter for more than one stack name,
             repeat this parameter with each name--for example:
 
-            - `http://localhost:8086/api/v2/stacks?&orgID=INFLUX_ORG_ID&name=project-stack-0&name=project-stack-1`
+            - `INFLUX_URL/api/v2/stacks?&orgID=INFLUX_ORG_ID&name=project-stack-0&name=project-stack-1`
           examples:
             findStackByName:
               summary: Find stacks with the event name
@@ -6314,14 +6313,14 @@ paths:
           schema:
             type: string
           description: |
-            The stack ID.
-            Only returns stacks with this ID.
+            A stack ID.
+            Only returns the specified stack.
 
             Repeatable.
             To filter for more than one stack ID,
             repeat this parameter with each ID--for example:
 
-            - `http://localhost:8086/api/v2/stacks?&orgID=INFLUX_ORG_ID&stackID=09bd87cd33be3000&stackID=09bef35081fe3000`
+            - `INFLUX_URL/api/v2/stacks?&orgID=INFLUX_ORG_ID&stackID=09bd87cd33be3000&stackID=09bef35081fe3000`
           examples:
             findStackByID:
               summary: Find a stack with the ID
@@ -6395,8 +6394,8 @@ paths:
 
         #### Related guides
 
-        - [InfluxDB stacks](https://docs.influxdata.com/influxdb/v2.3/influxdb-templates/stacks/)
-        - [Use InfluxDB templates](https://docs.influxdata.com/influxdb/v2.3/influxdb-templates/use/#apply-templates-to-an-influxdb-instance)
+        - [Initialize an InfluxDB stack](https://docs.influxdata.com/influxdb/v2.3/influxdb-templates/stacks/init/).
+        - [Use InfluxDB templates](https://docs.influxdata.com/influxdb/v2.3/influxdb-templates/use/#apply-templates-to-an-influxdb-instance).
       requestBody:
         description: The stack to create.
         required: true
@@ -9826,7 +9825,7 @@ paths:
         - Users
       summary: List users
       description: |
-        Retrieves a list of [users](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#user).
+        Lists [users](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#user).
         Default limit is `20`.
 
         To limit which users are returned, pass query parameters in your request.
@@ -9839,6 +9838,10 @@ paths:
         | List a specific user | `read-users` or `read-user USER_ID` | |
 
         *`USER_ID`* is the ID of the user that you want to retrieve.
+
+        #### Related guides
+
+        - [View users](https://docs.influxdata.com/influxdb/latest/users/view-users/).
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - $ref: '#/components/parameters/Offset'
@@ -9915,8 +9918,8 @@ paths:
         This endpoint represents the first two steps in a four-step process to allow a user
         to authenticate with a username and password, and then access data in an organization:
 
-          1. Create a user: send a `POST` request to `POST /api/v2/users`. `name` is required.
-          2. Extract the user ID (`id`) value from the API response for _step 1_.
+          1. Create a user: send a `POST` request to `POST /api/v2/users`. The `name` property is required.
+          2. Extract the user ID (`id` property) value from the API response for _step 1_.
           3. Create an authorization (and API token) for the user: send a `POST` request to [`POST /api/v2/authorizations`](#operation/PostAuthorizations), passing the user ID (`id`) from _step 2_.
           4. Create a password for the user: send a `POST` request to [`POST /api/v2/users/USER_ID/password`](#operation/PostUsersIDPassword), passing the user ID from _step 2_.
 
@@ -9982,24 +9985,34 @@ paths:
         - label: 'cURL: create a user and set a password'
           lang: Shell
           source: |
-            # Create the user and assign the user ID to a variable.
-            USER_ID=$(curl --request POST \
-                    "http://localhost:8086/api/v2/users/" \
-                    --header "Authorization: Token INFLUX_OP_TOKEN" \
-                    --header 'Content-type: application/json' \
-                    --data-binary @- << EOF | jq -r '.id'
-                    {
-                      "name": "USER_NAME",
-                      "status": "active"
-                    }
-            EOF
-            )
+            # The following steps show how to create a user and then set
+            # the user's password:
+            #
+            # 1. Send a request to this endpoint to create a user--for example:
 
-            # Pass the user ID and a password to set the password for the user.
-            curl request POST "http://localhost:8086/api/v2/users/$USER_ID/password/" \
-              --header "Authorization: Token INFLUX_OP_TOKEN" \
-              --header 'Content-type: application/json' \
-              --data '{ "password": "USER_PASSWORD" }'
+                  USER=$(curl --request POST \
+                          "INFLUX_URL/api/v2/users/" \
+                          --header "Authorization: Token INFLUX_API_TOKEN" \
+                          --header 'Content-type: application/json' \
+                          --data-binary @- << EOF
+                          {
+                            "name": "USER_NAME",
+                            "status": "active"
+                          }
+                  EOF
+                  )
+
+            # 2. Extract the id property from the response in step 1--for example:
+
+                  USER_ID=`echo $USER | jq -r '.id'`
+
+            # 3. To set the user's password, set the password property in a request
+            #    to the /api/v2/users/USER_ID/password endpoint--for example:
+
+                  curl request POST "INFLUX_URL/api/v2/users/$USER_ID/password/" \
+                    --header "Authorization: Token INFLUX_API_TOKEN" \
+                    --header 'Content-type: application/json' \
+                    --data '{ "password": "USER_PASSWORD" }'
   '/users/{userID}':
     get:
       operationId: GetUsersID
@@ -11872,7 +11885,7 @@ paths:
               $ref: '#/components/schemas/CreateDashboardRequest'
       responses:
         '201':
-          description: Added dashboard
+          description: Success. The dashboard is created.
           content:
             application/json:
               schema:
@@ -11889,7 +11902,13 @@ paths:
       operationId: GetDashboards
       tags:
         - Dashboards
-      summary: List all dashboards
+      summary: List dashboards
+      description: |
+        Lists [dashboards](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#dashboard).
+
+        #### Related guides
+
+        - [Manage dashboards](https://docs.influxdata.com/influxdb/v2.3/visualize-data/dashboards/).
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - $ref: '#/components/parameters/Offset'
@@ -11897,7 +11916,7 @@ paths:
         - $ref: '#/components/parameters/Descending'
         - in: query
           name: owner
-          description: A user identifier. Returns only dashboards where this user has the `owner` role.
+          description: 'A user ID. Only returns [dashboards](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#dashboard) where the specified user has the `owner` role.'
           schema:
             type: string
         - in: query
@@ -11911,24 +11930,33 @@ paths:
               - UpdatedAt
         - in: query
           name: id
-          description: 'A list of dashboard identifiers. Returns only the listed dashboards. If both `id` and `owner` are specified, only `id` is used.'
+          description: |
+            A list of dashboard IDs.
+            Returns only the specified [dashboards](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#dashboard).
+            If you specify `id` and `owner`, only `id` is used.
           schema:
             type: array
             items:
               type: string
         - in: query
           name: orgID
-          description: The identifier of the organization.
+          description: |
+            An organization ID.
+            Only returns [dashboards](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#dashboard) that belong to the specified
+            [organization](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#organization).
           schema:
             type: string
         - in: query
           name: org
-          description: The name of the organization.
+          description: |
+            An organization name.
+            Only returns [dashboards](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#dashboard) that belong to the specified
+            [organization](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#organization).
           schema:
             type: string
       responses:
         '200':
-          description: All dashboards
+          description: Success. The response body contains dashboards.
           content:
             application/json:
               schema:
@@ -16910,12 +16938,15 @@ components:
             description: this is a description
     LabelMapping:
       type: object
+      description: A _label mapping_ contains a `label` ID to attach to a resource.
       properties:
         labelID:
           description: |
-            Label ID.
-            The ID of the label to attach.
+            A label ID.
+            Specifies the label to attach.
           type: string
+      required:
+        - labelID
     LabelsResponse:
       type: object
       properties:
@@ -17045,19 +17076,19 @@ components:
             query: /api/v2/checks/1/query
           properties:
             self:
-              description: URL for this check
+              description: The URL for this check.
               $ref: '#/components/schemas/Link'
             labels:
-              description: URL to retrieve labels for this check
+              description: The URL to retrieve labels for this check.
               $ref: '#/components/schemas/Link'
             members:
-              description: URL to retrieve members for this check
+              description: The URL to retrieve members for this check.
               $ref: '#/components/schemas/Link'
             owners:
-              description: URL to retrieve owners for this check
+              description: The URL to retrieve owners for this check.
               $ref: '#/components/schemas/Link'
             query:
-              description: URL to retrieve flux script for this check
+              description: The URL to retrieve the Flux script for this check.
               $ref: '#/components/schemas/Link'
       required:
         - name
@@ -17374,19 +17405,19 @@ components:
             query: /api/v2/notificationRules/1/query
           properties:
             self:
-              description: URL for this endpoint.
+              description: The URL for this endpoint.
               $ref: '#/components/schemas/Link'
             labels:
-              description: URL to retrieve labels for this notification rule.
+              description: The URL to retrieve labels for this notification rule.
               $ref: '#/components/schemas/Link'
             members:
-              description: URL to retrieve members for this notification rule.
+              description: The URL to retrieve members for this notification rule.
               $ref: '#/components/schemas/Link'
             owners:
-              description: URL to retrieve owners for this notification rule.
+              description: The URL to retrieve owners for this notification rule.
               $ref: '#/components/schemas/Link'
             query:
-              description: URL to retrieve flux script for this notification rule.
+              description: The URL to retrieve the Flux script for this notification rule.
               $ref: '#/components/schemas/Link'
     TagRule:
       type: object
@@ -17595,16 +17626,16 @@ components:
             owners: /api/v2/notificationEndpoints/1/owners
           properties:
             self:
-              description: URL for this endpoint.
+              description: The URL for this endpoint.
               $ref: '#/components/schemas/Link'
             labels:
-              description: URL to retrieve labels for this endpoint.
+              description: The URL to retrieve labels for this endpoint.
               $ref: '#/components/schemas/Link'
             members:
-              description: URL to retrieve members for this endpoint.
+              description: The URL to retrieve members for this endpoint.
               $ref: '#/components/schemas/Link'
             owners:
-              description: URL to retrieve owners for this endpoint.
+              description: The URL to retrieve owners for this endpoint.
               $ref: '#/components/schemas/Link'
         type:
           $ref: '#/components/schemas/NotificationEndpointType'

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -830,19 +830,19 @@ components:
           properties:
             labels:
               $ref: '#/components/schemas/Link'
-              description: URL to retrieve labels for this check
+              description: The URL to retrieve labels for this check.
             members:
               $ref: '#/components/schemas/Link'
-              description: URL to retrieve members for this check
+              description: The URL to retrieve members for this check.
             owners:
               $ref: '#/components/schemas/Link'
-              description: URL to retrieve owners for this check
+              description: The URL to retrieve owners for this check.
             query:
               $ref: '#/components/schemas/Link'
-              description: URL to retrieve flux script for this check
+              description: The URL to retrieve the Flux script for this check.
             self:
               $ref: '#/components/schemas/Link'
-              description: URL for this check
+              description: The URL for this check.
           readOnly: true
           type: object
         name:
@@ -2297,12 +2297,15 @@ components:
       - name
       type: object
     LabelMapping:
+      description: A _label mapping_ contains a `label` ID to attach to a resource.
       properties:
         labelID:
           description: |
-            Label ID.
-            The ID of the label to attach.
+            A label ID.
+            Specifies the label to attach.
           type: string
+      required:
+      - labelID
       type: object
     LabelResponse:
       properties:
@@ -3082,16 +3085,16 @@ components:
           properties:
             labels:
               $ref: '#/components/schemas/Link'
-              description: URL to retrieve labels for this endpoint.
+              description: The URL to retrieve labels for this endpoint.
             members:
               $ref: '#/components/schemas/Link'
-              description: URL to retrieve members for this endpoint.
+              description: The URL to retrieve members for this endpoint.
             owners:
               $ref: '#/components/schemas/Link'
-              description: URL to retrieve owners for this endpoint.
+              description: The URL to retrieve owners for this endpoint.
             self:
               $ref: '#/components/schemas/Link'
-              description: URL for this endpoint.
+              description: The URL for this endpoint.
           readOnly: true
           type: object
         name:
@@ -3213,19 +3216,20 @@ components:
           properties:
             labels:
               $ref: '#/components/schemas/Link'
-              description: URL to retrieve labels for this notification rule.
+              description: The URL to retrieve labels for this notification rule.
             members:
               $ref: '#/components/schemas/Link'
-              description: URL to retrieve members for this notification rule.
+              description: The URL to retrieve members for this notification rule.
             owners:
               $ref: '#/components/schemas/Link'
-              description: URL to retrieve owners for this notification rule.
+              description: The URL to retrieve owners for this notification rule.
             query:
               $ref: '#/components/schemas/Link'
-              description: URL to retrieve flux script for this notification rule.
+              description: The URL to retrieve the Flux script for this notification
+                rule.
             self:
               $ref: '#/components/schemas/Link'
-              description: URL for this endpoint.
+              description: The URL for this endpoint.
           readOnly: true
           type: object
         name:
@@ -6980,7 +6984,7 @@ paths:
   /api/v2/buckets:
     get:
       description: |
-        Retrieves a list of [buckets](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#bucket).
+        Lists [buckets](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#bucket).
 
         InfluxDB retrieves buckets owned by the
         [organization](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#organization)
@@ -8223,7 +8227,7 @@ paths:
   /api/v2/buckets/{bucketID}/schema/measurements:
     get:
       description: |
-        Retrieves a list of _explicit_
+        Lists _explicit_
         [schemas](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#schema)
         (`"schemaType": "explicit"`) for a bucket.
 
@@ -8421,7 +8425,7 @@ paths:
       - label: cURL
         lang: Shell
         source: |
-          curl --request POST "https://cloud2.influxdata.com/api/v2/buckets/BUCKET_ID/schema/measurements \
+          curl --request POST "INFLUX_URL/api/v2/buckets/BUCKET_ID/schema/measurements \
             --header "Authorization: Token INFLUX_API_TOKEN" \
             --header "Accept: application/json" \
             --header "Content-Type: application/json" \
@@ -8590,7 +8594,7 @@ paths:
       - label: cURL
         lang: Shell
         source: |
-          curl --request PATCH "https://cloud2.influxdata.com/api/v2/buckets/BUCKET_ID/schema/measurements \
+          curl --request PATCH "INFLUX_URL/api/v2/buckets/BUCKET_ID/schema/measurements \
             --header "Authorization: Token INFLUX_API_TOKEN" \
             --header "Accept: application/json" \
             --header "Content-Type: application/json" \
@@ -8935,12 +8939,21 @@ paths:
       - Checks
   /api/v2/dashboards:
     get:
+      description: |
+        Lists [dashboards](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#dashboard).
+
+        #### Related guides
+
+        - [Manage dashboards](https://docs.influxdata.com/influxdb/cloud/visualize-data/dashboards/).
       operationId: GetDashboards
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
       - $ref: '#/components/parameters/Offset'
       - $ref: '#/components/parameters/Descending'
-      - description: The non-zero number of dashboards to return
+      - description: |
+          The maximum number of [dashboards](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#dashboard) to return.
+          Default is `20`.
+          The minimum is `-1` and the maximum is `100`.
         in: query
         name: limit
         schema:
@@ -8948,8 +8961,8 @@ paths:
           maximum: 100
           minimum: -1
           type: integer
-      - description: A user identifier. Returns only dashboards where this user has
-          the `owner` role.
+      - description: A user ID. Only returns [dashboards](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#dashboard)
+          where the specified user has the `owner` role.
         in: query
         name: owner
         schema:
@@ -8963,20 +8976,28 @@ paths:
           - CreatedAt
           - UpdatedAt
           type: string
-      - description: A list of dashboard identifiers. Returns only the listed dashboards.
-          If both `id` and `owner` are specified, only `id` is used.
+      - description: |
+          A list of dashboard IDs.
+          Returns only the specified [dashboards](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#dashboard).
+          If you specify `id` and `owner`, only `id` is used.
         in: query
         name: id
         schema:
           items:
             type: string
           type: array
-      - description: The identifier of the organization.
+      - description: |
+          An organization ID.
+          Only returns [dashboards](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#dashboard) that belong to the specified
+          [organization](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#organization).
         in: query
         name: orgID
         schema:
           type: string
-      - description: The name of the organization.
+      - description: |
+          An organization name.
+          Only returns [dashboards](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#dashboard) that belong to the specified
+          [organization](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#organization).
         in: query
         name: org
         schema:
@@ -8987,14 +9008,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Dashboards'
-          description: All dashboards
+          description: Success. The response body contains dashboards.
         default:
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Unexpected error
-      summary: List all dashboards
+      summary: List dashboards
       tags:
       - Dashboards
     post:
@@ -9016,7 +9037,7 @@ paths:
                 oneOf:
                 - $ref: '#/components/schemas/Dashboard'
                 - $ref: '#/components/schemas/DashboardWithViewProperties'
-          description: Added dashboard
+          description: Success. The dashboard is created.
         default:
           content:
             application/json:
@@ -12908,30 +12929,26 @@ paths:
   /api/v2/query/suggestions:
     get:
       description: |
-        Retrieves a list of Flux query suggestions. Each suggestion contains a
+        Lists Flux query suggestions. Each suggestion contains a
         [Flux function](https://docs.influxdata.com/flux/v0.x/stdlib/all-functions/)
         name and parameters.
 
         Use this endpoint to retrieve a list of Flux query suggestions used in the
-        InfluxDB Flux Query Builder. Helper function names have an underscore (`_`)
-        prefix and aren't meant to be used directly in queries--for example:
-
-        - **Recommended**:  Use `top(n, columns=["_value"], tables=<-)` to sort
-          on a column and keep the top n records instead of `_sortLimit_`.
-          `top` uses the `_sortLimit` helper function.
+        InfluxDB Flux Query Builder.
 
         #### Limitations
 
-        - Using `/api/v2/query/suggestions/` (note the trailing slash) with cURL
-        will result in a HTTP `301 Moved Permanently` status code. Please use
-        `/api/v2/query/suggestions` without a trailing slash.
-
         - When writing a query, avoid using `_functionName()` helper functions
-        exposed by this endpoint.
+        exposed by this endpoint.  Helper function names have an underscore (`_`)
+        prefix and aren't meant to be used directly in queries--for example:
+
+          - To sort on a column and keep the top n records, use the
+            `top(n, columns=["_value"], tables=<-)` function instead of the `_sortLimit`
+            helper function. `top` uses `_sortLimit`.
 
         #### Related Guides
 
-        - [List of all Flux functions](https://docs.influxdata.com/influxdb/cloud/flux/v0.x/stdlib/all-functions/)
+        - [List of all Flux functions](https://docs.influxdata.com/flux/v0.x/stdlib/all-functions/)
       operationId: GetQuerySuggestions
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
@@ -13548,21 +13565,21 @@ paths:
           description: |
             Moved Permanently.
             InfluxData has moved the URL of the endpoint.
-            Use `/api/v2/query/suggestions`.
+            Use `/api/v2/query/suggestions` (without a trailing slash).
         default:
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Internal server error.
-      summary: Retrieve Flux query suggestions
+      summary: List Flux query suggestions
       tags:
       - Query
       x-codeSamples:
       - label: cURL
         lang: Shell
         source: |
-          curl --request GET "https://cloud2.influxdata.com/api/v2/query/suggestions" \
+          curl --request GET "INFLUX_URL/api/v2/query/suggestions" \
             --header "Accept: application/json" \
             --header "Authorization: Token INFLUX_API_TOKEN"
   /api/v2/query/suggestions/{name}:
@@ -13584,13 +13601,12 @@ paths:
 
         #### Related Guides
 
-        - [List of all Flux functions](https://docs.influxdata.com/influxdb/cloud/flux/v0.x/stdlib/all-functions/)
+        - [List of all Flux functions](https://docs.influxdata.com/flux/v0.x/stdlib/all-functions/)
       operationId: GetQuerySuggestionsName
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
       - description: |
-          A Flux Function name.
-          Only returns functions with this name.
+          A [Flux function](https://docs.influxdata.com/flux/v0.x/stdlib/all-functions/) name.
         in: path
         name: name
         required: true
@@ -13635,7 +13651,7 @@ paths:
       - label: cURL
         lang: Shell
         source: |
-          curl --request GET "https://cloud2.influxdata.com/api/v2/query/suggestions/sum/" \
+          curl --request GET "INFLUX_URL/api/v2/query/suggestions/sum/" \
             --header "Accept: application/json" \
             --header "Authorization: Token INFLUX_API_TOKEN"
   /api/v2/resources:
@@ -13665,7 +13681,7 @@ paths:
   /api/v2/scripts:
     get:
       description: |
-        Retrieves a list of [scripts](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/).
+        Lists [scripts](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/).
 
         #### Related guides
 
@@ -13785,7 +13801,7 @@ paths:
       - label: 'cURL: retrieves the first 100 scripts.'
         lang: Shell
         source: |
-          curl --request GET "https://cloud2.influxdata.com/api/v2/scripts?limit=100&offset=0" \
+          curl --request GET "INFLUX_URL/api/v2/scripts?limit=100&offset=0" \
             --header "Authorization: Token INFLUX_API_TOKEN" \
             --header "Accept: application/json" \
             --header "Content-Type: application/json"
@@ -13860,7 +13876,7 @@ paths:
       - label: cURL
         lang: Shell
         source: |
-          curl --request POST "https://cloud2.influxdata.com/api/v2/scripts" \
+          curl --request POST "INFLUX_URL/api/v2/scripts" \
             --header "Authorization: Token INFLUX_API_TOKEN" \
             --header "Accept: application/json" \
             --header "Content-Type: application/json" \
@@ -14098,7 +14114,7 @@ paths:
       - label: cURL
         lang: Shell
         source: |
-          curl --request POST "https://cloud2.influxdata.com/api/v2/scripts/SCRIPT_ID/invoke" \
+          curl --request POST "INFLUX_URL/api/v2/scripts/SCRIPT_ID/invoke" \
                     --header "Authorization: Token INFLUX_TOKEN" \
                     --header 'Accept: application/csv' \
                     --header 'Content-Type: application/json' \
@@ -14384,16 +14400,20 @@ paths:
   /api/v2/stacks:
     get:
       description: |
-        Retrieves a list of installed InfluxDB stacks.
+        Lists installed InfluxDB stacks.
 
         To limit stacks in the response, pass query parameters in your request.
         If no query parameters are passed, InfluxDB returns all installed stacks
         for the organization.
+
+        #### Related guides
+
+        - [View InfluxDB stacks](https://docs.influxdata.com/influxdb/cloud/influxdb-templates/stacks/).
       operationId: ListStacks
       parameters:
       - description: |
-          The ID of the organization that owns the stacks.
-          Only returns stacks owned by this organization.
+          An organization ID.
+          Only returns stacks owned by the specified [organization](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#organization).
 
           #### InfluxDB Cloud
 
@@ -14405,14 +14425,14 @@ paths:
         schema:
           type: string
       - description: |
-          The stack name.
+          A stack name.
           Finds stack `events` with this name and returns the stacks.
 
           Repeatable.
           To filter for more than one stack name,
           repeat this parameter with each name--for example:
 
-          - `http://localhost:8086/api/v2/stacks?&orgID=INFLUX_ORG_ID&name=project-stack-0&name=project-stack-1`
+          - `INFLUX_URL/api/v2/stacks?&orgID=INFLUX_ORG_ID&name=project-stack-0&name=project-stack-1`
         examples:
           findStackByName:
             summary: Find stacks with the event name
@@ -14422,14 +14442,14 @@ paths:
         schema:
           type: string
       - description: |
-          The stack ID.
-          Only returns stacks with this ID.
+          A stack ID.
+          Only returns the specified stack.
 
           Repeatable.
           To filter for more than one stack ID,
           repeat this parameter with each ID--for example:
 
-          - `http://localhost:8086/api/v2/stacks?&orgID=INFLUX_ORG_ID&stackID=09bd87cd33be3000&stackID=09bef35081fe3000`
+          - `INFLUX_URL/api/v2/stacks?&orgID=INFLUX_ORG_ID&stackID=09bd87cd33be3000&stackID=09bef35081fe3000`
         examples:
           findStackByID:
             summary: Find a stack with the ID
@@ -14508,8 +14528,8 @@ paths:
 
         #### Related guides
 
-        - [InfluxDB stacks](https://docs.influxdata.com/influxdb/cloud/influxdb-templates/stacks/)
-        - [Use InfluxDB templates](https://docs.influxdata.com/influxdb/cloud/influxdb-templates/use/#apply-templates-to-an-influxdb-instance)
+        - [Initialize an InfluxDB stack](https://docs.influxdata.com/influxdb/cloud/influxdb-templates/stacks/init/).
+        - [Use InfluxDB templates](https://docs.influxdata.com/influxdb/cloud/influxdb-templates/use/#apply-templates-to-an-influxdb-instance).
       operationId: CreateStack
       requestBody:
         content:
@@ -14905,7 +14925,7 @@ paths:
       - label: 'cURL: all tasks, basic output'
         lang: Shell
         source: |
-          curl https://cloud2.influxdata.com/api/v2/tasks/?limit=-1&type=basic \
+          curl INFLUX_URL/api/v2/tasks/?limit=-1&type=basic \
             --header 'Content-Type: application/json' \
             --header 'Authorization: Token INFLUX_API_TOKEN'
     post:
@@ -15027,7 +15047,7 @@ paths:
       - label: 'cURL: create a Flux script task'
         lang: Shell
         source: |
-          curl https://cloud2.influxdata.com/api/v2/tasks \
+          curl INFLUX_URL/api/v2/tasks \
           --header "Content-type: application/json" \
           --header "Authorization: Token INFLUX_API_TOKEN" \
           --data-binary @- << EOF
@@ -15044,7 +15064,7 @@ paths:
       - label: 'cURL: create a Flux script reference task'
         lang: Shell
         source: |
-          curl https://cloud2.influxdata.com/api/v2/tasks \
+          curl INFLUX_URL/api/v2/tasks \
           --header "Content-type: application/json" \
           --header "Authorization: Token INFLUX_API_TOKEN" \
           --data-binary @- << EOF
@@ -16865,7 +16885,7 @@ paths:
   /api/v2/users:
     get:
       description: |
-        Retrieves a list of [users](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#user).
+        Lists [users](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#user).
 
         To limit which users are returned, pass query parameters in your request.
 

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -859,19 +859,19 @@ components:
           properties:
             labels:
               $ref: '#/components/schemas/Link'
-              description: URL to retrieve labels for this check
+              description: The URL to retrieve labels for this check.
             members:
               $ref: '#/components/schemas/Link'
-              description: URL to retrieve members for this check
+              description: The URL to retrieve members for this check.
             owners:
               $ref: '#/components/schemas/Link'
-              description: URL to retrieve owners for this check
+              description: The URL to retrieve owners for this check.
             query:
               $ref: '#/components/schemas/Link'
-              description: URL to retrieve flux script for this check
+              description: The URL to retrieve the Flux script for this check.
             self:
               $ref: '#/components/schemas/Link'
-              description: URL for this check
+              description: The URL for this check.
           readOnly: true
           type: object
         name:
@@ -2316,12 +2316,15 @@ components:
       - name
       type: object
     LabelMapping:
+      description: A _label mapping_ contains a `label` ID to attach to a resource.
       properties:
         labelID:
           description: |
-            Label ID.
-            The ID of the label to attach.
+            A label ID.
+            Specifies the label to attach.
           type: string
+      required:
+      - labelID
       type: object
     LabelResponse:
       properties:
@@ -2846,16 +2849,16 @@ components:
           properties:
             labels:
               $ref: '#/components/schemas/Link'
-              description: URL to retrieve labels for this endpoint.
+              description: The URL to retrieve labels for this endpoint.
             members:
               $ref: '#/components/schemas/Link'
-              description: URL to retrieve members for this endpoint.
+              description: The URL to retrieve members for this endpoint.
             owners:
               $ref: '#/components/schemas/Link'
-              description: URL to retrieve owners for this endpoint.
+              description: The URL to retrieve owners for this endpoint.
             self:
               $ref: '#/components/schemas/Link'
-              description: URL for this endpoint.
+              description: The URL for this endpoint.
           readOnly: true
           type: object
         name:
@@ -2977,19 +2980,20 @@ components:
           properties:
             labels:
               $ref: '#/components/schemas/Link'
-              description: URL to retrieve labels for this notification rule.
+              description: The URL to retrieve labels for this notification rule.
             members:
               $ref: '#/components/schemas/Link'
-              description: URL to retrieve members for this notification rule.
+              description: The URL to retrieve members for this notification rule.
             owners:
               $ref: '#/components/schemas/Link'
-              description: URL to retrieve owners for this notification rule.
+              description: The URL to retrieve owners for this notification rule.
             query:
               $ref: '#/components/schemas/Link'
-              description: URL to retrieve flux script for this notification rule.
+              description: The URL to retrieve the Flux script for this notification
+                rule.
             self:
               $ref: '#/components/schemas/Link'
-              description: URL for this endpoint.
+              description: The URL for this endpoint.
           readOnly: true
           type: object
         name:
@@ -7135,7 +7139,7 @@ paths:
   /api/v2/buckets:
     get:
       description: |
-        Retrieves a list of [buckets](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#bucket).
+        Lists [buckets](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#bucket).
 
         InfluxDB retrieves buckets owned by the
         [organization](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#organization)
@@ -8729,14 +8733,20 @@ paths:
       - System information endpoints
   /api/v2/dashboards:
     get:
+      description: |
+        Lists [dashboards](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#dashboard).
+
+        #### Related guides
+
+        - [Manage dashboards](https://docs.influxdata.com/influxdb/v2.3/visualize-data/dashboards/).
       operationId: GetDashboards
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
       - $ref: '#/components/parameters/Offset'
       - $ref: '#/components/parameters/Limit'
       - $ref: '#/components/parameters/Descending'
-      - description: A user identifier. Returns only dashboards where this user has
-          the `owner` role.
+      - description: A user ID. Only returns [dashboards](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#dashboard)
+          where the specified user has the `owner` role.
         in: query
         name: owner
         schema:
@@ -8750,20 +8760,28 @@ paths:
           - CreatedAt
           - UpdatedAt
           type: string
-      - description: A list of dashboard identifiers. Returns only the listed dashboards.
-          If both `id` and `owner` are specified, only `id` is used.
+      - description: |
+          A list of dashboard IDs.
+          Returns only the specified [dashboards](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#dashboard).
+          If you specify `id` and `owner`, only `id` is used.
         in: query
         name: id
         schema:
           items:
             type: string
           type: array
-      - description: The identifier of the organization.
+      - description: |
+          An organization ID.
+          Only returns [dashboards](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#dashboard) that belong to the specified
+          [organization](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#organization).
         in: query
         name: orgID
         schema:
           type: string
-      - description: The name of the organization.
+      - description: |
+          An organization name.
+          Only returns [dashboards](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#dashboard) that belong to the specified
+          [organization](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#organization).
         in: query
         name: org
         schema:
@@ -8774,14 +8792,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Dashboards'
-          description: All dashboards
+          description: Success. The response body contains dashboards.
         default:
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Unexpected error
-      summary: List all dashboards
+      summary: List dashboards
       tags:
       - Dashboards
     post:
@@ -8803,7 +8821,7 @@ paths:
                 oneOf:
                 - $ref: '#/components/schemas/Dashboard'
                 - $ref: '#/components/schemas/DashboardWithViewProperties'
-          description: Added dashboard
+          description: Success. The dashboard is created.
         default:
           content:
             application/json:
@@ -13428,30 +13446,26 @@ paths:
   /api/v2/query/suggestions:
     get:
       description: |
-        Retrieves a list of Flux query suggestions. Each suggestion contains a
+        Lists Flux query suggestions. Each suggestion contains a
         [Flux function](https://docs.influxdata.com/flux/v0.x/stdlib/all-functions/)
         name and parameters.
 
         Use this endpoint to retrieve a list of Flux query suggestions used in the
-        InfluxDB Flux Query Builder. Helper function names have an underscore (`_`)
-        prefix and aren't meant to be used directly in queries--for example:
-
-        - **Recommended**:  Use `top(n, columns=["_value"], tables=<-)` to sort
-          on a column and keep the top n records instead of `_sortLimit_`.
-          `top` uses the `_sortLimit` helper function.
+        InfluxDB Flux Query Builder.
 
         #### Limitations
 
-        - Using `/api/v2/query/suggestions/` (note the trailing slash) with cURL
-        will result in a HTTP `301 Moved Permanently` status code. Please use
-        `/api/v2/query/suggestions` without a trailing slash.
-
         - When writing a query, avoid using `_functionName()` helper functions
-        exposed by this endpoint.
+        exposed by this endpoint.  Helper function names have an underscore (`_`)
+        prefix and aren't meant to be used directly in queries--for example:
+
+          - To sort on a column and keep the top n records, use the
+            `top(n, columns=["_value"], tables=<-)` function instead of the `_sortLimit`
+            helper function. `top` uses `_sortLimit`.
 
         #### Related Guides
 
-        - [List of all Flux functions](https://docs.influxdata.com/influxdb/v2.3/flux/v0.x/stdlib/all-functions/)
+        - [List of all Flux functions](https://docs.influxdata.com/flux/v0.x/stdlib/all-functions/)
       operationId: GetQuerySuggestions
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
@@ -14068,21 +14082,21 @@ paths:
           description: |
             Moved Permanently.
             InfluxData has moved the URL of the endpoint.
-            Use `/api/v2/query/suggestions`.
+            Use `/api/v2/query/suggestions` (without a trailing slash).
         default:
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Internal server error.
-      summary: Retrieve Flux query suggestions
+      summary: List Flux query suggestions
       tags:
       - Query
       x-codeSamples:
       - label: cURL
         lang: Shell
         source: |
-          curl --request GET "https://cloud2.influxdata.com/api/v2/query/suggestions" \
+          curl --request GET "INFLUX_URL/api/v2/query/suggestions" \
             --header "Accept: application/json" \
             --header "Authorization: Token INFLUX_API_TOKEN"
   /api/v2/query/suggestions/{name}:
@@ -14104,13 +14118,12 @@ paths:
 
         #### Related Guides
 
-        - [List of all Flux functions](https://docs.influxdata.com/influxdb/v2.3/flux/v0.x/stdlib/all-functions/)
+        - [List of all Flux functions](https://docs.influxdata.com/flux/v0.x/stdlib/all-functions/)
       operationId: GetQuerySuggestionsName
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
       - description: |
-          A Flux Function name.
-          Only returns functions with this name.
+          A [Flux function](https://docs.influxdata.com/flux/v0.x/stdlib/all-functions/) name.
         in: path
         name: name
         required: true
@@ -14155,7 +14168,7 @@ paths:
       - label: cURL
         lang: Shell
         source: |
-          curl --request GET "https://cloud2.influxdata.com/api/v2/query/suggestions/sum/" \
+          curl --request GET "INFLUX_URL/api/v2/query/suggestions/sum/" \
             --header "Accept: application/json" \
             --header "Authorization: Token INFLUX_API_TOKEN"
   /ready:
@@ -15500,16 +15513,20 @@ paths:
   /api/v2/stacks:
     get:
       description: |
-        Retrieves a list of installed InfluxDB stacks.
+        Lists installed InfluxDB stacks.
 
         To limit stacks in the response, pass query parameters in your request.
         If no query parameters are passed, InfluxDB returns all installed stacks
         for the organization.
+
+        #### Related guides
+
+        - [View InfluxDB stacks](https://docs.influxdata.com/influxdb/v2.3/influxdb-templates/stacks/).
       operationId: ListStacks
       parameters:
       - description: |
-          The ID of the organization that owns the stacks.
-          Only returns stacks owned by this organization.
+          An organization ID.
+          Only returns stacks owned by the specified [organization](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#organization).
 
           #### InfluxDB Cloud
 
@@ -15521,14 +15538,14 @@ paths:
         schema:
           type: string
       - description: |
-          The stack name.
+          A stack name.
           Finds stack `events` with this name and returns the stacks.
 
           Repeatable.
           To filter for more than one stack name,
           repeat this parameter with each name--for example:
 
-          - `http://localhost:8086/api/v2/stacks?&orgID=INFLUX_ORG_ID&name=project-stack-0&name=project-stack-1`
+          - `INFLUX_URL/api/v2/stacks?&orgID=INFLUX_ORG_ID&name=project-stack-0&name=project-stack-1`
         examples:
           findStackByName:
             summary: Find stacks with the event name
@@ -15538,14 +15555,14 @@ paths:
         schema:
           type: string
       - description: |
-          The stack ID.
-          Only returns stacks with this ID.
+          A stack ID.
+          Only returns the specified stack.
 
           Repeatable.
           To filter for more than one stack ID,
           repeat this parameter with each ID--for example:
 
-          - `http://localhost:8086/api/v2/stacks?&orgID=INFLUX_ORG_ID&stackID=09bd87cd33be3000&stackID=09bef35081fe3000`
+          - `INFLUX_URL/api/v2/stacks?&orgID=INFLUX_ORG_ID&stackID=09bd87cd33be3000&stackID=09bef35081fe3000`
         examples:
           findStackByID:
             summary: Find a stack with the ID
@@ -15624,8 +15641,8 @@ paths:
 
         #### Related guides
 
-        - [InfluxDB stacks](https://docs.influxdata.com/influxdb/v2.3/influxdb-templates/stacks/)
-        - [Use InfluxDB templates](https://docs.influxdata.com/influxdb/v2.3/influxdb-templates/use/#apply-templates-to-an-influxdb-instance)
+        - [Initialize an InfluxDB stack](https://docs.influxdata.com/influxdb/v2.3/influxdb-templates/stacks/init/).
+        - [Use InfluxDB templates](https://docs.influxdata.com/influxdb/v2.3/influxdb-templates/use/#apply-templates-to-an-influxdb-instance).
       operationId: CreateStack
       requestBody:
         content:
@@ -17833,7 +17850,7 @@ paths:
   /api/v2/users:
     get:
       description: |
-        Retrieves a list of [users](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#user).
+        Lists [users](https://docs.influxdata.com/influxdb/v2.3/reference/glossary/#user).
         Default limit is `20`.
 
         To limit which users are returned, pass query parameters in your request.
@@ -17846,6 +17863,10 @@ paths:
         | List a specific user | `read-users` or `read-user USER_ID` | |
 
         *`USER_ID`* is the ID of the user that you want to retrieve.
+
+        #### Related guides
+
+        - [View users](https://docs.influxdata.com/influxdb/latest/users/view-users/).
       operationId: GetUsers
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
@@ -17923,8 +17944,8 @@ paths:
         This endpoint represents the first two steps in a four-step process to allow a user
         to authenticate with a username and password, and then access data in an organization:
 
-          1. Create a user: send a `POST` request to `POST /api/v2/users`. `name` is required.
-          2. Extract the user ID (`id`) value from the API response for _step 1_.
+          1. Create a user: send a `POST` request to `POST /api/v2/users`. The `name` property is required.
+          2. Extract the user ID (`id` property) value from the API response for _step 1_.
           3. Create an authorization (and API token) for the user: send a `POST` request to [`POST /api/v2/authorizations`](#operation/PostAuthorizations), passing the user ID (`id`) from _step 2_.
           4. Create a password for the user: send a `POST` request to [`POST /api/v2/users/USER_ID/password`](#operation/PostUsersIDPassword), passing the user ID from _step 2_.
 
@@ -17994,24 +18015,34 @@ paths:
       - label: 'cURL: create a user and set a password'
         lang: Shell
         source: |
-          # Create the user and assign the user ID to a variable.
-          USER_ID=$(curl --request POST \
-                  "http://localhost:8086/api/v2/users/" \
-                  --header "Authorization: Token INFLUX_OP_TOKEN" \
-                  --header 'Content-type: application/json' \
-                  --data-binary @- << EOF | jq -r '.id'
-                  {
-                    "name": "USER_NAME",
-                    "status": "active"
-                  }
-          EOF
-          )
+          # The following steps show how to create a user and then set
+          # the user's password:
+          #
+          # 1. Send a request to this endpoint to create a user--for example:
 
-          # Pass the user ID and a password to set the password for the user.
-          curl request POST "http://localhost:8086/api/v2/users/$USER_ID/password/" \
-            --header "Authorization: Token INFLUX_OP_TOKEN" \
-            --header 'Content-type: application/json' \
-            --data '{ "password": "USER_PASSWORD" }'
+                USER=$(curl --request POST \
+                        "INFLUX_URL/api/v2/users/" \
+                        --header "Authorization: Token INFLUX_API_TOKEN" \
+                        --header 'Content-type: application/json' \
+                        --data-binary @- << EOF
+                        {
+                          "name": "USER_NAME",
+                          "status": "active"
+                        }
+                EOF
+                )
+
+          # 2. Extract the id property from the response in step 1--for example:
+
+                USER_ID=`echo $USER | jq -r '.id'`
+
+          # 3. To set the user's password, set the password property in a request
+          #    to the /api/v2/users/USER_ID/password endpoint--for example:
+
+                curl request POST "INFLUX_URL/api/v2/users/$USER_ID/password/" \
+                  --header "Authorization: Token INFLUX_API_TOKEN" \
+                  --header 'Content-type: application/json' \
+                  --data '{ "password": "USER_PASSWORD" }'
   /api/v2/users/{userID}:
     delete:
       description: |

--- a/contracts/svc/invocable-scripts.yml
+++ b/contracts/svc/invocable-scripts.yml
@@ -27,7 +27,7 @@ paths:
         - Invokable Scripts
       summary: List scripts
       description: |
-        Retrieves a list of [scripts](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/).
+        Lists [scripts](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/).
 
         #### Related guides
 
@@ -139,7 +139,7 @@ paths:
         - lang: Shell
           label: 'cURL: retrieves the first 100 scripts.'
           source: |
-            curl --request GET "https://cloud2.influxdata.com/api/v2/scripts?limit=100&offset=0" \
+            curl --request GET "INFLUX_URL/api/v2/scripts?limit=100&offset=0" \
               --header "Authorization: Token INFLUX_API_TOKEN" \
               --header "Accept: application/json" \
               --header "Content-Type: application/json"
@@ -213,7 +213,7 @@ paths:
         - lang: Shell
           label: cURL
           source: |
-            curl --request POST "https://cloud2.influxdata.com/api/v2/scripts" \
+            curl --request POST "INFLUX_URL/api/v2/scripts" \
               --header "Authorization: Token INFLUX_API_TOKEN" \
               --header "Accept: application/json" \
               --header "Content-Type: application/json" \
@@ -449,7 +449,7 @@ paths:
         - lang: Shell
           label: cURL
           source: |
-            curl --request POST "https://cloud2.influxdata.com/api/v2/scripts/SCRIPT_ID/invoke" \
+            curl --request POST "INFLUX_URL/api/v2/scripts/SCRIPT_ID/invoke" \
                       --header "Authorization: Token INFLUX_TOKEN" \
                       --header 'Accept: application/csv' \
                       --header 'Content-Type: application/json' \

--- a/src/cloud/paths/dashboards.yml
+++ b/src/cloud/paths/dashboards.yml
@@ -14,7 +14,7 @@ post:
           $ref: "../../common/schemas/CreateDashboardRequest.yml"
   responses:
     "201":
-      description: Added dashboard
+      description: Success. The dashboard is created.
       content:
         application/json:
           schema:
@@ -31,7 +31,14 @@ get:
   operationId: GetDashboards
   tags:
     - Dashboards
-  summary: List all dashboards
+  summary: List dashboards
+  description: |
+    Lists [dashboards]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#dashboard).
+
+    #### Related guides
+
+    - [Manage dashboards]({{% INFLUXDB_DOCS_URL %}}/visualize-data/dashboards/).
+
   parameters:
     - $ref: "../../common/parameters/TraceSpan.yml"
     - $ref: "../../common/parameters/Offset.yml"
@@ -43,10 +50,13 @@ get:
         minimum: -1
         maximum: 100
         default: 20
-      description: The non-zero number of dashboards to return
+      description: |
+        The maximum number of [dashboards]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#dashboard) to return.
+        Default is `20`.
+        The minimum is `-1` and the maximum is `100`.
     - in: query
       name: owner
-      description: A user identifier. Returns only dashboards where this user has the `owner` role.
+      description: A user ID. Only returns [dashboards]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#dashboard) where the specified user has the `owner` role.
       schema:
         type: string
     - in: query
@@ -60,24 +70,33 @@ get:
           - "UpdatedAt"
     - in: query
       name: id
-      description: A list of dashboard identifiers. Returns only the listed dashboards. If both `id` and `owner` are specified, only `id` is used.
+      description: |
+        A list of dashboard IDs.
+        Returns only the specified [dashboards]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#dashboard).
+        If you specify `id` and `owner`, only `id` is used.
       schema:
         type: array
         items:
           type: string
     - in: query
       name: orgID
-      description: The identifier of the organization.
+      description: |
+        An organization ID.
+        Only returns [dashboards]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#dashboard) that belong to the specified
+        [organization]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#organization).
       schema:
         type: string
     - in: query
       name: org
-      description: The name of the organization.
+      description: |
+        An organization name.
+        Only returns [dashboards]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#dashboard) that belong to the specified
+        [organization]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#organization).
       schema:
         type: string
   responses:
     "200":
-      description: All dashboards
+      description: Success. The response body contains dashboards.
       content:
         application/json:
           schema:

--- a/src/cloud/paths/measurements.yml
+++ b/src/cloud/paths/measurements.yml
@@ -2,7 +2,7 @@ summary: Bucket schemas
 get:
   summary: List measurement schemas of a bucket
   description: |
-    Retrieves a list of _explicit_
+    Lists _explicit_
     [schemas]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#schema)
     (`"schemaType": "explicit"`) for a bucket.
 
@@ -207,7 +207,7 @@ post:
     - lang: Shell
       label: cURL
       source: |
-        curl --request POST "https://cloud2.influxdata.com/api/v2/buckets/BUCKET_ID/schema/measurements \
+        curl --request POST "INFLUX_URL/api/v2/buckets/BUCKET_ID/schema/measurements \
           --header "Authorization: Token INFLUX_API_TOKEN" \
           --header "Accept: application/json" \
           --header "Content-Type: application/json" \

--- a/src/cloud/paths/measurements_measurementID.yml
+++ b/src/cloud/paths/measurements_measurementID.yml
@@ -145,7 +145,7 @@ patch:
     - lang: Shell
       label: cURL
       source: |
-        curl --request PATCH "https://cloud2.influxdata.com/api/v2/buckets/BUCKET_ID/schema/measurements \
+        curl --request PATCH "INFLUX_URL/api/v2/buckets/BUCKET_ID/schema/measurements \
           --header "Authorization: Token INFLUX_API_TOKEN" \
           --header "Accept: application/json" \
           --header "Content-Type: application/json" \

--- a/src/cloud/paths/tasks.yml
+++ b/src/cloud/paths/tasks.yml
@@ -139,7 +139,7 @@ get:
     - lang: Shell
       label: "cURL: all tasks, basic output"
       source: |
-        curl https://cloud2.influxdata.com/api/v2/tasks/?limit=-1&type=basic \
+        curl INFLUX_URL/api/v2/tasks/?limit=-1&type=basic \
           --header 'Content-Type: application/json' \
           --header 'Authorization: Token INFLUX_API_TOKEN'
 post:
@@ -262,7 +262,7 @@ post:
     - lang: Shell
       label: "cURL: create a Flux script task"
       source: |
-        curl https://cloud2.influxdata.com/api/v2/tasks \
+        curl INFLUX_URL/api/v2/tasks \
         --header "Content-type: application/json" \
         --header "Authorization: Token INFLUX_API_TOKEN" \
         --data-binary @- << EOF
@@ -279,7 +279,7 @@ post:
     - lang: Shell
       label: "cURL: create a Flux script reference task"
       source: |
-        curl https://cloud2.influxdata.com/api/v2/tasks \
+        curl INFLUX_URL/api/v2/tasks \
         --header "Content-type: application/json" \
         --header "Authorization: Token INFLUX_API_TOKEN" \
         --data-binary @- << EOF

--- a/src/cloud/paths/users.yml
+++ b/src/cloud/paths/users.yml
@@ -5,7 +5,7 @@ get:
     - Users
   summary: List users
   description: |
-    Retrieves a list of [users]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user).
+    Lists [users]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user).
 
     To limit which users are returned, pass query parameters in your request.
 
@@ -25,7 +25,7 @@ get:
 
     #### Related guides
 
-    - [Manage users]({{% INFLUXDB_DOCS_URL %}}/organizations/users/)
+    - [Manage users](https://docs.influxdata.com/influxdb/cloud/organizations/users/)
   parameters:
     - $ref: "../../common/parameters/TraceSpan.yml"
     - in: query

--- a/src/common/paths/buckets.yml
+++ b/src/common/paths/buckets.yml
@@ -4,7 +4,7 @@ get:
     - Buckets
   summary: List buckets
   description: |
-    Retrieves a list of [buckets]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#bucket).
+    Lists [buckets]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#bucket).
 
     InfluxDB retrieves buckets owned by the
     [organization]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#organization)

--- a/src/common/paths/dashboards.yml
+++ b/src/common/paths/dashboards.yml
@@ -14,7 +14,7 @@ post:
           $ref: "../schemas/CreateDashboardRequest.yml"
   responses:
     "201":
-      description: Added dashboard
+      description: Success. The dashboard is created.
       content:
         application/json:
           schema:
@@ -31,7 +31,13 @@ get:
   operationId: GetDashboards
   tags:
     - Dashboards
-  summary: List all dashboards
+  summary: List dashboards
+  description: |
+    Lists [dashboards]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#dashboard).
+
+    #### Related guides
+
+    - [Manage dashboards]({{% INFLUXDB_DOCS_URL %}}/visualize-data/dashboards/).
   parameters:
     - $ref: "../parameters/TraceSpan.yml"
     - $ref: "../parameters/Offset.yml"
@@ -39,7 +45,7 @@ get:
     - $ref: "../parameters/Descending.yml"
     - in: query
       name: owner
-      description: A user identifier. Returns only dashboards where this user has the `owner` role.
+      description: A user ID. Only returns [dashboards]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#dashboard) where the specified user has the `owner` role.
       schema:
         type: string
     - in: query
@@ -53,24 +59,33 @@ get:
           - "UpdatedAt"
     - in: query
       name: id
-      description: A list of dashboard identifiers. Returns only the listed dashboards. If both `id` and `owner` are specified, only `id` is used.
+      description: |
+        A list of dashboard IDs.
+        Returns only the specified [dashboards]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#dashboard).
+        If you specify `id` and `owner`, only `id` is used.
       schema:
         type: array
         items:
           type: string
     - in: query
       name: orgID
-      description: The identifier of the organization.
+      description: |
+        An organization ID.
+        Only returns [dashboards]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#dashboard) that belong to the specified
+        [organization]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#organization).
       schema:
         type: string
     - in: query
       name: org
-      description: The name of the organization.
+      description: |
+        An organization name.
+        Only returns [dashboards]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#dashboard) that belong to the specified
+        [organization]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#organization).
       schema:
         type: string
   responses:
     "200":
-      description: All dashboards
+      description: Success. The response body contains dashboards.
       content:
         application/json:
           schema:

--- a/src/common/paths/query_suggestions.yml
+++ b/src/common/paths/query_suggestions.yml
@@ -2,32 +2,28 @@ get:
   operationId: GetQuerySuggestions
   tags:
     - Query
-  summary: Retrieve Flux query suggestions
+  summary: List Flux query suggestions
   description: |
-    Retrieves a list of Flux query suggestions. Each suggestion contains a
+    Lists Flux query suggestions. Each suggestion contains a
     [Flux function](https://docs.influxdata.com/flux/v0.x/stdlib/all-functions/)
     name and parameters.
 
     Use this endpoint to retrieve a list of Flux query suggestions used in the
-    InfluxDB Flux Query Builder. Helper function names have an underscore (`_`)
-    prefix and aren't meant to be used directly in queries--for example:
-
-    - **Recommended**:  Use `top(n, columns=["_value"], tables=<-)` to sort
-      on a column and keep the top n records instead of `_sortLimit_`.
-      `top` uses the `_sortLimit` helper function.
+    InfluxDB Flux Query Builder.
 
     #### Limitations
 
-    - Using `/api/v2/query/suggestions/` (note the trailing slash) with cURL
-    will result in a HTTP `301 Moved Permanently` status code. Please use
-    `/api/v2/query/suggestions` without a trailing slash.
-
     - When writing a query, avoid using `_functionName()` helper functions
-    exposed by this endpoint.
+    exposed by this endpoint.  Helper function names have an underscore (`_`)
+    prefix and aren't meant to be used directly in queries--for example:
+
+      - To sort on a column and keep the top n records, use the
+        `top(n, columns=["_value"], tables=<-)` function instead of the `_sortLimit`
+        helper function. `top` uses `_sortLimit`.
 
     #### Related Guides
 
-    - [List of all Flux functions]({{% INFLUXDB_DOCS_URL %}}/flux/v0.x/stdlib/all-functions/)
+    - [List of all Flux functions](https://docs.influxdata.com/flux/v0.x/stdlib/all-functions/)
   parameters:
     - $ref: "../parameters/TraceSpan.yml"
   responses:
@@ -46,7 +42,7 @@ get:
       description: |
         Moved Permanently.
         InfluxData has moved the URL of the endpoint.
-        Use `/api/v2/query/suggestions`.
+        Use `/api/v2/query/suggestions` (without a trailing slash).
       content:
         text/html:
           schema:
@@ -68,6 +64,6 @@ get:
     - lang: Shell
       label: cURL
       source: |
-        curl --request GET "https://cloud2.influxdata.com/api/v2/query/suggestions" \
+        curl --request GET "INFLUX_URL/api/v2/query/suggestions" \
           --header "Accept: application/json" \
           --header "Authorization: Token INFLUX_API_TOKEN"

--- a/src/common/paths/query_suggestions_name.yml
+++ b/src/common/paths/query_suggestions_name.yml
@@ -20,7 +20,7 @@ get:
 
     #### Related Guides
 
-    - [List of all Flux functions]({{% INFLUXDB_DOCS_URL %}}/flux/v0.x/stdlib/all-functions/)
+    - [List of all Flux functions](https://docs.influxdata.com/flux/v0.x/stdlib/all-functions/)
 
   parameters:
     - $ref: "../parameters/TraceSpan.yml"
@@ -30,8 +30,7 @@ get:
         type: string
       required: true
       description: |
-        A Flux Function name.
-        Only returns functions with this name.
+        A [Flux function](https://docs.influxdata.com/flux/v0.x/stdlib/all-functions/) name.
   responses:
     "200":
       description: |
@@ -64,6 +63,6 @@ get:
     - lang: Shell
       label: cURL
       source: |
-        curl --request GET "https://cloud2.influxdata.com/api/v2/query/suggestions/sum/" \
+        curl --request GET "INFLUX_URL/api/v2/query/suggestions/sum/" \
           --header "Accept: application/json" \
           --header "Authorization: Token INFLUX_API_TOKEN"

--- a/src/common/paths/stacks.yml
+++ b/src/common/paths/stacks.yml
@@ -4,11 +4,15 @@ get:
     - Templates
   summary: List installed stacks
   description: |
-    Retrieves a list of installed InfluxDB stacks.
+    Lists installed InfluxDB stacks.
 
     To limit stacks in the response, pass query parameters in your request.
     If no query parameters are passed, InfluxDB returns all installed stacks
     for the organization.
+
+    #### Related guides
+
+    - [View InfluxDB stacks]({{% INFLUXDB_DOCS_URL %}}/influxdb-templates/stacks/).
   parameters:
     - in: query
       name: orgID
@@ -16,8 +20,8 @@ get:
       schema:
         type: string
       description: |
-        The ID of the organization that owns the stacks.
-        Only returns stacks owned by this organization.
+        An organization ID.
+        Only returns stacks owned by the specified [organization]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#organization).
 
         #### InfluxDB Cloud
 
@@ -28,14 +32,14 @@ get:
       schema:
         type: string
       description: |
-        The stack name.
+        A stack name.
         Finds stack `events` with this name and returns the stacks.
 
         Repeatable.
         To filter for more than one stack name,
         repeat this parameter with each name--for example:
 
-        - `http://localhost:8086/api/v2/stacks?&orgID=INFLUX_ORG_ID&name=project-stack-0&name=project-stack-1`
+        - `INFLUX_URL/api/v2/stacks?&orgID=INFLUX_ORG_ID&name=project-stack-0&name=project-stack-1`
       examples:
         findStackByName:
           summary: Find stacks with the event name
@@ -45,14 +49,14 @@ get:
       schema:
         type: string
       description: |
-        The stack ID.
-        Only returns stacks with this ID.
+        A stack ID.
+        Only returns the specified stack.
 
         Repeatable.
         To filter for more than one stack ID,
         repeat this parameter with each ID--for example:
 
-        - `http://localhost:8086/api/v2/stacks?&orgID=INFLUX_ORG_ID&stackID=09bd87cd33be3000&stackID=09bef35081fe3000`
+        - `INFLUX_URL/api/v2/stacks?&orgID=INFLUX_ORG_ID&stackID=09bd87cd33be3000&stackID=09bef35081fe3000`
       examples:
         findStackByID:
           summary: Find a stack with the ID
@@ -128,8 +132,8 @@ post:
 
     #### Related guides
 
-    - [InfluxDB stacks]({{% INFLUXDB_DOCS_URL %}}/influxdb-templates/stacks/)
-    - [Use InfluxDB templates]({{% INFLUXDB_DOCS_URL %}}/influxdb-templates/use/#apply-templates-to-an-influxdb-instance)
+    - [Initialize an InfluxDB stack]({{% INFLUXDB_DOCS_URL %}}/influxdb-templates/stacks/init/).
+    - [Use InfluxDB templates]({{% INFLUXDB_DOCS_URL %}}/influxdb-templates/use/#apply-templates-to-an-influxdb-instance).
   requestBody:
     description: The stack to create.
     required: true

--- a/src/common/paths/users.yml
+++ b/src/common/paths/users.yml
@@ -5,7 +5,7 @@ get:
     - Users
   summary: List users
   description: |
-    Retrieves a list of [users]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user).
+    Lists [users]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user).
     Default limit is `20`.
 
     To limit which users are returned, pass query parameters in your request.
@@ -18,6 +18,10 @@ get:
     | List a specific user | `read-users` or `read-user USER_ID` | |
 
     *`USER_ID`* is the ID of the user that you want to retrieve.
+
+    #### Related guides
+
+    - [View users](https://docs.influxdata.com/influxdb/latest/users/view-users/).
   parameters:
     - $ref: "../../common/parameters/TraceSpan.yml"
     - $ref: "../../common/parameters/Offset.yml"
@@ -96,8 +100,8 @@ post:
     This endpoint represents the first two steps in a four-step process to allow a user
     to authenticate with a username and password, and then access data in an organization:
 
-      1. Create a user: send a `POST` request to `POST /api/v2/users`. `name` is required.
-      2. Extract the user ID (`id`) value from the API response for _step 1_.
+      1. Create a user: send a `POST` request to `POST /api/v2/users`. The `name` property is required.
+      2. Extract the user ID (`id` property) value from the API response for _step 1_.
       3. Create an authorization (and API token) for the user: send a `POST` request to [`POST /api/v2/authorizations`](#operation/PostAuthorizations), passing the user ID (`id`) from _step 2_.
       4. Create a password for the user: send a `POST` request to [`POST /api/v2/users/USER_ID/password`](#operation/PostUsersIDPassword), passing the user ID from _step 2_.
 
@@ -165,22 +169,31 @@ post:
     - label: "cURL: create a user and set a password"
       lang: Shell
       source: |
-        # Create the user and assign the user ID to a variable.
-        USER_ID=$(curl --request POST \
-                "http://localhost:8086/api/v2/users/" \
-                --header "Authorization: Token INFLUX_OP_TOKEN" \
+        # The following steps show how to create a user and then set
+        # the user's password:
+        #
+        # 1. Send a request to this endpoint to create a user--for example:
+
+              USER=$(curl --request POST \
+                      "INFLUX_URL/api/v2/users/" \
+                      --header "Authorization: Token INFLUX_API_TOKEN" \
+                      --header 'Content-type: application/json' \
+                      --data-binary @- << EOF
+                      {
+                        "name": "USER_NAME",
+                        "status": "active"
+                      }
+              EOF
+              )
+
+        # 2. Extract the id property from the response in step 1--for example:
+
+              USER_ID=`echo $USER | jq -r '.id'`
+
+        # 3. To set the user's password, set the password property in a request
+        #    to the /api/v2/users/USER_ID/password endpoint--for example:
+
+              curl request POST "INFLUX_URL/api/v2/users/$USER_ID/password/" \
+                --header "Authorization: Token INFLUX_API_TOKEN" \
                 --header 'Content-type: application/json' \
-                --data-binary @- << EOF | jq -r '.id'
-                {
-                  "name": "USER_NAME",
-                  "status": "active"
-                }
-        EOF
-        )
-
-        # Pass the user ID and a password to set the password for the user.
-        curl request POST "http://localhost:8086/api/v2/users/$USER_ID/password/" \
-          --header "Authorization: Token INFLUX_OP_TOKEN" \
-          --header 'Content-type: application/json' \
-          --data '{ "password": "USER_PASSWORD" }'
-
+                --data '{ "password": "USER_PASSWORD" }'

--- a/src/common/schemas/CheckBase.yml
+++ b/src/common/schemas/CheckBase.yml
@@ -57,18 +57,18 @@
         query: "/api/v2/checks/1/query"
       properties:
         self:
-          description: URL for this check
+          description: The URL for this check.
           $ref: "./Link.yml"
         labels:
-          description: URL to retrieve labels for this check
+          description: The URL to retrieve labels for this check.
           $ref: "./Link.yml"
         members:
-          description: URL to retrieve members for this check
+          description: The URL to retrieve members for this check.
           $ref: "./Link.yml"
         owners:
-          description: URL to retrieve owners for this check
+          description: The URL to retrieve owners for this check.
           $ref: "./Link.yml"
         query:
-          description: URL to retrieve flux script for this check
+          description: The URL to retrieve the Flux script for this check.
           $ref: "./Link.yml"
   required: [name, orgID, query]

--- a/src/common/schemas/LabelMapping.yml
+++ b/src/common/schemas/LabelMapping.yml
@@ -1,7 +1,10 @@
   type: object
+  description: A _label mapping_ contains a `label` ID to attach to a resource.
   properties:
     labelID:
       description: |
-        Label ID.
-        The ID of the label to attach.
+        A label ID.
+        Specifies the label to attach.
       type: string
+  required:
+    - labelID

--- a/src/common/schemas/NotificationEndpointBase.yml
+++ b/src/common/schemas/NotificationEndpointBase.yml
@@ -37,16 +37,16 @@
         owners: "/api/v2/notificationEndpoints/1/owners"
       properties:
         self:
-          description: URL for this endpoint.
+          description: The URL for this endpoint.
           $ref: "./Link.yml"
         labels:
-          description: URL to retrieve labels for this endpoint.
+          description: The URL to retrieve labels for this endpoint.
           $ref: "./Link.yml"
         members:
-          description: URL to retrieve members for this endpoint.
+          description: The URL to retrieve members for this endpoint.
           $ref: "./Link.yml"
         owners:
-          description: URL to retrieve owners for this endpoint.
+          description: The URL to retrieve owners for this endpoint.
           $ref: "./Link.yml"
     type:
       $ref: "./NotificationEndpointType.yml"

--- a/src/common/schemas/NotificationRuleBase.yml
+++ b/src/common/schemas/NotificationRuleBase.yml
@@ -92,17 +92,17 @@
         query: "/api/v2/notificationRules/1/query"
       properties:
         self:
-          description: URL for this endpoint.
+          description: The URL for this endpoint.
           $ref: "./Link.yml"
         labels:
-          description: URL to retrieve labels for this notification rule.
+          description: The URL to retrieve labels for this notification rule.
           $ref: "./Link.yml"
         members:
-          description: URL to retrieve members for this notification rule.
+          description: The URL to retrieve members for this notification rule.
           $ref: "./Link.yml"
         owners:
-          description: URL to retrieve owners for this notification rule.
+          description: The URL to retrieve owners for this notification rule.
           $ref: "./Link.yml"
         query:
-          description: URL to retrieve flux script for this notification rule.
+          description: The URL to retrieve the Flux script for this notification rule.
           $ref: "./Link.yml"

--- a/src/svc/invocable-scripts/paths/scripts.yml
+++ b/src/svc/invocable-scripts/paths/scripts.yml
@@ -5,7 +5,7 @@ get:
     - Invokable Scripts
   summary: List scripts
   description: |
-    Retrieves a list of [scripts](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/).
+    Lists [scripts](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/).
 
     #### Related guides
 
@@ -91,7 +91,7 @@ get:
     - lang: Shell
       label: 'cURL: retrieves the first 100 scripts.'
       source: |
-        curl --request GET "https://cloud2.influxdata.com/api/v2/scripts?limit=100&offset=0" \
+        curl --request GET "INFLUX_URL/api/v2/scripts?limit=100&offset=0" \
           --header "Authorization: Token INFLUX_API_TOKEN" \
           --header "Accept: application/json" \
           --header "Content-Type: application/json"
@@ -157,7 +157,7 @@ post:
     - lang: Shell
       label: cURL
       source: |
-        curl --request POST "https://cloud2.influxdata.com/api/v2/scripts" \
+        curl --request POST "INFLUX_URL/api/v2/scripts" \
           --header "Authorization: Token INFLUX_API_TOKEN" \
           --header "Accept: application/json" \
           --header "Content-Type: application/json" \

--- a/src/svc/invocable-scripts/paths/scripts_scriptID_invoke.yml
+++ b/src/svc/invocable-scripts/paths/scripts_scriptID_invoke.yml
@@ -124,7 +124,7 @@ post:
     - lang: Shell
       label: cURL
       source: |
-        curl --request POST "https://cloud2.influxdata.com/api/v2/scripts/SCRIPT_ID/invoke" \
+        curl --request POST "INFLUX_URL/api/v2/scripts/SCRIPT_ID/invoke" \
                   --header "Authorization: Token INFLUX_TOKEN" \
                   --header 'Accept: application/csv' \
                   --header 'Content-Type: application/json' \


### PR DESCRIPTION
- Style and format dashboard descriptions.
- Replace 'retrieve lists' with 'lists'.
- Fix links.
- Fix links to Flux docs.
- Replace code URLs with placeholders.