### PR TITLE
chore(aim): Add Org State to unity routes

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -2392,9 +2392,9 @@ components:
           description: provider of the org
         clusterHost:
           type: string
-          description: the url of the current cluster
+          description: URL of the current cluster
         state:
-          description: the current state of the organization
+          description: Current state of the organization
           type: string
           enum:
             - pending
@@ -2448,7 +2448,7 @@ components:
             description: the friendly name of the region where the organization is hosted
           state:
             $ref: '#/components/schemas/Organization/properties/state'
-            description: the current state of the organization
+            description: Current state of the organization
         required:
           - id
           - name

--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -2292,12 +2292,8 @@ components:
           type: string
           description: provider of the org
         state:
-          type: string
+          $ref: '#/components/schemas/Organization/properties/state'
           description: the state of existence that the org is in
-          enum:
-            - pending
-            - provisioned
-            - suspended
         date:
           type: string
           description: date org was created
@@ -2397,6 +2393,13 @@ components:
         clusterHost:
           type: string
           description: the url of the current cluster
+        state:
+          description: the current state of the organization
+          type: string
+          enum:
+            - pending
+            - provisioned
+            - suspended
       required:
         - id
         - clusterHost
@@ -2443,6 +2446,9 @@ components:
           regionName:
             type: string
             description: the friendly name of the region where the organization is hosted
+          state:
+            $ref: '#/components/schemas/Organization/properties/state'
+            description: the current state of the organization
         required:
           - id
           - name

--- a/src/unity/schemas/OperatorOrganization.yml
+++ b/src/unity/schemas/OperatorOrganization.yml
@@ -16,9 +16,8 @@ properties:
     type: string
     description: provider of the org
   state:
-    type: string
+    $ref: './OrganizationState.yml'
     description: the state of existence that the org is in
-    enum: ["pending", "provisioned", "suspended"]
   date:
     type: string
     description: date org was created

--- a/src/unity/schemas/Organization.yml
+++ b/src/unity/schemas/Organization.yml
@@ -25,4 +25,7 @@ properties:
   clusterHost:
     type: string
     description: the url of the current cluster
+  state:
+    $ref: './OrganizationState.yml'
+    description: the current state of the organization
 required: [id, clusterHost, regionCode, regionName]

--- a/src/unity/schemas/Organization.yml
+++ b/src/unity/schemas/Organization.yml
@@ -24,8 +24,8 @@ properties:
     description: provider of the org
   clusterHost:
     type: string
-    description: the url of the current cluster
+    description: URL of the current cluster
   state:
     $ref: './OrganizationState.yml'
-    description: the current state of the organization
+    description: Current state of the organization
 required: [id, clusterHost, regionCode, regionName]

--- a/src/unity/schemas/OrganizationState.yml
+++ b/src/unity/schemas/OrganizationState.yml
@@ -1,5 +1,5 @@
 type: string
-description: state of an organization
+description: State of an organization
 enum:
   - pending
   - provisioned

--- a/src/unity/schemas/OrganizationState.yml
+++ b/src/unity/schemas/OrganizationState.yml
@@ -1,0 +1,6 @@
+type: string
+description: state of an organization
+enum:
+  - pending
+  - provisioned
+  - suspended

--- a/src/unity/schemas/OrganizationSummary.yml
+++ b/src/unity/schemas/OrganizationSummary.yml
@@ -23,5 +23,5 @@ properties:
     description: the friendly name of the region where the organization is hosted
   state:
     $ref: './OrganizationState.yml'
-    description: the current state of the organization
+    description: Current state of the organization
 required: [id, name, isActive, isDefault]

--- a/src/unity/schemas/OrganizationSummary.yml
+++ b/src/unity/schemas/OrganizationSummary.yml
@@ -21,4 +21,7 @@ properties:
   regionName:
     type: string
     description: the friendly name of the region where the organization is hosted
+  state:
+    $ref: './OrganizationState.yml'
+    description: the current state of the organization
 required: [id, name, isActive, isDefault]


### PR DESCRIPTION
Adds an `OrganizationState` enum and the org state property to the endpoints that return orgs.