### PR TITLE
chore(unity): remove isBeta flag

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -1516,11 +1516,6 @@ components:
         - name
     Cluster:
       properties:
-        isBeta:
-          description: determines if the cluster is in beta
-          nullable: false
-          readOnly: true
-          type: boolean
         priority:
           description: priority for sorting the cluster
           nullable: false
@@ -1754,9 +1749,6 @@ components:
         isAvailable:
           type: boolean
           description: the availability of the provider
-        isBeta:
-          type: boolean
-          description: determines if the region is in beta
         isPrivate:
           type: boolean
           description: determines if the region is a private region
@@ -1766,7 +1758,6 @@ components:
         - provider
         - priority
         - isAvailable
-        - isBeta
         - isPrivate
     OperatorRegions:
       type: array

--- a/src/unity/schemas/Cluster.yml
+++ b/src/unity/schemas/Cluster.yml
@@ -1,9 +1,4 @@
 properties:
-  isBeta:
-    description: determines if the cluster is in beta
-    nullable: false
-    readOnly: true
-    type: boolean
   priority:
     description: priority for sorting the cluster
     nullable: false

--- a/src/unity/schemas/OperatorRegion.yml
+++ b/src/unity/schemas/OperatorRegion.yml
@@ -15,10 +15,7 @@ properties:
   isAvailable:
     type: boolean
     description: the availability of the provider
-  isBeta:
-    type: boolean
-    description: determines if the region is in beta
   isPrivate:
     type: boolean
     description: determines if the region is a private region
-required: [region, title, provider, priority, isAvailable, isBeta, isPrivate]
+required: [region, title, provider, priority, isAvailable, isPrivate]


### PR DESCRIPTION
Part of influxdata/quartz#6988

We are eliminating the concept of a beta cluster going forward. This removes the flag from `Cluster` and `OperatorRegion`.

It is not currently used anywhere in the UI codebase (though there is some WIP that might reference it).