### PR TITLE
chore: add state property to OperatorOrganization

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -2291,6 +2291,13 @@ components:
         provider:
           type: string
           description: provider of the org
+        state:
+          type: string
+          description: the state of existence that the org is in
+          enum:
+            - pending
+            - provisioned
+            - suspended
         date:
           type: string
           description: date org was created

--- a/src/unity/schemas/OperatorOrganization.yml
+++ b/src/unity/schemas/OperatorOrganization.yml
@@ -15,6 +15,10 @@ properties:
   provider:
     type: string
     description: provider of the org
+  state:
+    type: string
+    description: the state of existence that the org is in
+    enum: ["pending", "provisioned", "suspended"]
   date:
     type: string
     description: date org was created


### PR DESCRIPTION
This adds the `state` property to the `OperatorOrganization` schema.