### PR TITLE
Describe /signout

### DIFF
--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -4645,5 +4645,8 @@ components:
         curl --get "INFLUX_URL/api/v2/signin"
             --header "Authorization: Basic VVNFUk5BTUU6UEFTU1dPUkQ="
         ```
+
+        To learn more about HTTP authentication, see
+        [Mozilla Developer Network (MDN) Web Docs, HTTP authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication)._
 security:
   - TokenAuthentication: []

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -121,8 +121,9 @@
       "post": {
         "operationId": "PostSignin",
         "summary": "Create a user session.",
-        "description": "Authenticates [Basic authentication credentials](#section/Authentication/BasicAuthentication)\nfor a [user]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user),\nand then, if successful, generates a user session.\n\nTo authenticate a user, pass the HTTP `Authorization` header with the\n`Basic` scheme and the base64-encoded username and password.\nFor syntax and more information, see [Basic Authentication](#section/Authentication/BasicAuthentication) for\nsyntax and more information.\n\nIf authentication is successful, InfluxDB creates a new session for the user\nand then returns the session cookie in the `Set-Cookie` response header.\n\nUser sessions exist only in memory.\nThey expire within ten minutes and during restarts of the InfluxDB instance.\n\n#### User sessions with authorizations\n\n- In InfluxDB Cloud, a user session inherits all the user's permissions for\n  the organization.\n- In InfluxDB OSS, a user session inherits all the user's permissions for all\n  the organizations that the user belongs to.\n\n#### Related endpoints\n\n- [Signout](#tag/Signout)\n",
+        "description": "Authenticates [Basic authentication credentials](#section/Authentication/BasicAuthentication)\nfor a [user]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user),\nand then, if successful, generates a user session.\n\nTo authenticate a user, pass the HTTP `Authorization` header with the\n`Basic` scheme and the base64-encoded username and password.\nFor syntax and more information, see [Basic Authentication](#section/Authentication/BasicAuthentication) for\nsyntax and more information.\n\nIf authentication is successful, InfluxDB creates a new session for the user\nand then returns the session cookie in the `Set-Cookie` response header.\n\nInfluxDB stores user sessions in memory only.\nThey expire within ten minutes and during restarts of the InfluxDB instance.\n\n#### User sessions with authorizations\n\n- In InfluxDB Cloud, a user session inherits all the user's permissions for\n  the organization.\n- In InfluxDB OSS, a user session inherits all the user's permissions for all\n  the organizations that the user belongs to.\n\n#### Related endpoints\n\n- [Signout](#tag/Signout)\n",
         "tags": [
+          "Security and access endpoints",
           "Signin"
         ],
         "security": [
@@ -182,11 +183,12 @@
     "/signout": {
       "post": {
         "operationId": "PostSignout",
-        "summary": "Expire the current UI session",
+        "summary": "Expire a user session",
         "tags": [
+          "Security and access endpoints",
           "Signout"
         ],
-        "description": "Expires the current UI session for the user.",
+        "description": "Expires a user session specified by a session cookie.\n\nUse this endpoint to expire a user session that was generated when the user\nauthenticated with the InfluxDB Developer Console (UI) or the `POST /api/v2/signin` endpoint.\n\nFor example, the `POST /api/v2/signout` endpoint represents the third step\nin the following three-step process\nto authenticate a user, retrieve the `user` resource, and then expire the session:\n\n1. Send a request with the user's [Basic authentication credentials](#section/Authentication/BasicAuthentication)\n   to the `POST /api/v2/signin` endpoint to create a user session and\n   generate a session cookie.\n2. Send a request to the `GET /api/v2/me` endpoint, passing the stored session cookie\n   from step 1 to retrieve user information.\n3. Send a request to the `POST /api/v2/signout` endpoint, passing the stored session\n   cookie to expire the session.\n\n_See the complete example in request samples._\n\nInfluxDB stores user sessions in memory only.\nIf a user doesn't sign out, then the user session automatically expires within ten minutes or\nduring a restart of the InfluxDB instance.\n\nTo learn more about cookies in HTTP requests, see\n[Mozilla Developer Network (MDN) Web Docs, HTTP cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies).\n\n#### Related endpoints\n\n- [Signin](#tag/Signin)\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -194,10 +196,10 @@
         ],
         "responses": {
           "204": {
-            "description": "Session successfully expired"
+            "description": "Success. The session is expired."
           },
           "401": {
-            "description": "Unauthorized access",
+            "description": "Unauthorized.",
             "content": {
               "application/json": {
                 "schema": {
@@ -207,7 +209,7 @@
             }
           },
           "default": {
-            "description": "Unsuccessful session expiry",
+            "description": "The session expiry is unsuccessful.",
             "content": {
               "application/json": {
                 "schema": {
@@ -216,7 +218,14 @@
               }
             }
           }
-        }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "Shell",
+            "label": "cURL: sign in a user, verify the user session, and then end the session",
+            "source": "# The following example shows how to use cURL and the InfluxDB API\n# to do the following:\n# 1. Sign in a user with a username and password.\n# 2. Check that the user session exists for the user.\n# 3. Sign out the user to expire the session.\n# 4. Check that the session is no longer active.\n\n# 1. Send a request to `POST /api/v2/signin` to sign in the user.\n#    In your request, pass the following:\n#\n#      - `--user` option with basic authentication credentials.\n#      - `-c` option with a file path where cURL will write cookies.\n\n      curl --request POST \\\n        -c ./cookie-file.tmp \\\n        \"$INFLUX_URL/api/v2/signin\" \\\n        --user \"${INFLUX_USER_NAME}:${INFLUX_USER_PASSWORD}\"\n\n# 2. To check that a user session exists for the user in step 1,\n#    send a request to `GET /api/v2/me`.\n#    In your request, pass the `-b` option with the session cookie file path from step 1.\n\n      curl --request GET \\\n        -b ./cookie-file.tmp \\\n        \"$INFLUX_URL/api/v2/me\"\n\n#    InfluxDB responds with the `user` resource.\n\n# 3. Send a request to `POST /api/v2/signout` to expire the user session.\n#    In your request, pass the `-b` option with the session cookie file path from step 1.\n\n      curl --request POST \\\n        -b ./cookie-file.tmp \\\n        \"$INFLUX_URL/api/v2/signout\"\n\n#     If the user session is successfully expired, InfluxDB responds with\n      an HTTP `204` status code.\n\n# 4. To check that the user session is expired, call `GET /api/v2/me` again,\n#    passing the `-b` option with the cookie file path.\n\n      curl --request GET \\\n        -b ./cookie-file.tmp \\\n        \"$INFLUX_URL/api/v2/me\"\n\n#    If the user session is expired, InfluxDB responds with an HTTP `401` status code.\n"
+          }
+        ]
       }
     },
     "/ping": {
@@ -22083,7 +22092,7 @@
       "BasicAuthentication": {
         "type": "http",
         "scheme": "basic",
-        "description": "### Basic authentication scheme\n\nUse the HTTP Basic authentication scheme for InfluxDB `/api/v2` API operations that support it:\n\n### Syntax\n\n`Authorization: Basic BASE64_ENCODED_CREDENTIALS`\n\nTo construct the `BASE64_ENCODED_CREDENTIALS`, combine the username and\nthe password with a colon (`USERNAME:PASSWORD`), and then encode the\nresulting string in [base64](https://developer.mozilla.org/en-US/docs/Glossary/Base64).\nMany HTTP clients encode the credentials for you before sending the\nrequest.\n\n_**Warning**: Base64-encoding can easily be reversed to obtain the original\nusername and password. It is used to keep the data intact and does not provide\nsecurity. You should always use HTTPS when authenticating or sending a request with\nsensitive information._\n\n### Examples\n\nIn the examples, replace the following:\n\n- **`EMAIL_ADDRESS`**: InfluxDB Cloud username (the email address the user signed up with)\n- **`PASSWORD`**: InfluxDB Cloud [API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token)\n- **`INFLUX_URL`**: your InfluxDB Cloud URL\n\n#### Encode credentials with cURL\n\nThe following example shows how to use cURL to send an API request that uses Basic authentication.\nWith the `--user` option, cURL encodes the credentials and passes them\nin the `Authorization: Basic` header.\n\n```sh\ncurl --get \"INFLUX_URL/api/v2/signin\"\n    --user \"EMAIL_ADDRESS\":\"PASSWORD\"\n```\n\n#### Encode credentials with Flux\n\nThe Flux [`http.basicAuth()` function](https://docs.influxdata.com/flux/v0.x/stdlib/http/basicauth/) returns a Base64-encoded\nbasic authentication header using a specified username and password combination.\n\n#### Encode credentials with JavaScript\n\nThe following example shows how to use the JavaScript `btoa()` function\nto create a Base64-encoded string:\n\n```js\nbtoa('EMAIL_ADDRESS:PASSWORD')\n```\n\nThe output is the following:\n\n```js\n'VVNFUk5BTUU6UEFTU1dPUkQ='\n```\n\nOnce you have the Base64-encoded credentials, you can pass them in the\n`Authorization` header--for example:\n\n```sh\ncurl --get \"INFLUX_URL/api/v2/signin\"\n    --header \"Authorization: Basic VVNFUk5BTUU6UEFTU1dPUkQ=\"\n```\n"
+        "description": "### Basic authentication scheme\n\nUse the HTTP Basic authentication scheme for InfluxDB `/api/v2` API operations that support it:\n\n### Syntax\n\n`Authorization: Basic BASE64_ENCODED_CREDENTIALS`\n\nTo construct the `BASE64_ENCODED_CREDENTIALS`, combine the username and\nthe password with a colon (`USERNAME:PASSWORD`), and then encode the\nresulting string in [base64](https://developer.mozilla.org/en-US/docs/Glossary/Base64).\nMany HTTP clients encode the credentials for you before sending the\nrequest.\n\n_**Warning**: Base64-encoding can easily be reversed to obtain the original\nusername and password. It is used to keep the data intact and does not provide\nsecurity. You should always use HTTPS when authenticating or sending a request with\nsensitive information._\n\n### Examples\n\nIn the examples, replace the following:\n\n- **`EMAIL_ADDRESS`**: InfluxDB Cloud username (the email address the user signed up with)\n- **`PASSWORD`**: InfluxDB Cloud [API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token)\n- **`INFLUX_URL`**: your InfluxDB Cloud URL\n\n#### Encode credentials with cURL\n\nThe following example shows how to use cURL to send an API request that uses Basic authentication.\nWith the `--user` option, cURL encodes the credentials and passes them\nin the `Authorization: Basic` header.\n\n```sh\ncurl --get \"INFLUX_URL/api/v2/signin\"\n    --user \"EMAIL_ADDRESS\":\"PASSWORD\"\n```\n\n#### Encode credentials with Flux\n\nThe Flux [`http.basicAuth()` function](https://docs.influxdata.com/flux/v0.x/stdlib/http/basicauth/) returns a Base64-encoded\nbasic authentication header using a specified username and password combination.\n\n#### Encode credentials with JavaScript\n\nThe following example shows how to use the JavaScript `btoa()` function\nto create a Base64-encoded string:\n\n```js\nbtoa('EMAIL_ADDRESS:PASSWORD')\n```\n\nThe output is the following:\n\n```js\n'VVNFUk5BTUU6UEFTU1dPUkQ='\n```\n\nOnce you have the Base64-encoded credentials, you can pass them in the\n`Authorization` header--for example:\n\n```sh\ncurl --get \"INFLUX_URL/api/v2/signin\"\n    --header \"Authorization: Basic VVNFUk5BTUU6UEFTU1dPUkQ=\"\n```\n\nTo learn more about HTTP authentication, see\n[Mozilla Developer Network (MDN) Web Docs, HTTP authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication)._\n"
       }
     }
   },

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -302,7 +302,7 @@ paths:
         If authentication is successful, InfluxDB creates a new session for the user
         and then returns the session cookie in the `Set-Cookie` response header.
 
-        User sessions exist only in memory.
+        InfluxDB stores user sessions in memory only.
         They expire within ten minutes and during restarts of the InfluxDB instance.
 
         #### User sessions with authorizations
@@ -316,6 +316,7 @@ paths:
 
         - [Signout](#tag/Signout)
       tags:
+        - Security and access endpoints
         - Signin
       security:
         - BasicAuthentication: []
@@ -360,27 +361,107 @@ paths:
   /signout:
     post:
       operationId: PostSignout
-      summary: Expire the current UI session
+      summary: Expire a user session
       tags:
+        - Security and access endpoints
         - Signout
-      description: Expires the current UI session for the user.
+      description: |
+        Expires a user session specified by a session cookie.
+
+        Use this endpoint to expire a user session that was generated when the user
+        authenticated with the InfluxDB Developer Console (UI) or the `POST /api/v2/signin` endpoint.
+
+        For example, the `POST /api/v2/signout` endpoint represents the third step
+        in the following three-step process
+        to authenticate a user, retrieve the `user` resource, and then expire the session:
+
+        1. Send a request with the user's [Basic authentication credentials](#section/Authentication/BasicAuthentication)
+           to the `POST /api/v2/signin` endpoint to create a user session and
+           generate a session cookie.
+        2. Send a request to the `GET /api/v2/me` endpoint, passing the stored session cookie
+           from step 1 to retrieve user information.
+        3. Send a request to the `POST /api/v2/signout` endpoint, passing the stored session
+           cookie to expire the session.
+
+        _See the complete example in request samples._
+
+        InfluxDB stores user sessions in memory only.
+        If a user doesn't sign out, then the user session automatically expires within ten minutes or
+        during a restart of the InfluxDB instance.
+
+        To learn more about cookies in HTTP requests, see
+        [Mozilla Developer Network (MDN) Web Docs, HTTP cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies).
+
+        #### Related endpoints
+
+        - [Signin](#tag/Signin)
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
       responses:
         '204':
-          description: Session successfully expired
+          description: Success. The session is expired.
         '401':
-          description: Unauthorized access
+          description: Unauthorized.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
         default:
-          description: Unsuccessful session expiry
+          description: The session expiry is unsuccessful.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+      x-codeSamples:
+        - lang: Shell
+          label: 'cURL: sign in a user, verify the user session, and then end the session'
+          source: |
+            # The following example shows how to use cURL and the InfluxDB API
+            # to do the following:
+            # 1. Sign in a user with a username and password.
+            # 2. Check that the user session exists for the user.
+            # 3. Sign out the user to expire the session.
+            # 4. Check that the session is no longer active.
+
+            # 1. Send a request to `POST /api/v2/signin` to sign in the user.
+            #    In your request, pass the following:
+            #
+            #      - `--user` option with basic authentication credentials.
+            #      - `-c` option with a file path where cURL will write cookies.
+
+                  curl --request POST \
+                    -c ./cookie-file.tmp \
+                    "$INFLUX_URL/api/v2/signin" \
+                    --user "${INFLUX_USER_NAME}:${INFLUX_USER_PASSWORD}"
+
+            # 2. To check that a user session exists for the user in step 1,
+            #    send a request to `GET /api/v2/me`.
+            #    In your request, pass the `-b` option with the session cookie file path from step 1.
+
+                  curl --request GET \
+                    -b ./cookie-file.tmp \
+                    "$INFLUX_URL/api/v2/me"
+
+            #    InfluxDB responds with the `user` resource.
+
+            # 3. Send a request to `POST /api/v2/signout` to expire the user session.
+            #    In your request, pass the `-b` option with the session cookie file path from step 1.
+
+                  curl --request POST \
+                    -b ./cookie-file.tmp \
+                    "$INFLUX_URL/api/v2/signout"
+
+            #     If the user session is successfully expired, InfluxDB responds with
+                  an HTTP `204` status code.
+
+            # 4. To check that the user session is expired, call `GET /api/v2/me` again,
+            #    passing the `-b` option with the cookie file path.
+
+                  curl --request GET \
+                    -b ./cookie-file.tmp \
+                    "$INFLUX_URL/api/v2/me"
+
+            #    If the user session is expired, InfluxDB responds with an HTTP `401` status code.
   /ping:
     get:
       operationId: GetPing
@@ -17357,5 +17438,8 @@ components:
         curl --get "INFLUX_URL/api/v2/signin"
             --header "Authorization: Basic VVNFUk5BTUU6UEFTU1dPUkQ="
         ```
+
+        To learn more about HTTP authentication, see
+        [Mozilla Developer Network (MDN) Web Docs, HTTP authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication)._
 security:
   - TokenAuthentication: []

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -25,7 +25,7 @@ paths:
         If authentication is successful, InfluxDB creates a new session for the user
         and then returns the session cookie in the `Set-Cookie` response header.
 
-        User sessions exist only in memory.
+        InfluxDB stores user sessions in memory only.
         They expire within ten minutes and during restarts of the InfluxDB instance.
 
         #### User sessions with authorizations
@@ -39,6 +39,7 @@ paths:
 
         - [Signout](#tag/Signout)
       tags:
+        - Security and access endpoints
         - Signin
       security:
         - BasicAuthentication: []
@@ -83,27 +84,107 @@ paths:
   /signout:
     post:
       operationId: PostSignout
-      summary: Expire the current UI session
+      summary: Expire a user session
       tags:
+        - Security and access endpoints
         - Signout
-      description: Expires the current UI session for the user.
+      description: |
+        Expires a user session specified by a session cookie.
+
+        Use this endpoint to expire a user session that was generated when the user
+        authenticated with the InfluxDB Developer Console (UI) or the `POST /api/v2/signin` endpoint.
+
+        For example, the `POST /api/v2/signout` endpoint represents the third step
+        in the following three-step process
+        to authenticate a user, retrieve the `user` resource, and then expire the session:
+
+        1. Send a request with the user's [Basic authentication credentials](#section/Authentication/BasicAuthentication)
+           to the `POST /api/v2/signin` endpoint to create a user session and
+           generate a session cookie.
+        2. Send a request to the `GET /api/v2/me` endpoint, passing the stored session cookie
+           from step 1 to retrieve user information.
+        3. Send a request to the `POST /api/v2/signout` endpoint, passing the stored session
+           cookie to expire the session.
+
+        _See the complete example in request samples._
+
+        InfluxDB stores user sessions in memory only.
+        If a user doesn't sign out, then the user session automatically expires within ten minutes or
+        during a restart of the InfluxDB instance.
+
+        To learn more about cookies in HTTP requests, see
+        [Mozilla Developer Network (MDN) Web Docs, HTTP cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies).
+
+        #### Related endpoints
+
+        - [Signin](#tag/Signin)
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
       responses:
         '204':
-          description: Session successfully expired
+          description: Success. The session is expired.
         '401':
-          description: Unauthorized access
+          description: Unauthorized.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
         default:
-          description: Unsuccessful session expiry
+          description: The session expiry is unsuccessful.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+      x-codeSamples:
+        - lang: Shell
+          label: 'cURL: sign in a user, verify the user session, and then end the session'
+          source: |
+            # The following example shows how to use cURL and the InfluxDB API
+            # to do the following:
+            # 1. Sign in a user with a username and password.
+            # 2. Check that the user session exists for the user.
+            # 3. Sign out the user to expire the session.
+            # 4. Check that the session is no longer active.
+
+            # 1. Send a request to `POST /api/v2/signin` to sign in the user.
+            #    In your request, pass the following:
+            #
+            #      - `--user` option with basic authentication credentials.
+            #      - `-c` option with a file path where cURL will write cookies.
+
+                  curl --request POST \
+                    -c ./cookie-file.tmp \
+                    "$INFLUX_URL/api/v2/signin" \
+                    --user "${INFLUX_USER_NAME}:${INFLUX_USER_PASSWORD}"
+
+            # 2. To check that a user session exists for the user in step 1,
+            #    send a request to `GET /api/v2/me`.
+            #    In your request, pass the `-b` option with the session cookie file path from step 1.
+
+                  curl --request GET \
+                    -b ./cookie-file.tmp \
+                    "$INFLUX_URL/api/v2/me"
+
+            #    InfluxDB responds with the `user` resource.
+
+            # 3. Send a request to `POST /api/v2/signout` to expire the user session.
+            #    In your request, pass the `-b` option with the session cookie file path from step 1.
+
+                  curl --request POST \
+                    -b ./cookie-file.tmp \
+                    "$INFLUX_URL/api/v2/signout"
+
+            #     If the user session is successfully expired, InfluxDB responds with
+                  an HTTP `204` status code.
+
+            # 4. To check that the user session is expired, call `GET /api/v2/me` again,
+            #    passing the `-b` option with the cookie file path.
+
+                  curl --request GET \
+                    -b ./cookie-file.tmp \
+                    "$INFLUX_URL/api/v2/me"
+
+            #    If the user session is expired, InfluxDB responds with an HTTP `401` status code.
   /ping:
     get:
       operationId: GetPing

--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -6526,5 +6526,8 @@ components:
         curl --get "INFLUX_URL/api/v2/signin"
             --header "Authorization: Basic VVNFUk5BTUU6UEFTU1dPUkQ="
         ```
+
+        To learn more about HTTP authentication, see
+        [Mozilla Developer Network (MDN) Web Docs, HTTP authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication)._
 security:
   - TokenAuthentication: []

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -122,8 +122,9 @@
       "post": {
         "operationId": "PostSignin",
         "summary": "Create a user session.",
-        "description": "Authenticates [Basic authentication credentials](#section/Authentication/BasicAuthentication)\nfor a [user]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user),\nand then, if successful, generates a user session.\n\nTo authenticate a user, pass the HTTP `Authorization` header with the\n`Basic` scheme and the base64-encoded username and password.\nFor syntax and more information, see [Basic Authentication](#section/Authentication/BasicAuthentication) for\nsyntax and more information.\n\nIf authentication is successful, InfluxDB creates a new session for the user\nand then returns the session cookie in the `Set-Cookie` response header.\n\nUser sessions exist only in memory.\nThey expire within ten minutes and during restarts of the InfluxDB instance.\n\n#### User sessions with authorizations\n\n- In InfluxDB Cloud, a user session inherits all the user's permissions for\n  the organization.\n- In InfluxDB OSS, a user session inherits all the user's permissions for all\n  the organizations that the user belongs to.\n\n#### Related endpoints\n\n- [Signout](#tag/Signout)\n",
+        "description": "Authenticates [Basic authentication credentials](#section/Authentication/BasicAuthentication)\nfor a [user]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user),\nand then, if successful, generates a user session.\n\nTo authenticate a user, pass the HTTP `Authorization` header with the\n`Basic` scheme and the base64-encoded username and password.\nFor syntax and more information, see [Basic Authentication](#section/Authentication/BasicAuthentication) for\nsyntax and more information.\n\nIf authentication is successful, InfluxDB creates a new session for the user\nand then returns the session cookie in the `Set-Cookie` response header.\n\nInfluxDB stores user sessions in memory only.\nThey expire within ten minutes and during restarts of the InfluxDB instance.\n\n#### User sessions with authorizations\n\n- In InfluxDB Cloud, a user session inherits all the user's permissions for\n  the organization.\n- In InfluxDB OSS, a user session inherits all the user's permissions for all\n  the organizations that the user belongs to.\n\n#### Related endpoints\n\n- [Signout](#tag/Signout)\n",
         "tags": [
+          "Security and access endpoints",
           "Signin"
         ],
         "security": [
@@ -183,11 +184,12 @@
     "/signout": {
       "post": {
         "operationId": "PostSignout",
-        "summary": "Expire the current UI session",
+        "summary": "Expire a user session",
         "tags": [
+          "Security and access endpoints",
           "Signout"
         ],
-        "description": "Expires the current UI session for the user.",
+        "description": "Expires a user session specified by a session cookie.\n\nUse this endpoint to expire a user session that was generated when the user\nauthenticated with the InfluxDB Developer Console (UI) or the `POST /api/v2/signin` endpoint.\n\nFor example, the `POST /api/v2/signout` endpoint represents the third step\nin the following three-step process\nto authenticate a user, retrieve the `user` resource, and then expire the session:\n\n1. Send a request with the user's [Basic authentication credentials](#section/Authentication/BasicAuthentication)\n   to the `POST /api/v2/signin` endpoint to create a user session and\n   generate a session cookie.\n2. Send a request to the `GET /api/v2/me` endpoint, passing the stored session cookie\n   from step 1 to retrieve user information.\n3. Send a request to the `POST /api/v2/signout` endpoint, passing the stored session\n   cookie to expire the session.\n\n_See the complete example in request samples._\n\nInfluxDB stores user sessions in memory only.\nIf a user doesn't sign out, then the user session automatically expires within ten minutes or\nduring a restart of the InfluxDB instance.\n\nTo learn more about cookies in HTTP requests, see\n[Mozilla Developer Network (MDN) Web Docs, HTTP cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies).\n\n#### Related endpoints\n\n- [Signin](#tag/Signin)\n",
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
@@ -195,10 +197,10 @@
         ],
         "responses": {
           "204": {
-            "description": "Session successfully expired"
+            "description": "Success. The session is expired."
           },
           "401": {
-            "description": "Unauthorized access",
+            "description": "Unauthorized.",
             "content": {
               "application/json": {
                 "schema": {
@@ -208,7 +210,7 @@
             }
           },
           "default": {
-            "description": "Unsuccessful session expiry",
+            "description": "The session expiry is unsuccessful.",
             "content": {
               "application/json": {
                 "schema": {
@@ -217,7 +219,14 @@
               }
             }
           }
-        }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "Shell",
+            "label": "cURL: sign in a user, verify the user session, and then end the session",
+            "source": "# The following example shows how to use cURL and the InfluxDB API\n# to do the following:\n# 1. Sign in a user with a username and password.\n# 2. Check that the user session exists for the user.\n# 3. Sign out the user to expire the session.\n# 4. Check that the session is no longer active.\n\n# 1. Send a request to `POST /api/v2/signin` to sign in the user.\n#    In your request, pass the following:\n#\n#      - `--user` option with basic authentication credentials.\n#      - `-c` option with a file path where cURL will write cookies.\n\n      curl --request POST \\\n        -c ./cookie-file.tmp \\\n        \"$INFLUX_URL/api/v2/signin\" \\\n        --user \"${INFLUX_USER_NAME}:${INFLUX_USER_PASSWORD}\"\n\n# 2. To check that a user session exists for the user in step 1,\n#    send a request to `GET /api/v2/me`.\n#    In your request, pass the `-b` option with the session cookie file path from step 1.\n\n      curl --request GET \\\n        -b ./cookie-file.tmp \\\n        \"$INFLUX_URL/api/v2/me\"\n\n#    InfluxDB responds with the `user` resource.\n\n# 3. Send a request to `POST /api/v2/signout` to expire the user session.\n#    In your request, pass the `-b` option with the session cookie file path from step 1.\n\n      curl --request POST \\\n        -b ./cookie-file.tmp \\\n        \"$INFLUX_URL/api/v2/signout\"\n\n#     If the user session is successfully expired, InfluxDB responds with\n      an HTTP `204` status code.\n\n# 4. To check that the user session is expired, call `GET /api/v2/me` again,\n#    passing the `-b` option with the cookie file path.\n\n      curl --request GET \\\n        -b ./cookie-file.tmp \\\n        \"$INFLUX_URL/api/v2/me\"\n\n#    If the user session is expired, InfluxDB responds with an HTTP `401` status code.\n"
+          }
+        ]
       }
     },
     "/ping": {
@@ -24716,7 +24725,7 @@
       "BasicAuthentication": {
         "type": "http",
         "scheme": "basic",
-        "description": "### Basic authentication scheme\n\nUse the HTTP Basic authentication scheme for InfluxDB `/api/v2` API operations that support it:\n\n### Syntax\n\n`Authorization: Basic BASE64_ENCODED_CREDENTIALS`\n\nTo construct the `BASE64_ENCODED_CREDENTIALS`, combine the username and\nthe password with a colon (`USERNAME:PASSWORD`), and then encode the\nresulting string in [base64](https://developer.mozilla.org/en-US/docs/Glossary/Base64).\nMany HTTP clients encode the credentials for you before sending the\nrequest.\n\n_**Warning**: Base64-encoding can easily be reversed to obtain the original\nusername and password. It is used to keep the data intact and does not provide\nsecurity. You should always use HTTPS when authenticating or sending a request with\nsensitive information._\n\n### Examples\n\nIn the examples, replace the following:\n\n- **`USERNAME`**: InfluxDB username\n- **`PASSWORD`**: InfluxDB [API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token)\n- **`INFLUX_URL`**: your InfluxDB URL\n\n#### Encode credentials with cURL\n\nThe following example shows how to use cURL to send an API request that uses Basic authentication.\nWith the `--user` option, cURL encodes the credentials and passes them\nin the `Authorization: Basic` header.\n\n```sh\ncurl --get \"INFLUX_URL/api/v2/signin\"\n    --user \"USERNAME\":\"PASSWORD\"\n```\n\n#### Encode credentials with Flux\n\nThe Flux [`http.basicAuth()` function](https://docs.influxdata.com/flux/v0.x/stdlib/http/basicauth/) returns a Base64-encoded\nbasic authentication header using a specified username and password combination.\n\n#### Encode credentials with JavaScript\n\nThe following example shows how to use the JavaScript `btoa()` function\nto create a Base64-encoded string:\n\n```js\nbtoa('USERNAME:PASSWORD')\n```\n\nThe output is the following:\n\n```js\n'VVNFUk5BTUU6UEFTU1dPUkQ='\n```\n\nOnce you have the Base64-encoded credentials, you can pass them in the\n`Authorization` header--for example:\n\n```sh\ncurl --get \"INFLUX_URL/api/v2/signin\"\n    --header \"Authorization: Basic VVNFUk5BTUU6UEFTU1dPUkQ=\"\n```\n"
+        "description": "### Basic authentication scheme\n\nUse the HTTP Basic authentication scheme for InfluxDB `/api/v2` API operations that support it:\n\n### Syntax\n\n`Authorization: Basic BASE64_ENCODED_CREDENTIALS`\n\nTo construct the `BASE64_ENCODED_CREDENTIALS`, combine the username and\nthe password with a colon (`USERNAME:PASSWORD`), and then encode the\nresulting string in [base64](https://developer.mozilla.org/en-US/docs/Glossary/Base64).\nMany HTTP clients encode the credentials for you before sending the\nrequest.\n\n_**Warning**: Base64-encoding can easily be reversed to obtain the original\nusername and password. It is used to keep the data intact and does not provide\nsecurity. You should always use HTTPS when authenticating or sending a request with\nsensitive information._\n\n### Examples\n\nIn the examples, replace the following:\n\n- **`USERNAME`**: InfluxDB username\n- **`PASSWORD`**: InfluxDB [API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token)\n- **`INFLUX_URL`**: your InfluxDB URL\n\n#### Encode credentials with cURL\n\nThe following example shows how to use cURL to send an API request that uses Basic authentication.\nWith the `--user` option, cURL encodes the credentials and passes them\nin the `Authorization: Basic` header.\n\n```sh\ncurl --get \"INFLUX_URL/api/v2/signin\"\n    --user \"USERNAME\":\"PASSWORD\"\n```\n\n#### Encode credentials with Flux\n\nThe Flux [`http.basicAuth()` function](https://docs.influxdata.com/flux/v0.x/stdlib/http/basicauth/) returns a Base64-encoded\nbasic authentication header using a specified username and password combination.\n\n#### Encode credentials with JavaScript\n\nThe following example shows how to use the JavaScript `btoa()` function\nto create a Base64-encoded string:\n\n```js\nbtoa('USERNAME:PASSWORD')\n```\n\nThe output is the following:\n\n```js\n'VVNFUk5BTUU6UEFTU1dPUkQ='\n```\n\nOnce you have the Base64-encoded credentials, you can pass them in the\n`Authorization` header--for example:\n\n```sh\ncurl --get \"INFLUX_URL/api/v2/signin\"\n    --header \"Authorization: Basic VVNFUk5BTUU6UEFTU1dPUkQ=\"\n```\n\nTo learn more about HTTP authentication, see\n[Mozilla Developer Network (MDN) Web Docs, HTTP authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication)._\n"
       }
     }
   },

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -290,7 +290,7 @@ paths:
         If authentication is successful, InfluxDB creates a new session for the user
         and then returns the session cookie in the `Set-Cookie` response header.
 
-        User sessions exist only in memory.
+        InfluxDB stores user sessions in memory only.
         They expire within ten minutes and during restarts of the InfluxDB instance.
 
         #### User sessions with authorizations
@@ -304,6 +304,7 @@ paths:
 
         - [Signout](#tag/Signout)
       tags:
+        - Security and access endpoints
         - Signin
       security:
         - BasicAuthentication: []
@@ -348,27 +349,107 @@ paths:
   /signout:
     post:
       operationId: PostSignout
-      summary: Expire the current UI session
+      summary: Expire a user session
       tags:
+        - Security and access endpoints
         - Signout
-      description: Expires the current UI session for the user.
+      description: |
+        Expires a user session specified by a session cookie.
+
+        Use this endpoint to expire a user session that was generated when the user
+        authenticated with the InfluxDB Developer Console (UI) or the `POST /api/v2/signin` endpoint.
+
+        For example, the `POST /api/v2/signout` endpoint represents the third step
+        in the following three-step process
+        to authenticate a user, retrieve the `user` resource, and then expire the session:
+
+        1. Send a request with the user's [Basic authentication credentials](#section/Authentication/BasicAuthentication)
+           to the `POST /api/v2/signin` endpoint to create a user session and
+           generate a session cookie.
+        2. Send a request to the `GET /api/v2/me` endpoint, passing the stored session cookie
+           from step 1 to retrieve user information.
+        3. Send a request to the `POST /api/v2/signout` endpoint, passing the stored session
+           cookie to expire the session.
+
+        _See the complete example in request samples._
+
+        InfluxDB stores user sessions in memory only.
+        If a user doesn't sign out, then the user session automatically expires within ten minutes or
+        during a restart of the InfluxDB instance.
+
+        To learn more about cookies in HTTP requests, see
+        [Mozilla Developer Network (MDN) Web Docs, HTTP cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies).
+
+        #### Related endpoints
+
+        - [Signin](#tag/Signin)
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
       responses:
         '204':
-          description: Session successfully expired
+          description: Success. The session is expired.
         '401':
-          description: Unauthorized access
+          description: Unauthorized.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
         default:
-          description: Unsuccessful session expiry
+          description: The session expiry is unsuccessful.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+      x-codeSamples:
+        - lang: Shell
+          label: 'cURL: sign in a user, verify the user session, and then end the session'
+          source: |
+            # The following example shows how to use cURL and the InfluxDB API
+            # to do the following:
+            # 1. Sign in a user with a username and password.
+            # 2. Check that the user session exists for the user.
+            # 3. Sign out the user to expire the session.
+            # 4. Check that the session is no longer active.
+
+            # 1. Send a request to `POST /api/v2/signin` to sign in the user.
+            #    In your request, pass the following:
+            #
+            #      - `--user` option with basic authentication credentials.
+            #      - `-c` option with a file path where cURL will write cookies.
+
+                  curl --request POST \
+                    -c ./cookie-file.tmp \
+                    "$INFLUX_URL/api/v2/signin" \
+                    --user "${INFLUX_USER_NAME}:${INFLUX_USER_PASSWORD}"
+
+            # 2. To check that a user session exists for the user in step 1,
+            #    send a request to `GET /api/v2/me`.
+            #    In your request, pass the `-b` option with the session cookie file path from step 1.
+
+                  curl --request GET \
+                    -b ./cookie-file.tmp \
+                    "$INFLUX_URL/api/v2/me"
+
+            #    InfluxDB responds with the `user` resource.
+
+            # 3. Send a request to `POST /api/v2/signout` to expire the user session.
+            #    In your request, pass the `-b` option with the session cookie file path from step 1.
+
+                  curl --request POST \
+                    -b ./cookie-file.tmp \
+                    "$INFLUX_URL/api/v2/signout"
+
+            #     If the user session is successfully expired, InfluxDB responds with
+                  an HTTP `204` status code.
+
+            # 4. To check that the user session is expired, call `GET /api/v2/me` again,
+            #    passing the `-b` option with the cookie file path.
+
+                  curl --request GET \
+                    -b ./cookie-file.tmp \
+                    "$INFLUX_URL/api/v2/me"
+
+            #    If the user session is expired, InfluxDB responds with an HTTP `401` status code.
   /ping:
     get:
       operationId: GetPing
@@ -19097,5 +19178,8 @@ components:
         curl --get "INFLUX_URL/api/v2/signin"
             --header "Authorization: Basic VVNFUk5BTUU6UEFTU1dPUkQ="
         ```
+
+        To learn more about HTTP authentication, see
+        [Mozilla Developer Network (MDN) Web Docs, HTTP authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication)._
 security:
   - TokenAuthentication: []

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -6691,6 +6691,9 @@ components:
         curl --get "INFLUX_URL/api/v2/signin"
             --header "Authorization: Basic VVNFUk5BTUU6UEFTU1dPUkQ="
         ```
+
+        To learn more about HTTP authentication, see
+        [Mozilla Developer Network (MDN) Web Docs, HTTP authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication)._
       scheme: basic
       type: http
     TokenAuthentication:
@@ -14658,7 +14661,7 @@ paths:
         If authentication is successful, InfluxDB creates a new session for the user
         and then returns the session cookie in the `Set-Cookie` response header.
 
-        User sessions exist only in memory.
+        InfluxDB stores user sessions in memory only.
         They expire within ten minutes and during restarts of the InfluxDB instance.
 
         #### User sessions with authorizations
@@ -14708,6 +14711,7 @@ paths:
       - BasicAuthentication: []
       summary: Create a user session.
       tags:
+      - Security and access endpoints
       - Signin
       x-codeSamples:
       - label: 'cURL: signin with --user option encoding'
@@ -14717,28 +14721,108 @@ paths:
                --user "USERNAME:PASSWORD"
   /api/v2/signout:
     post:
-      description: Expires the current UI session for the user.
+      description: |
+        Expires a user session specified by a session cookie.
+
+        Use this endpoint to expire a user session that was generated when the user
+        authenticated with the InfluxDB Developer Console (UI) or the `POST /api/v2/signin` endpoint.
+
+        For example, the `POST /api/v2/signout` endpoint represents the third step
+        in the following three-step process
+        to authenticate a user, retrieve the `user` resource, and then expire the session:
+
+        1. Send a request with the user's [Basic authentication credentials](#section/Authentication/BasicAuthentication)
+           to the `POST /api/v2/signin` endpoint to create a user session and
+           generate a session cookie.
+        2. Send a request to the `GET /api/v2/me` endpoint, passing the stored session cookie
+           from step 1 to retrieve user information.
+        3. Send a request to the `POST /api/v2/signout` endpoint, passing the stored session
+           cookie to expire the session.
+
+        _See the complete example in request samples._
+
+        InfluxDB stores user sessions in memory only.
+        If a user doesn't sign out, then the user session automatically expires within ten minutes or
+        during a restart of the InfluxDB instance.
+
+        To learn more about cookies in HTTP requests, see
+        [Mozilla Developer Network (MDN) Web Docs, HTTP cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies).
+
+        #### Related endpoints
+
+        - [Signin](#tag/Signin)
       operationId: PostSignout
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
       responses:
         "204":
-          description: Session successfully expired
+          description: Success. The session is expired.
         "401":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-          description: Unauthorized access
+          description: Unauthorized.
         default:
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-          description: Unsuccessful session expiry
-      summary: Expire the current UI session
+          description: The session expiry is unsuccessful.
+      summary: Expire a user session
       tags:
+      - Security and access endpoints
       - Signout
+      x-codeSamples:
+      - label: 'cURL: sign in a user, verify the user session, and then end the session'
+        lang: Shell
+        source: |
+          # The following example shows how to use cURL and the InfluxDB API
+          # to do the following:
+          # 1. Sign in a user with a username and password.
+          # 2. Check that the user session exists for the user.
+          # 3. Sign out the user to expire the session.
+          # 4. Check that the session is no longer active.
+
+          # 1. Send a request to `POST /api/v2/signin` to sign in the user.
+          #    In your request, pass the following:
+          #
+          #      - `--user` option with basic authentication credentials.
+          #      - `-c` option with a file path where cURL will write cookies.
+
+                curl --request POST \
+                  -c ./cookie-file.tmp \
+                  "$INFLUX_URL/api/v2/signin" \
+                  --user "${INFLUX_USER_NAME}:${INFLUX_USER_PASSWORD}"
+
+          # 2. To check that a user session exists for the user in step 1,
+          #    send a request to `GET /api/v2/me`.
+          #    In your request, pass the `-b` option with the session cookie file path from step 1.
+
+                curl --request GET \
+                  -b ./cookie-file.tmp \
+                  "$INFLUX_URL/api/v2/me"
+
+          #    InfluxDB responds with the `user` resource.
+
+          # 3. Send a request to `POST /api/v2/signout` to expire the user session.
+          #    In your request, pass the `-b` option with the session cookie file path from step 1.
+
+                curl --request POST \
+                  -b ./cookie-file.tmp \
+                  "$INFLUX_URL/api/v2/signout"
+
+          #     If the user session is successfully expired, InfluxDB responds with
+                an HTTP `204` status code.
+
+          # 4. To check that the user session is expired, call `GET /api/v2/me` again,
+          #    passing the `-b` option with the cookie file path.
+
+                curl --request GET \
+                  -b ./cookie-file.tmp \
+                  "$INFLUX_URL/api/v2/me"
+
+          #    If the user session is expired, InfluxDB responds with an HTTP `401` status code.
   /api/v2/stacks:
     get:
       description: |

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -6736,6 +6736,9 @@ components:
         curl --get "INFLUX_URL/api/v2/signin"
             --header "Authorization: Basic VVNFUk5BTUU6UEFTU1dPUkQ="
         ```
+
+        To learn more about HTTP authentication, see
+        [Mozilla Developer Network (MDN) Web Docs, HTTP authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication)._
       scheme: basic
       type: http
     TokenAuthentication:
@@ -15360,7 +15363,7 @@ paths:
         If authentication is successful, InfluxDB creates a new session for the user
         and then returns the session cookie in the `Set-Cookie` response header.
 
-        User sessions exist only in memory.
+        InfluxDB stores user sessions in memory only.
         They expire within ten minutes and during restarts of the InfluxDB instance.
 
         #### User sessions with authorizations
@@ -15410,6 +15413,7 @@ paths:
       - BasicAuthentication: []
       summary: Create a user session.
       tags:
+      - Security and access endpoints
       - Signin
       x-codeSamples:
       - label: 'cURL: signin with --user option encoding'
@@ -15419,28 +15423,108 @@ paths:
                --user "USERNAME:PASSWORD"
   /api/v2/signout:
     post:
-      description: Expires the current UI session for the user.
+      description: |
+        Expires a user session specified by a session cookie.
+
+        Use this endpoint to expire a user session that was generated when the user
+        authenticated with the InfluxDB Developer Console (UI) or the `POST /api/v2/signin` endpoint.
+
+        For example, the `POST /api/v2/signout` endpoint represents the third step
+        in the following three-step process
+        to authenticate a user, retrieve the `user` resource, and then expire the session:
+
+        1. Send a request with the user's [Basic authentication credentials](#section/Authentication/BasicAuthentication)
+           to the `POST /api/v2/signin` endpoint to create a user session and
+           generate a session cookie.
+        2. Send a request to the `GET /api/v2/me` endpoint, passing the stored session cookie
+           from step 1 to retrieve user information.
+        3. Send a request to the `POST /api/v2/signout` endpoint, passing the stored session
+           cookie to expire the session.
+
+        _See the complete example in request samples._
+
+        InfluxDB stores user sessions in memory only.
+        If a user doesn't sign out, then the user session automatically expires within ten minutes or
+        during a restart of the InfluxDB instance.
+
+        To learn more about cookies in HTTP requests, see
+        [Mozilla Developer Network (MDN) Web Docs, HTTP cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies).
+
+        #### Related endpoints
+
+        - [Signin](#tag/Signin)
       operationId: PostSignout
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
       responses:
         "204":
-          description: Session successfully expired
+          description: Success. The session is expired.
         "401":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-          description: Unauthorized access
+          description: Unauthorized.
         default:
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-          description: Unsuccessful session expiry
-      summary: Expire the current UI session
+          description: The session expiry is unsuccessful.
+      summary: Expire a user session
       tags:
+      - Security and access endpoints
       - Signout
+      x-codeSamples:
+      - label: 'cURL: sign in a user, verify the user session, and then end the session'
+        lang: Shell
+        source: |
+          # The following example shows how to use cURL and the InfluxDB API
+          # to do the following:
+          # 1. Sign in a user with a username and password.
+          # 2. Check that the user session exists for the user.
+          # 3. Sign out the user to expire the session.
+          # 4. Check that the session is no longer active.
+
+          # 1. Send a request to `POST /api/v2/signin` to sign in the user.
+          #    In your request, pass the following:
+          #
+          #      - `--user` option with basic authentication credentials.
+          #      - `-c` option with a file path where cURL will write cookies.
+
+                curl --request POST \
+                  -c ./cookie-file.tmp \
+                  "$INFLUX_URL/api/v2/signin" \
+                  --user "${INFLUX_USER_NAME}:${INFLUX_USER_PASSWORD}"
+
+          # 2. To check that a user session exists for the user in step 1,
+          #    send a request to `GET /api/v2/me`.
+          #    In your request, pass the `-b` option with the session cookie file path from step 1.
+
+                curl --request GET \
+                  -b ./cookie-file.tmp \
+                  "$INFLUX_URL/api/v2/me"
+
+          #    InfluxDB responds with the `user` resource.
+
+          # 3. Send a request to `POST /api/v2/signout` to expire the user session.
+          #    In your request, pass the `-b` option with the session cookie file path from step 1.
+
+                curl --request POST \
+                  -b ./cookie-file.tmp \
+                  "$INFLUX_URL/api/v2/signout"
+
+          #     If the user session is successfully expired, InfluxDB responds with
+                an HTTP `204` status code.
+
+          # 4. To check that the user session is expired, call `GET /api/v2/me` again,
+          #    passing the `-b` option with the cookie file path.
+
+                curl --request GET \
+                  -b ./cookie-file.tmp \
+                  "$INFLUX_URL/api/v2/me"
+
+          #    If the user session is expired, InfluxDB responds with an HTTP `401` status code.
   /api/v2/sources:
     get:
       operationId: GetSources

--- a/src/cloud.yml
+++ b/src/cloud.yml
@@ -207,5 +207,8 @@ components:
         curl --get "INFLUX_URL/api/v2/signin"
             --header "Authorization: Basic VVNFUk5BTUU6UEFTU1dPUkQ="
         ```
+
+        To learn more about HTTP authentication, see
+        [Mozilla Developer Network (MDN) Web Docs, HTTP authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication)._
 security:
   - TokenAuthentication: []

--- a/src/common/paths/signin.yml
+++ b/src/common/paths/signin.yml
@@ -14,7 +14,7 @@ post:
     If authentication is successful, InfluxDB creates a new session for the user
     and then returns the session cookie in the `Set-Cookie` response header.
 
-    User sessions exist only in memory.
+    InfluxDB stores user sessions in memory only.
     They expire within ten minutes and during restarts of the InfluxDB instance.
 
     #### User sessions with authorizations
@@ -27,8 +27,8 @@ post:
     #### Related endpoints
 
     - [Signout](#tag/Signout)
-
   tags:
+    - Security and access endpoints
     - Signin
   security:
     - BasicAuthentication: []

--- a/src/common/paths/signout.yml
+++ b/src/common/paths/signout.yml
@@ -1,23 +1,103 @@
 post:
   operationId: PostSignout
-  summary: Expire the current UI session
+  summary: Expire a user session
   tags:
+    - Security and access endpoints
     - Signout
-  description: Expires the current UI session for the user.
+  description: |
+    Expires a user session specified by a session cookie.
+
+    Use this endpoint to expire a user session that was generated when the user
+    authenticated with the InfluxDB Developer Console (UI) or the `POST /api/v2/signin` endpoint.
+
+    For example, the `POST /api/v2/signout` endpoint represents the third step
+    in the following three-step process
+    to authenticate a user, retrieve the `user` resource, and then expire the session:
+
+    1. Send a request with the user's [Basic authentication credentials](#section/Authentication/BasicAuthentication)
+       to the `POST /api/v2/signin` endpoint to create a user session and
+       generate a session cookie.
+    2. Send a request to the `GET /api/v2/me` endpoint, passing the stored session cookie
+       from step 1 to retrieve user information.
+    3. Send a request to the `POST /api/v2/signout` endpoint, passing the stored session
+       cookie to expire the session.
+
+    _See the complete example in request samples._
+
+    InfluxDB stores user sessions in memory only.
+    If a user doesn't sign out, then the user session automatically expires within ten minutes or
+    during a restart of the InfluxDB instance.
+
+    To learn more about cookies in HTTP requests, see
+    [Mozilla Developer Network (MDN) Web Docs, HTTP cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies).
+
+    #### Related endpoints
+
+    - [Signin](#tag/Signin)
   parameters:
     - $ref: "../parameters/TraceSpan.yml"
   responses:
     "204":
-      description: Session successfully expired
+      description: Success. The session is expired.
     "401":
-      description: Unauthorized access
+      description: Unauthorized.
       content:
         application/json:
           schema:
             $ref: "../schemas/Error.yml"
     default:
-      description: Unsuccessful session expiry
+      description: The session expiry is unsuccessful.
       content:
         application/json:
           schema:
             $ref: "../schemas/Error.yml"
+  x-codeSamples:
+    - lang: Shell
+      label: "cURL: sign in a user, verify the user session, and then end the session"
+      source: |
+        # The following example shows how to use cURL and the InfluxDB API
+        # to do the following:
+        # 1. Sign in a user with a username and password.
+        # 2. Check that the user session exists for the user.
+        # 3. Sign out the user to expire the session.
+        # 4. Check that the session is no longer active.
+
+        # 1. Send a request to `POST /api/v2/signin` to sign in the user.
+        #    In your request, pass the following:
+        #
+        #      - `--user` option with basic authentication credentials.
+        #      - `-c` option with a file path where cURL will write cookies.
+
+              curl --request POST \
+                -c ./cookie-file.tmp \
+                "$INFLUX_URL/api/v2/signin" \
+                --user "${INFLUX_USER_NAME}:${INFLUX_USER_PASSWORD}"
+
+        # 2. To check that a user session exists for the user in step 1,
+        #    send a request to `GET /api/v2/me`.
+        #    In your request, pass the `-b` option with the session cookie file path from step 1.
+
+              curl --request GET \
+                -b ./cookie-file.tmp \
+                "$INFLUX_URL/api/v2/me"
+
+        #    InfluxDB responds with the `user` resource.
+
+        # 3. Send a request to `POST /api/v2/signout` to expire the user session.
+        #    In your request, pass the `-b` option with the session cookie file path from step 1.
+
+              curl --request POST \
+                -b ./cookie-file.tmp \
+                "$INFLUX_URL/api/v2/signout"
+
+        #     If the user session is successfully expired, InfluxDB responds with
+              an HTTP `204` status code.
+
+        # 4. To check that the user session is expired, call `GET /api/v2/me` again,
+        #    passing the `-b` option with the cookie file path.
+
+              curl --request GET \
+                -b ./cookie-file.tmp \
+                "$INFLUX_URL/api/v2/me"
+
+        #    If the user session is expired, InfluxDB responds with an HTTP `401` status code.

--- a/src/oss.yml
+++ b/src/oss.yml
@@ -333,6 +333,9 @@ components:
         curl --get "INFLUX_URL/api/v2/signin"
             --header "Authorization: Basic VVNFUk5BTUU6UEFTU1dPUkQ="
         ```
+
+        To learn more about HTTP authentication, see
+        [Mozilla Developer Network (MDN) Web Docs, HTTP authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication)._
 security:
   - TokenAuthentication: []
   # TODO: Uncomment when Bearer auth is also available in Cloud:


### PR DESCRIPTION
- Restore link to Mozilla HTTP authentication doc.
- Add description and example for /api/v2/signout, expiring a user session (Closes #375).