### PR TITLE
chore(aim): Add private delete org endpoint

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -656,6 +656,37 @@ paths:
           description: Unexpected error
           $ref: '#/components/responses/ServerError'
   '/orgs/{orgId}':
+    delete:
+      operationId: DeleteOrgId
+      tags:
+        - Organization
+      summary: Deletes an organization
+      parameters:
+        - in: path
+          name: orgId
+          schema:
+            type: string
+          required: true
+          description: The IDPE ID of the organization to delete.
+      responses:
+        '200':
+          description: Organization successfully deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Organization'
+        '401':
+          description: Unauthorized
+          $ref: '#/components/responses/ServerError'
+        '403':
+          description: Forbidden
+          $ref: '#/components/responses/ServerError'
+        '404':
+          description: Not Found
+          $ref: '#/components/responses/ServerError'
+        default:
+          description: Unexpected error
+          $ref: '#/components/responses/ServerError'
     get:
       operationId: GetOrgsId
       tags:

--- a/src/unity/paths/orgs_orgId.yml
+++ b/src/unity/paths/orgs_orgId.yml
@@ -1,3 +1,34 @@
+delete:
+  operationId: DeleteOrgId
+  tags:
+    - Organization
+  summary: Deletes an organization
+  parameters:
+    - in: path
+      name: orgId
+      schema:
+        type: string
+      required: true
+      description: The IDPE ID of the organization to delete.
+  responses:
+    '200':
+      description: Organization successfully deleted.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/Organization.yml'
+    '401':
+      description: Unauthorized
+      $ref: '../../common/responses/ServerError.yml'
+    '403':
+      description: Forbidden
+      $ref: '../../common/responses/ServerError.yml'
+    '404':
+      description: Not Found
+      $ref: '../../common/responses/ServerError.yml'
+    default:
+      description: Unexpected error
+      $ref: '../../common/responses/ServerError.yml'
 get:
   operationId: GetOrgsId
   tags:
@@ -11,12 +42,12 @@ get:
       required: true
       description: The IDPE ID of the organization to get.
   responses:
-    "200":
+    '200':
       description: Organization returned successfully.
       content:
         application/json:
           schema:
-            $ref: "../schemas/Organization.yml"
+            $ref: '../schemas/Organization.yml'
     '401':
       description: Unauthorized
       $ref: '../../common/responses/ServerError.yml'
@@ -34,7 +65,7 @@ patch:
     content:
       application/json:
         schema:
-          $ref: "../schemas/OrganizationUpdate.yml"
+          $ref: '../schemas/OrganizationUpdate.yml'
   parameters:
     - in: path
       name: orgId
@@ -43,12 +74,12 @@ patch:
       required: true
       description: The IDPE ID of the organization to update.
   responses:
-    "200":
+    '200':
       description: Organization updated
       content:
         application/json:
           schema:
-            $ref: "../schemas/Organization.yml"
+            $ref: '../schemas/Organization.yml'
     '401':
       description: Unauthorized
       $ref: '../../common/responses/ServerError.yml'


### PR DESCRIPTION
As part of Multi-Org, this adds a private api endpoint for deleting orgs. This feature is limited to PAYG and contract accounts. 