### PR TITLE
chore: add defaultStorageType to organization

### DIFF
--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -3565,6 +3565,12 @@ components:
               type: string
             name:
               type: string
+            defaultStorageType:
+              description: Discloses whether the org uses tsm or iox.
+              type: string
+              enum:
+                - tsm
+                - iox
             description:
               type: string
             createdAt:

--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -3566,7 +3566,7 @@ components:
             name:
               type: string
             defaultStorageType:
-              description: Discloses whether the org uses tsm or iox.
+              description: Discloses whether the organization uses TSM or IOx.
               type: string
               enum:
                 - tsm
@@ -3582,7 +3582,7 @@ components:
               format: date-time
               readOnly: true
             status:
-              description: If inactive the organization is inactive.
+              description: 'If inactive, the organization is inactive.'
               default: active
               type: string
               enum:

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -14922,7 +14922,7 @@
             "type": "string"
           },
           "defaultStorageType": {
-            "description": "Discloses whether the org uses tsm or iox.",
+            "description": "Discloses whether the organization uses TSM or IOx.",
             "type": "string",
             "enum": [
               "tsm",
@@ -14943,7 +14943,7 @@
             "readOnly": true
           },
           "status": {
-            "description": "If inactive the organization is inactive.",
+            "description": "If inactive, the organization is inactive.",
             "default": "active",
             "type": "string",
             "enum": [

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -14921,6 +14921,14 @@
           "name": {
             "type": "string"
           },
+          "defaultStorageType": {
+            "description": "Discloses whether the org uses tsm or iox.",
+            "type": "string",
+            "enum": [
+              "tsm",
+              "iox"
+            ]
+          },
           "description": {
             "type": "string"
           },

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -12355,6 +12355,12 @@ components:
           type: string
         name:
           type: string
+        defaultStorageType:
+          description: Discloses whether the org uses tsm or iox.
+          type: string
+          enum:
+            - tsm
+            - iox
         description:
           type: string
         createdAt:

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -12356,7 +12356,7 @@ components:
         name:
           type: string
         defaultStorageType:
-          description: Discloses whether the org uses tsm or iox.
+          description: Discloses whether the organization uses TSM or IOx.
           type: string
           enum:
             - tsm
@@ -12372,7 +12372,7 @@ components:
           format: date-time
           readOnly: true
         status:
-          description: If inactive the organization is inactive.
+          description: 'If inactive, the organization is inactive.'
           default: active
           type: string
           enum:

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -10521,7 +10521,7 @@ components:
         name:
           type: string
         defaultStorageType:
-          description: Discloses whether the org uses tsm or iox.
+          description: Discloses whether the organization uses TSM or IOx.
           type: string
           enum:
             - tsm
@@ -10537,7 +10537,7 @@ components:
           format: date-time
           readOnly: true
         status:
-          description: If inactive the organization is inactive.
+          description: 'If inactive, the organization is inactive.'
           default: active
           type: string
           enum:

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -10520,6 +10520,12 @@ components:
           type: string
         name:
           type: string
+        defaultStorageType:
+          description: Discloses whether the org uses tsm or iox.
+          type: string
+          enum:
+            - tsm
+            - iox
         description:
           type: string
         createdAt:

--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -5305,6 +5305,12 @@ components:
               type: string
             name:
               type: string
+            defaultStorageType:
+              description: Discloses whether the org uses tsm or iox.
+              type: string
+              enum:
+                - tsm
+                - iox
             description:
               type: string
             createdAt:

--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -5306,7 +5306,7 @@ components:
             name:
               type: string
             defaultStorageType:
-              description: Discloses whether the org uses tsm or iox.
+              description: Discloses whether the organization uses TSM or IOx.
               type: string
               enum:
                 - tsm
@@ -5322,7 +5322,7 @@ components:
               format: date-time
               readOnly: true
             status:
-              description: If inactive the organization is inactive.
+              description: 'If inactive, the organization is inactive.'
               default: active
               type: string
               enum:

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -17303,7 +17303,7 @@
             "type": "string"
           },
           "defaultStorageType": {
-            "description": "Discloses whether the org uses tsm or iox.",
+            "description": "Discloses whether the organization uses TSM or IOx.",
             "type": "string",
             "enum": [
               "tsm",
@@ -17324,7 +17324,7 @@
             "readOnly": true
           },
           "status": {
-            "description": "If inactive the organization is inactive.",
+            "description": "If inactive, the organization is inactive.",
             "default": "active",
             "type": "string",
             "enum": [

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -17302,6 +17302,14 @@
           "name": {
             "type": "string"
           },
+          "defaultStorageType": {
+            "description": "Discloses whether the org uses tsm or iox.",
+            "type": "string",
+            "enum": [
+              "tsm",
+              "iox"
+            ]
+          },
           "description": {
             "type": "string"
           },

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -13936,6 +13936,12 @@ components:
           type: string
         name:
           type: string
+        defaultStorageType:
+          description: Discloses whether the org uses tsm or iox.
+          type: string
+          enum:
+            - tsm
+            - iox
         description:
           type: string
         createdAt:

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -13937,7 +13937,7 @@ components:
         name:
           type: string
         defaultStorageType:
-          description: Discloses whether the org uses tsm or iox.
+          description: Discloses whether the organization uses TSM or IOx.
           type: string
           enum:
             - tsm
@@ -13953,7 +13953,7 @@ components:
           format: date-time
           readOnly: true
         status:
-          description: If inactive the organization is inactive.
+          description: 'If inactive, the organization is inactive.'
           default: active
           type: string
           enum:

--- a/contracts/priv/cloud-priv.yml
+++ b/contracts/priv/cloud-priv.yml
@@ -721,7 +721,7 @@ components:
             name:
               type: string
             defaultStorageType:
-              description: Discloses whether the org uses tsm or iox.
+              description: Discloses whether the organization uses TSM or IOx.
               type: string
               enum:
                 - tsm
@@ -737,7 +737,7 @@ components:
               format: date-time
               readOnly: true
             status:
-              description: If inactive the organization is inactive.
+              description: 'If inactive, the organization is inactive.'
               default: active
               type: string
               enum:

--- a/contracts/priv/cloud-priv.yml
+++ b/contracts/priv/cloud-priv.yml
@@ -720,6 +720,12 @@ components:
               type: string
             name:
               type: string
+            defaultStorageType:
+              description: Discloses whether the org uses tsm or iox.
+              type: string
+              enum:
+                - tsm
+                - iox
             description:
               type: string
             createdAt:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -3400,7 +3400,7 @@ components:
           readOnly: true
           type: string
         defaultStorageType:
-          description: Discloses whether the org uses tsm or iox.
+          description: Discloses whether the organization uses TSM or IOx.
           enum:
           - tsm
           - iox
@@ -3443,7 +3443,7 @@ components:
           type: string
         status:
           default: active
-          description: If inactive the organization is inactive.
+          description: If inactive, the organization is inactive.
           enum:
           - active
           - inactive

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -3399,6 +3399,12 @@ components:
           format: date-time
           readOnly: true
           type: string
+        defaultStorageType:
+          description: Discloses whether the org uses tsm or iox.
+          enum:
+          - tsm
+          - iox
+          type: string
         description:
           type: string
         id:

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -3168,6 +3168,12 @@ components:
           format: date-time
           readOnly: true
           type: string
+        defaultStorageType:
+          description: Discloses whether the org uses tsm or iox.
+          enum:
+          - tsm
+          - iox
+          type: string
         description:
           type: string
         id:

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -3169,7 +3169,7 @@ components:
           readOnly: true
           type: string
         defaultStorageType:
-          description: Discloses whether the org uses tsm or iox.
+          description: Discloses whether the organization uses TSM or IOx.
           enum:
           - tsm
           - iox
@@ -3212,7 +3212,7 @@ components:
           type: string
         status:
           default: active
-          description: If inactive the organization is inactive.
+          description: If inactive, the organization is inactive.
           enum:
           - active
           - inactive

--- a/src/common/schemas/Organization.yml
+++ b/src/common/schemas/Organization.yml
@@ -1,53 +1,59 @@
-  properties:
-    links:
-      type: object
-      readOnly: true
-      example:
-        self: "/api/v2/orgs/1"
-        members: "/api/v2/orgs/1/members"
-        owners: "/api/v2/orgs/1/owners"
-        labels: "/api/v2/orgs/1/labels"
-        secrets: "/api/v2/orgs/1/secrets"
-        buckets: "/api/v2/buckets?org=myorg"
-        tasks: "/api/v2/tasks?org=myorg"
-        dashboards: "/api/v2/dashboards?org=myorg"
-      properties:
-        self:
-          $ref: "./Link.yml"
-        members:
-          $ref: "./Link.yml"
-        owners:
-          $ref: "./Link.yml"
-        labels:
-          $ref: "./Link.yml"
-        secrets:
-          $ref: "./Link.yml"
-        buckets:
-          $ref: "./Link.yml"
-        tasks:
-          $ref: "./Link.yml"
-        dashboards:
-          $ref: "./Link.yml"
-    id:
-      readOnly: true
-      type: string
-    name:
-      type: string
-    description:
-      type: string
-    createdAt:
-      type: string
-      format: date-time
-      readOnly: true
-    updatedAt:
-      type: string
-      format: date-time
-      readOnly: true
-    status:
-      description: If inactive the organization is inactive.
-      default: active
-      type: string
-      enum:
-        - active
-        - inactive
-  required: [name]
+properties:
+  links:
+    type: object
+    readOnly: true
+    example:
+      self: "/api/v2/orgs/1"
+      members: "/api/v2/orgs/1/members"
+      owners: "/api/v2/orgs/1/owners"
+      labels: "/api/v2/orgs/1/labels"
+      secrets: "/api/v2/orgs/1/secrets"
+      buckets: "/api/v2/buckets?org=myorg"
+      tasks: "/api/v2/tasks?org=myorg"
+      dashboards: "/api/v2/dashboards?org=myorg"
+    properties:
+      self:
+        $ref: "./Link.yml"
+      members:
+        $ref: "./Link.yml"
+      owners:
+        $ref: "./Link.yml"
+      labels:
+        $ref: "./Link.yml"
+      secrets:
+        $ref: "./Link.yml"
+      buckets:
+        $ref: "./Link.yml"
+      tasks:
+        $ref: "./Link.yml"
+      dashboards:
+        $ref: "./Link.yml"
+  id:
+    readOnly: true
+    type: string
+  name:
+    type: string
+  defaultStorageType:
+    description: Discloses whether the org uses tsm or iox.
+    type: string
+    enum:
+      - tsm
+      - iox
+  description:
+    type: string
+  createdAt:
+    type: string
+    format: date-time
+    readOnly: true
+  updatedAt:
+    type: string
+    format: date-time
+    readOnly: true
+  status:
+    description: If inactive the organization is inactive.
+    default: active
+    type: string
+    enum:
+      - active
+      - inactive
+required: [name]

--- a/src/common/schemas/Organization.yml
+++ b/src/common/schemas/Organization.yml
@@ -34,7 +34,7 @@ properties:
   name:
     type: string
   defaultStorageType:
-    description: Discloses whether the org uses tsm or iox.
+    description: Discloses whether the organization uses TSM or IOx.
     type: string
     enum:
       - tsm
@@ -50,7 +50,7 @@ properties:
     format: date-time
     readOnly: true
   status:
-    description: If inactive the organization is inactive.
+    description: If inactive, the organization is inactive.
     default: active
     type: string
     enum:


### PR DESCRIPTION
api/v2/orgs (the IDPE orgs endpoint) can send back a `defaultStorageType` property that discloses whether the org is using tsm or iox. This PR adds that optional property to the openapi spec.
