### PR TITLE
fix(aim): Add `content-type` to reactivate org endpoint

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -1425,6 +1425,11 @@ paths:
             type: string
           required: true
           description: The IDPE id of the organization to reactivate.
+      requestBody:
+        content:
+          application/json; charset=utf-8:
+            schema:
+              type: object
       responses:
         '200':
           description: Organization successfully reactivated.

--- a/src/unity/paths/operator_orgs_orgId_reactivate.yml
+++ b/src/unity/paths/operator_orgs_orgId_reactivate.yml
@@ -12,6 +12,11 @@ post:
         type: string
       required: true
       description: The IDPE id of the organization to reactivate.
+  requestBody:
+    content:
+      application/json; charset=utf-8:
+        schema:
+          type: object
   responses:
     '200':
       description: Organization successfully reactivated.


### PR DESCRIPTION
When I added the org reactivate endpoint in #618, I didn't realize Oats would need the content type for an empty body still. This adds that back in so that the `unityRoutes` file gets generated correctly.