### PR TITLE
fix(bucket schemas): `requestBody` for `createMeasurementSchema` and `updateMeasurementSchema` should be required

### DIFF
--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -1055,6 +1055,7 @@ paths:
       tags:
         - Bucket Schemas
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -1250,6 +1251,7 @@ paths:
       tags:
         - Bucket Schemas
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -12233,6 +12233,7 @@
           "Bucket Schemas"
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -12450,6 +12451,7 @@
           "Bucket Schemas"
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -9929,6 +9929,7 @@ paths:
       tags:
         - Bucket Schemas
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -10124,6 +10125,7 @@ paths:
       tags:
         - Bucket Schemas
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -8340,6 +8340,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/MeasurementSchemaCreateRequest'
+        required: true
       responses:
         "201":
           content:
@@ -8541,6 +8542,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/MeasurementSchemaUpdateRequest'
+        required: true
       responses:
         "200":
           content:

--- a/src/cloud/paths/measurements.yml
+++ b/src/cloud/paths/measurements.yml
@@ -131,6 +131,7 @@ post:
   tags:
     - Bucket Schemas
   requestBody:
+    required: true
     content:
       application/json:
         schema:

--- a/src/cloud/paths/measurements_measurementID.yml
+++ b/src/cloud/paths/measurements_measurementID.yml
@@ -106,6 +106,7 @@ patch:
   tags:
     - Bucket Schemas
   requestBody:
+    required: true
     content:
       application/json:
         schema:


### PR DESCRIPTION
The request body should be marked as a required. Without required the `OpenAPI` generator allow creates request without body which causes InfluxDB error: 

```
>>> Request: 'POST https://us-west-2-1.aws.cloud2.influxdata.com/api/v2/buckets/7100bd8a60da51ca/schema/measurements?orgID=04014de4ed590000'
>>> Accept: application/json
>>> Content-Type: application/json
>>> Authorization: ***
>>> User-Agent: influxdb-client-python/1.34.0dev0
>>> Body: None
```

```
<<< Response: 400
<<< Date: Sun, 06 Nov 2022 20:31:04 GMT
<<< Content-Type: application/json; charset=utf-8
<<< Content-Length: 67
<<< Connection: keep-alive
<<< trace-id: d86c9bd64c29c43d
<<< trace-sampled: false
<<< x-platform-error-code: invalid
<<< Strict-Transport-Security: max-age=15724800; includeSubDomains
<<< X-Influxdb-Request-ID: 83205924ffa18967e95a3ce441b2bb7b
<<< X-Influxdb-Build: Cloud
<<< Body: {
	"code": "invalid",
	"message": "failed to unmarshal json: EOF"
}
```