### PR TITLE
chore(aim): Add IDPE ID to transfer removed user's data to

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -960,6 +960,10 @@ paths:
           application/json; charset=utf-8:
             schema:
               type: object
+              properties:
+                transferIdpeId:
+                  type: string
+                  description: the id of the user to transfer IDPE data to
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path

--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -963,7 +963,7 @@ paths:
               properties:
                 transferIdpeId:
                   type: string
-                  description: the id of the user to transfer IDPE data to
+                  description: User ID to transfer IDPE data to.
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path

--- a/src/unity/paths/orgs_orgId_users_userId.yml
+++ b/src/unity/paths/orgs_orgId_users_userId.yml
@@ -12,7 +12,7 @@ delete:
           properties:
             transferIdpeId:
               type: string
-              description: the id of the user to transfer IDPE data to
+              description: User ID to transfer IDPE data to.
   parameters:
     - $ref: '../../common/parameters/TraceSpan.yml'
     - in: path

--- a/src/unity/paths/orgs_orgId_users_userId.yml
+++ b/src/unity/paths/orgs_orgId_users_userId.yml
@@ -9,6 +9,10 @@ delete:
       application/json; charset=utf-8:
         schema:
           type: object
+          properties:
+            transferIdpeId:
+              type: string
+              description: the id of the user to transfer IDPE data to
   parameters:
     - $ref: '../../common/parameters/TraceSpan.yml'
     - in: path


### PR DESCRIPTION
When deleting a user, we will include the option to transfer the user's IDPE data to another user. This adds an optional parameter to the request body to provide a transfer's IDPE ID.