### PR TITLE
fix(aim): Add `Content-Type` to delete orgs endpoint

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -668,6 +668,11 @@ paths:
             type: string
           required: true
           description: The IDPE ID of the organization to delete.
+      requestBody:
+        content:
+          application/json; charset=utf-8:
+            schema:
+              type: object
       responses:
         '200':
           description: Organization successfully deleted.

--- a/src/unity/paths/orgs_orgId.yml
+++ b/src/unity/paths/orgs_orgId.yml
@@ -10,6 +10,11 @@ delete:
         type: string
       required: true
       description: The IDPE ID of the organization to delete.
+  requestBody:
+    content:
+      application/json; charset=utf-8:
+        schema:
+          type: object
   responses:
     '200':
       description: Organization successfully deleted.


### PR DESCRIPTION
Similar to #620, this adds content type to the delete orgs endpoint, which is necessary for OATS to generate the correct unity routes.