### PR TITLE
fix: nullable property requires a type:

### DIFF
--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -15324,37 +15324,43 @@
             },
             "value": {
               "description": "Value provided to fulfill reference",
-              "nullable": true,
               "oneOf": [
                 {
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
-                  "type": "integer"
+                  "type": "integer",
+                  "nullable": true
                 },
                 {
-                  "type": "number"
+                  "type": "number",
+                  "nullable": true
                 },
                 {
-                  "type": "boolean"
+                  "type": "boolean",
+                  "nullable": true
                 }
               ]
             },
             "defaultValue": {
               "description": "Default value that will be provided for the reference when no value is provided",
-              "nullable": true,
               "oneOf": [
                 {
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
-                  "type": "integer"
+                  "type": "integer",
+                  "nullable": true
                 },
                 {
-                  "type": "number"
+                  "type": "number",
+                  "nullable": true
                 },
                 {
-                  "type": "boolean"
+                  "type": "boolean",
+                  "nullable": true
                 }
               ]
             }

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -12769,20 +12769,26 @@ components:
             description: Key identified as environment reference and is the key identified in the template
           value:
             description: Value provided to fulfill reference
-            nullable: true
             oneOf:
               - type: string
+                nullable: true
               - type: integer
+                nullable: true
               - type: number
+                nullable: true
               - type: boolean
+                nullable: true
           defaultValue:
             description: Default value that will be provided for the reference when no value is provided
-            nullable: true
             oneOf:
               - type: string
+                nullable: true
               - type: integer
+                nullable: true
               - type: number
+                nullable: true
               - type: boolean
+                nullable: true
         required:
           - resourceField
           - envRefKey

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -10934,20 +10934,26 @@ components:
             description: Key identified as environment reference and is the key identified in the template
           value:
             description: Value provided to fulfill reference
-            nullable: true
             oneOf:
               - type: string
+                nullable: true
               - type: integer
+                nullable: true
               - type: number
+                nullable: true
               - type: boolean
+                nullable: true
           defaultValue:
             description: Default value that will be provided for the reference when no value is provided
-            nullable: true
             oneOf:
               - type: string
+                nullable: true
               - type: integer
+                nullable: true
               - type: number
+                nullable: true
               - type: boolean
+                nullable: true
         required:
           - resourceField
           - envRefKey

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -17705,37 +17705,43 @@
             },
             "value": {
               "description": "Value provided to fulfill reference",
-              "nullable": true,
               "oneOf": [
                 {
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
-                  "type": "integer"
+                  "type": "integer",
+                  "nullable": true
                 },
                 {
-                  "type": "number"
+                  "type": "number",
+                  "nullable": true
                 },
                 {
-                  "type": "boolean"
+                  "type": "boolean",
+                  "nullable": true
                 }
               ]
             },
             "defaultValue": {
               "description": "Default value that will be provided for the reference when no value is provided",
-              "nullable": true,
               "oneOf": [
                 {
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
-                  "type": "integer"
+                  "type": "integer",
+                  "nullable": true
                 },
                 {
-                  "type": "number"
+                  "type": "number",
+                  "nullable": true
                 },
                 {
-                  "type": "boolean"
+                  "type": "boolean",
+                  "nullable": true
                 }
               ]
             }

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -14350,20 +14350,26 @@ components:
             description: Key identified as environment reference and is the key identified in the template
           value:
             description: Value provided to fulfill reference
-            nullable: true
             oneOf:
               - type: string
+                nullable: true
               - type: integer
+                nullable: true
               - type: number
+                nullable: true
               - type: boolean
+                nullable: true
           defaultValue:
             description: Default value that will be provided for the reference when no value is provided
-            nullable: true
             oneOf:
               - type: string
+                nullable: true
               - type: integer
+                nullable: true
               - type: number
+                nullable: true
               - type: boolean
+                nullable: true
         required:
           - resourceField
           - envRefKey

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -5478,12 +5478,15 @@ components:
           defaultValue:
             description: Default value that will be provided for the reference when
               no value is provided
-            nullable: true
             oneOf:
-            - type: string
-            - type: integer
-            - type: number
-            - type: boolean
+            - nullable: true
+              type: string
+            - nullable: true
+              type: integer
+            - nullable: true
+              type: number
+            - nullable: true
+              type: boolean
           envRefKey:
             description: Key identified as environment reference and is the key identified
               in the template
@@ -5493,12 +5496,15 @@ components:
             type: string
           value:
             description: Value provided to fulfill reference
-            nullable: true
             oneOf:
-            - type: string
-            - type: integer
-            - type: number
-            - type: boolean
+            - nullable: true
+              type: string
+            - nullable: true
+              type: integer
+            - nullable: true
+              type: number
+            - nullable: true
+              type: boolean
         required:
         - resourceField
         - envRefKey

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -5533,12 +5533,15 @@ components:
           defaultValue:
             description: Default value that will be provided for the reference when
               no value is provided
-            nullable: true
             oneOf:
-            - type: string
-            - type: integer
-            - type: number
-            - type: boolean
+            - nullable: true
+              type: string
+            - nullable: true
+              type: integer
+            - nullable: true
+              type: number
+            - nullable: true
+              type: boolean
           envRefKey:
             description: Key identified as environment reference and is the key identified
               in the template
@@ -5548,12 +5551,15 @@ components:
             type: string
           value:
             description: Value provided to fulfill reference
-            nullable: true
             oneOf:
-            - type: string
-            - type: integer
-            - type: number
-            - type: boolean
+            - nullable: true
+              type: string
+            - nullable: true
+              type: integer
+            - nullable: true
+              type: number
+            - nullable: true
+              type: boolean
         required:
         - resourceField
         - envRefKey

--- a/src/common/schemas/TemplateEnvReferences.yml
+++ b/src/common/schemas/TemplateEnvReferences.yml
@@ -10,18 +10,24 @@
         description: Key identified as environment reference and is the key identified in the template
       value:
         description: Value provided to fulfill reference
-        nullable: true
         oneOf:
           - type: string
+            nullable: true
           - type: integer
+            nullable: true
           - type: number
+            nullable: true
           - type: boolean
+            nullable: true
       defaultValue:
         description: Default value that will be provided for the reference when no value is provided
-        nullable: true
         oneOf:
           - type: string
+            nullable: true
           - type: integer
+            nullable: true
           - type: number
+            nullable: true
           - type: boolean
+            nullable: true
     required: [resourceField, envRefKey]


### PR DESCRIPTION
- TemplateEnvReferences fails validation because the nullable properties require a type.
- If a property may use one or more subschemas with different types, make each subschema nullable.