### PR TITLE
fix: unintentional payload object mappings for checks and notification endpoints

### DIFF
--- a/contracts/cloud-diff.yml
+++ b/contracts/cloud-diff.yml
@@ -1884,240 +1884,239 @@ paths:
                                             checkID:
                                               type: string
                                             check:
-                                              allOf:
-                                                - oneOf:
-                                                    - allOf:
-                                                        - properties:
-                                                            id:
-                                                              readOnly: true
-                                                              type: string
-                                                            name:
-                                                              type: string
-                                                            orgID:
-                                                              description: The ID of the organization that owns this check.
-                                                              type: string
-                                                            taskID:
-                                                              description: The ID of the task associated with this check.
-                                                              type: string
-                                                            ownerID:
-                                                              description: The ID of creator used to create this check.
-                                                              type: string
-                                                              readOnly: true
-                                                            createdAt:
-                                                              type: string
-                                                              format: date-time
-                                                              readOnly: true
-                                                            updatedAt:
-                                                              type: string
-                                                              format: date-time
-                                                              readOnly: true
-                                                            query:
-                                                              $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/1/allOf/1/properties/cells/items/allOf/1/properties/properties/oneOf/0/properties/queries/items'
-                                                            status:
-                                                              $ref: '#/components/schemas/Task/properties/status'
-                                                            description:
-                                                              description: An optional description of the check.
-                                                              type: string
-                                                            latestCompleted:
-                                                              type: string
-                                                              description: 'A timestamp ([RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp)) of the latest scheduled and completed run.'
-                                                              format: date-time
-                                                              readOnly: true
-                                                            lastRunStatus:
-                                                              readOnly: true
-                                                              type: string
-                                                              enum:
-                                                                - failed
-                                                                - success
-                                                                - canceled
-                                                            lastRunError:
-                                                              readOnly: true
-                                                              type: string
+                                              oneOf:
+                                                - allOf:
+                                                    - properties:
+                                                        id:
+                                                          readOnly: true
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        orgID:
+                                                          description: The ID of the organization that owns this check.
+                                                          type: string
+                                                        taskID:
+                                                          description: The ID of the task associated with this check.
+                                                          type: string
+                                                        ownerID:
+                                                          description: The ID of creator used to create this check.
+                                                          type: string
+                                                          readOnly: true
+                                                        createdAt:
+                                                          type: string
+                                                          format: date-time
+                                                          readOnly: true
+                                                        updatedAt:
+                                                          type: string
+                                                          format: date-time
+                                                          readOnly: true
+                                                        query:
+                                                          $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/1/allOf/1/properties/cells/items/allOf/1/properties/properties/oneOf/0/properties/queries/items'
+                                                        status:
+                                                          $ref: '#/components/schemas/Task/properties/status'
+                                                        description:
+                                                          description: An optional description of the check.
+                                                          type: string
+                                                        latestCompleted:
+                                                          type: string
+                                                          description: 'A timestamp ([RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp)) of the latest scheduled and completed run.'
+                                                          format: date-time
+                                                          readOnly: true
+                                                        lastRunStatus:
+                                                          readOnly: true
+                                                          type: string
+                                                          enum:
+                                                            - failed
+                                                            - success
+                                                            - canceled
+                                                        lastRunError:
+                                                          readOnly: true
+                                                          type: string
+                                                        labels:
+                                                          $ref: '#/components/schemas/Variable/properties/labels'
+                                                        links:
+                                                          type: object
+                                                          readOnly: true
+                                                          example:
+                                                            self: /api/v2/checks/1
+                                                            labels: /api/v2/checks/1/labels
+                                                            members: /api/v2/checks/1/members
+                                                            owners: /api/v2/checks/1/owners
+                                                            query: /api/v2/checks/1/query
+                                                          properties:
+                                                            self:
+                                                              description: The URL for this check.
+                                                              $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/0/allOf/1/properties/links/properties/org'
                                                             labels:
-                                                              $ref: '#/components/schemas/Variable/properties/labels'
-                                                            links:
-                                                              type: object
-                                                              readOnly: true
-                                                              example:
-                                                                self: /api/v2/checks/1
-                                                                labels: /api/v2/checks/1/labels
-                                                                members: /api/v2/checks/1/members
-                                                                owners: /api/v2/checks/1/owners
-                                                                query: /api/v2/checks/1/query
-                                                              properties:
-                                                                self:
-                                                                  description: The URL for this check.
-                                                                  $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/0/allOf/1/properties/links/properties/org'
-                                                                labels:
-                                                                  description: The URL to retrieve labels for this check.
-                                                                  $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/0/allOf/1/properties/links/properties/org'
-                                                                members:
-                                                                  description: The URL to retrieve members for this check.
-                                                                  $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/0/allOf/1/properties/links/properties/org'
-                                                                owners:
-                                                                  description: The URL to retrieve owners for this check.
-                                                                  $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/0/allOf/1/properties/links/properties/org'
-                                                                query:
-                                                                  description: The URL to retrieve the Flux script for this check.
-                                                                  $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/0/allOf/1/properties/links/properties/org'
-                                                          required:
-                                                            - name
-                                                            - orgID
-                                                            - query
-                                                        - type: object
-                                                          required:
-                                                            - type
-                                                          properties:
-                                                            type:
-                                                              type: string
-                                                              enum:
-                                                                - deadman
-                                                            timeSince:
-                                                              description: String duration before deadman triggers.
-                                                              type: string
-                                                            staleTime:
-                                                              description: String duration for time that a series is considered stale and should not trigger deadman.
-                                                              type: string
-                                                            reportZero:
-                                                              description: 'If only zero values reported since time, trigger an alert'
-                                                              type: boolean
-                                                            level:
-                                                              description: The state to record if check matches a criteria.
-                                                              type: string
-                                                              enum:
-                                                                - UNKNOWN
-                                                                - OK
-                                                                - INFO
-                                                                - CRIT
-                                                                - WARN
-                                                            every:
-                                                              description: Check repetition interval.
-                                                              type: string
-                                                            offset:
-                                                              description: 'Duration to delay after the schedule, before executing check.'
-                                                              type: string
-                                                            tags:
-                                                              description: List of tags to write to each status.
-                                                              type: array
-                                                              items:
-                                                                type: object
-                                                                properties:
-                                                                  key:
-                                                                    type: string
-                                                                  value:
-                                                                    type: string
-                                                            statusMessageTemplate:
-                                                              description: The template used to generate and write a status message.
-                                                              type: string
-                                                    - allOf:
-                                                        - $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/1/allOf/1/properties/cells/items/allOf/1/properties/properties/oneOf/8/properties/check/allOf/0/oneOf/0/allOf/0'
-                                                        - type: object
-                                                          required:
-                                                            - type
-                                                          properties:
-                                                            type:
-                                                              type: string
-                                                              enum:
-                                                                - threshold
-                                                            thresholds:
-                                                              type: array
-                                                              items:
-                                                                oneOf:
-                                                                  - allOf:
-                                                                      - properties:
-                                                                          level:
-                                                                            $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/1/allOf/1/properties/cells/items/allOf/1/properties/properties/oneOf/8/properties/check/allOf/0/oneOf/0/allOf/1/properties/level'
-                                                                          allValues:
-                                                                            description: 'If true, only alert if all values meet threshold.'
-                                                                            type: boolean
-                                                                      - type: object
-                                                                        required:
-                                                                          - type
-                                                                          - value
-                                                                        properties:
-                                                                          type:
-                                                                            type: string
-                                                                            enum:
-                                                                              - greater
-                                                                          value:
-                                                                            type: number
-                                                                            format: float
-                                                                  - allOf:
-                                                                      - $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/1/allOf/1/properties/cells/items/allOf/1/properties/properties/oneOf/8/properties/check/allOf/0/oneOf/1/allOf/1/properties/thresholds/items/oneOf/0/allOf/0'
-                                                                      - type: object
-                                                                        required:
-                                                                          - type
-                                                                          - value
-                                                                        properties:
-                                                                          type:
-                                                                            type: string
-                                                                            enum:
-                                                                              - lesser
-                                                                          value:
-                                                                            type: number
-                                                                            format: float
-                                                                  - allOf:
-                                                                      - $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/1/allOf/1/properties/cells/items/allOf/1/properties/properties/oneOf/8/properties/check/allOf/0/oneOf/1/allOf/1/properties/thresholds/items/oneOf/0/allOf/0'
-                                                                      - type: object
-                                                                        required:
-                                                                          - type
-                                                                          - min
-                                                                          - max
-                                                                          - within
-                                                                        properties:
-                                                                          type:
-                                                                            type: string
-                                                                            enum:
-                                                                              - range
-                                                                          min:
-                                                                            type: number
-                                                                            format: float
-                                                                          max:
-                                                                            type: number
-                                                                            format: float
-                                                                          within:
-                                                                            type: boolean
-                                                                discriminator:
-                                                                  propertyName: type
-                                                                  mapping:
-                                                                    greater: '#/components/schemas/GreaterThreshold'
-                                                                    lesser: '#/components/schemas/LesserThreshold'
-                                                                    range: '#/components/schemas/RangeThreshold'
-                                                            every:
-                                                              description: Check repetition interval.
-                                                              type: string
-                                                            offset:
-                                                              description: 'Duration to delay after the schedule, before executing check.'
-                                                              type: string
-                                                            tags:
-                                                              description: List of tags to write to each status.
-                                                              type: array
-                                                              items:
-                                                                type: object
-                                                                properties:
-                                                                  key:
-                                                                    type: string
-                                                                  value:
-                                                                    type: string
-                                                            statusMessageTemplate:
-                                                              description: The template used to generate and write a status message.
-                                                              type: string
-                                                    - allOf:
-                                                        - $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/1/allOf/1/properties/cells/items/allOf/1/properties/properties/oneOf/8/properties/check/allOf/0/oneOf/0/allOf/0'
-                                                        - type: object
-                                                          properties:
-                                                            type:
-                                                              type: string
-                                                              enum:
-                                                                - custom
-                                                          required:
-                                                            - type
-                                                  discriminator:
-                                                    propertyName: type
-                                                    mapping:
-                                                      deadman: '#/components/schemas/DeadmanCheck'
-                                                      threshold: '#/components/schemas/ThresholdCheck'
-                                                      custom: '#/components/schemas/CustomCheck'
+                                                              description: The URL to retrieve labels for this check.
+                                                              $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/0/allOf/1/properties/links/properties/org'
+                                                            members:
+                                                              description: The URL to retrieve members for this check.
+                                                              $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/0/allOf/1/properties/links/properties/org'
+                                                            owners:
+                                                              description: The URL to retrieve owners for this check.
+                                                              $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/0/allOf/1/properties/links/properties/org'
+                                                            query:
+                                                              description: The URL to retrieve the Flux script for this check.
+                                                              $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/0/allOf/1/properties/links/properties/org'
+                                                      required:
+                                                        - name
+                                                        - orgID
+                                                        - query
+                                                    - type: object
+                                                      required:
+                                                        - type
+                                                      properties:
+                                                        type:
+                                                          type: string
+                                                          enum:
+                                                            - deadman
+                                                        timeSince:
+                                                          description: String duration before deadman triggers.
+                                                          type: string
+                                                        staleTime:
+                                                          description: String duration for time that a series is considered stale and should not trigger deadman.
+                                                          type: string
+                                                        reportZero:
+                                                          description: 'If only zero values reported since time, trigger an alert'
+                                                          type: boolean
+                                                        level:
+                                                          description: The state to record if check matches a criteria.
+                                                          type: string
+                                                          enum:
+                                                            - UNKNOWN
+                                                            - OK
+                                                            - INFO
+                                                            - CRIT
+                                                            - WARN
+                                                        every:
+                                                          description: Check repetition interval.
+                                                          type: string
+                                                        offset:
+                                                          description: 'Duration to delay after the schedule, before executing check.'
+                                                          type: string
+                                                        tags:
+                                                          description: List of tags to write to each status.
+                                                          type: array
+                                                          items:
+                                                            type: object
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                        statusMessageTemplate:
+                                                          description: The template used to generate and write a status message.
+                                                          type: string
+                                                - allOf:
+                                                    - $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/1/allOf/1/properties/cells/items/allOf/1/properties/properties/oneOf/8/properties/check/oneOf/0/allOf/0'
+                                                    - type: object
+                                                      required:
+                                                        - type
+                                                      properties:
+                                                        type:
+                                                          type: string
+                                                          enum:
+                                                            - threshold
+                                                        thresholds:
+                                                          type: array
+                                                          items:
+                                                            oneOf:
+                                                              - allOf:
+                                                                  - properties:
+                                                                      level:
+                                                                        $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/1/allOf/1/properties/cells/items/allOf/1/properties/properties/oneOf/8/properties/check/oneOf/0/allOf/1/properties/level'
+                                                                      allValues:
+                                                                        description: 'If true, only alert if all values meet threshold.'
+                                                                        type: boolean
+                                                                  - type: object
+                                                                    required:
+                                                                      - type
+                                                                      - value
+                                                                    properties:
+                                                                      type:
+                                                                        type: string
+                                                                        enum:
+                                                                          - greater
+                                                                      value:
+                                                                        type: number
+                                                                        format: float
+                                                              - allOf:
+                                                                  - $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/1/allOf/1/properties/cells/items/allOf/1/properties/properties/oneOf/8/properties/check/oneOf/1/allOf/1/properties/thresholds/items/oneOf/0/allOf/0'
+                                                                  - type: object
+                                                                    required:
+                                                                      - type
+                                                                      - value
+                                                                    properties:
+                                                                      type:
+                                                                        type: string
+                                                                        enum:
+                                                                          - lesser
+                                                                      value:
+                                                                        type: number
+                                                                        format: float
+                                                              - allOf:
+                                                                  - $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/1/allOf/1/properties/cells/items/allOf/1/properties/properties/oneOf/8/properties/check/oneOf/1/allOf/1/properties/thresholds/items/oneOf/0/allOf/0'
+                                                                  - type: object
+                                                                    required:
+                                                                      - type
+                                                                      - min
+                                                                      - max
+                                                                      - within
+                                                                    properties:
+                                                                      type:
+                                                                        type: string
+                                                                        enum:
+                                                                          - range
+                                                                      min:
+                                                                        type: number
+                                                                        format: float
+                                                                      max:
+                                                                        type: number
+                                                                        format: float
+                                                                      within:
+                                                                        type: boolean
+                                                            discriminator:
+                                                              propertyName: type
+                                                              mapping:
+                                                                greater: '#/components/schemas/GreaterThreshold'
+                                                                lesser: '#/components/schemas/LesserThreshold'
+                                                                range: '#/components/schemas/RangeThreshold'
+                                                        every:
+                                                          description: Check repetition interval.
+                                                          type: string
+                                                        offset:
+                                                          description: 'Duration to delay after the schedule, before executing check.'
+                                                          type: string
+                                                        tags:
+                                                          description: List of tags to write to each status.
+                                                          type: array
+                                                          items:
+                                                            type: object
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                        statusMessageTemplate:
+                                                          description: The template used to generate and write a status message.
+                                                          type: string
+                                                - allOf:
+                                                    - $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/1/allOf/1/properties/cells/items/allOf/1/properties/properties/oneOf/8/properties/check/oneOf/0/allOf/0'
+                                                    - type: object
+                                                      properties:
+                                                        type:
+                                                          type: string
+                                                          enum:
+                                                            - custom
+                                                      required:
+                                                        - type
+                                              discriminator:
+                                                propertyName: type
+                                                mapping:
+                                                  deadman: '#/components/schemas/DeadmanCheck'
+                                                  threshold: '#/components/schemas/ThresholdCheck'
+                                                  custom: '#/components/schemas/CustomCheck'
                                             queries:
                                               type: array
                                               items:

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -9895,7 +9895,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/PostCheck"
+                "$ref": "#/components/schemas/CheckDiscriminator"
               }
             }
           }
@@ -9906,7 +9906,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Check"
+                  "$ref": "#/components/schemas/CheckDiscriminator"
                 }
               }
             }
@@ -9951,7 +9951,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Check"
+                  "$ref": "#/components/schemas/CheckDiscriminator"
                 }
               }
             }
@@ -9980,7 +9980,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/Check"
+                "$ref": "#/components/schemas/CheckDiscriminator"
               }
             }
           }
@@ -10005,7 +10005,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Check"
+                  "$ref": "#/components/schemas/CheckDiscriminator"
                 }
               }
             }
@@ -10069,7 +10069,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Check"
+                  "$ref": "#/components/schemas/CheckDiscriminator"
                 }
               }
             }
@@ -10379,7 +10379,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/PostNotificationRule"
+                "$ref": "#/components/schemas/NotificationRuleDiscriminator"
               }
             }
           }
@@ -10390,7 +10390,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NotificationRule"
+                  "$ref": "#/components/schemas/NotificationRuleDiscriminator"
                 }
               }
             }
@@ -10500,7 +10500,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NotificationRule"
+                  "$ref": "#/components/schemas/NotificationRuleDiscriminator"
                 }
               }
             }
@@ -10529,7 +10529,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/NotificationRule"
+                "$ref": "#/components/schemas/NotificationRuleDiscriminator"
               }
             }
           }
@@ -10554,7 +10554,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NotificationRule"
+                  "$ref": "#/components/schemas/NotificationRuleDiscriminator"
                 }
               }
             }
@@ -10618,7 +10618,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NotificationRule"
+                  "$ref": "#/components/schemas/NotificationRuleDiscriminator"
                 }
               }
             }
@@ -10975,7 +10975,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/PostNotificationEndpoint"
+                "$ref": "#/components/schemas/NotificationEndpointDiscriminator"
               }
             }
           }
@@ -10986,7 +10986,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NotificationEndpoint"
+                  "$ref": "#/components/schemas/NotificationEndpointDiscriminator"
                 }
               }
             }
@@ -11031,7 +11031,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NotificationEndpoint"
+                  "$ref": "#/components/schemas/NotificationEndpointDiscriminator"
                 }
               }
             }
@@ -11060,7 +11060,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/NotificationEndpoint"
+                "$ref": "#/components/schemas/NotificationEndpointDiscriminator"
               }
             }
           }
@@ -11085,7 +11085,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NotificationEndpoint"
+                  "$ref": "#/components/schemas/NotificationEndpointDiscriminator"
                 }
               }
             }
@@ -11149,7 +11149,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NotificationEndpoint"
+                  "$ref": "#/components/schemas/NotificationEndpointDiscriminator"
                 }
               }
             }
@@ -18582,7 +18582,7 @@
             "type": "string"
           },
           "check": {
-            "$ref": "#/components/schemas/Check"
+            "$ref": "#/components/schemas/CheckDiscriminator"
           },
           "queries": {
             "type": "array",
@@ -19968,25 +19968,17 @@
         }
       },
       "Check": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/CheckDiscriminator"
-          }
-        ]
+        "$ref": "#/components/schemas/CheckDiscriminator"
       },
       "PostCheck": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/CheckDiscriminator"
-          }
-        ]
+        "$ref": "#/components/schemas/CheckDiscriminator"
       },
       "Checks": {
         "properties": {
           "checks": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Check"
+              "$ref": "#/components/schemas/CheckDiscriminator"
             }
           },
           "links": {
@@ -20426,25 +20418,17 @@
         }
       },
       "NotificationRule": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/NotificationRuleDiscriminator"
-          }
-        ]
+        "$ref": "#/components/schemas/NotificationRuleDiscriminator"
       },
       "PostNotificationRule": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/NotificationRuleDiscriminator"
-          }
-        ]
+        "$ref": "#/components/schemas/NotificationRuleDiscriminator"
       },
       "NotificationRules": {
         "properties": {
           "notificationRules": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/NotificationRule"
+              "$ref": "#/components/schemas/NotificationRuleDiscriminator"
             }
           },
           "links": {
@@ -20843,25 +20827,17 @@
         }
       },
       "NotificationEndpoint": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/NotificationEndpointDiscriminator"
-          }
-        ]
+        "$ref": "#/components/schemas/NotificationEndpointDiscriminator"
       },
       "PostNotificationEndpoint": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/NotificationEndpointDiscriminator"
-          }
-        ]
+        "$ref": "#/components/schemas/NotificationEndpointDiscriminator"
       },
       "NotificationEndpoints": {
         "properties": {
           "notificationEndpoints": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/NotificationEndpoint"
+              "$ref": "#/components/schemas/NotificationEndpointDiscriminator"
             }
           },
           "links": {

--- a/contracts/cloud.json
+++ b/contracts/cloud.json
@@ -15332,37 +15332,43 @@
             },
             "value": {
               "description": "Value provided to fulfill reference",
-              "nullable": true,
               "oneOf": [
                 {
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
-                  "type": "integer"
+                  "type": "integer",
+                  "nullable": true
                 },
                 {
-                  "type": "number"
+                  "type": "number",
+                  "nullable": true
                 },
                 {
-                  "type": "boolean"
+                  "type": "boolean",
+                  "nullable": true
                 }
               ]
             },
             "defaultValue": {
               "description": "Default value that will be provided for the reference when no value is provided",
-              "nullable": true,
               "oneOf": [
                 {
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
-                  "type": "integer"
+                  "type": "integer",
+                  "nullable": true
                 },
                 {
-                  "type": "number"
+                  "type": "number",
+                  "nullable": true
                 },
                 {
-                  "type": "boolean"
+                  "type": "boolean",
+                  "nullable": true
                 }
               ]
             }

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -12775,20 +12775,26 @@ components:
             description: Key identified as environment reference and is the key identified in the template
           value:
             description: Value provided to fulfill reference
-            nullable: true
             oneOf:
               - type: string
+                nullable: true
               - type: integer
+                nullable: true
               - type: number
+                nullable: true
               - type: boolean
+                nullable: true
           defaultValue:
             description: Default value that will be provided for the reference when no value is provided
-            nullable: true
             oneOf:
               - type: string
+                nullable: true
               - type: integer
+                nullable: true
               - type: number
+                nullable: true
               - type: boolean
+                nullable: true
         required:
           - resourceField
           - envRefKey

--- a/contracts/cloud.yml
+++ b/contracts/cloud.yml
@@ -8446,14 +8446,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PostCheck'
+              $ref: '#/components/schemas/CheckDiscriminator'
       responses:
         '201':
           description: Check created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Check'
+                $ref: '#/components/schemas/CheckDiscriminator'
         default:
           description: Unexpected error
           content:
@@ -8480,7 +8480,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Check'
+                $ref: '#/components/schemas/CheckDiscriminator'
         default:
           description: Unexpected error
           content:
@@ -8498,7 +8498,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Check'
+              $ref: '#/components/schemas/CheckDiscriminator'
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -8513,7 +8513,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Check'
+                $ref: '#/components/schemas/CheckDiscriminator'
         '404':
           description: The check was not found
           content:
@@ -8552,7 +8552,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Check'
+                $ref: '#/components/schemas/CheckDiscriminator'
         '404':
           description: The check was not found
           content:
@@ -8740,14 +8740,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PostNotificationRule'
+              $ref: '#/components/schemas/NotificationRuleDiscriminator'
       responses:
         '201':
           description: Notification rule created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationRule'
+                $ref: '#/components/schemas/NotificationRuleDiscriminator'
         default:
           description: Unexpected error
           content:
@@ -8813,7 +8813,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationRule'
+                $ref: '#/components/schemas/NotificationRuleDiscriminator'
         default:
           description: Unexpected error
           content:
@@ -8831,7 +8831,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NotificationRule'
+              $ref: '#/components/schemas/NotificationRuleDiscriminator'
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -8846,7 +8846,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationRule'
+                $ref: '#/components/schemas/NotificationRuleDiscriminator'
         '404':
           description: The notification rule was not found
           content:
@@ -8885,7 +8885,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationRule'
+                $ref: '#/components/schemas/NotificationRuleDiscriminator'
         '404':
           description: The notification rule was not found
           content:
@@ -9100,14 +9100,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PostNotificationEndpoint'
+              $ref: '#/components/schemas/NotificationEndpointDiscriminator'
       responses:
         '201':
           description: Notification endpoint created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationEndpoint'
+                $ref: '#/components/schemas/NotificationEndpointDiscriminator'
         default:
           description: Unexpected error
           content:
@@ -9134,7 +9134,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationEndpoint'
+                $ref: '#/components/schemas/NotificationEndpointDiscriminator'
         default:
           description: Unexpected error
           content:
@@ -9152,7 +9152,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NotificationEndpoint'
+              $ref: '#/components/schemas/NotificationEndpointDiscriminator'
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -9167,7 +9167,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationEndpoint'
+                $ref: '#/components/schemas/NotificationEndpointDiscriminator'
         '404':
           description: The notification endpoint was not found
           content:
@@ -9206,7 +9206,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationEndpoint'
+                $ref: '#/components/schemas/NotificationEndpointDiscriminator'
         '404':
           description: The notification endpoint was not found
           content:
@@ -15055,7 +15055,7 @@ components:
         checkID:
           type: string
         check:
-          $ref: '#/components/schemas/Check'
+          $ref: '#/components/schemas/CheckDiscriminator'
         queries:
           type: array
           items:
@@ -15970,17 +15970,15 @@ components:
           threshold: '#/components/schemas/ThresholdCheck'
           custom: '#/components/schemas/CustomCheck'
     Check:
-      allOf:
-        - $ref: '#/components/schemas/CheckDiscriminator'
+      $ref: '#/components/schemas/CheckDiscriminator'
     PostCheck:
-      allOf:
-        - $ref: '#/components/schemas/CheckDiscriminator'
+      $ref: '#/components/schemas/CheckDiscriminator'
     Checks:
       properties:
         checks:
           type: array
           items:
-            $ref: '#/components/schemas/Check'
+            $ref: '#/components/schemas/CheckDiscriminator'
         links:
           $ref: '#/components/schemas/Links'
     CheckBase:
@@ -16264,17 +16262,15 @@ components:
           http: '#/components/schemas/HTTPNotificationRule'
           telegram: '#/components/schemas/TelegramNotificationRule'
     NotificationRule:
-      allOf:
-        - $ref: '#/components/schemas/NotificationRuleDiscriminator'
+      $ref: '#/components/schemas/NotificationRuleDiscriminator'
     PostNotificationRule:
-      allOf:
-        - $ref: '#/components/schemas/NotificationRuleDiscriminator'
+      $ref: '#/components/schemas/NotificationRuleDiscriminator'
     NotificationRules:
       properties:
         notificationRules:
           type: array
           items:
-            $ref: '#/components/schemas/NotificationRule'
+            $ref: '#/components/schemas/NotificationRuleDiscriminator'
         links:
           $ref: '#/components/schemas/Links'
     NotificationRuleBase:
@@ -16536,17 +16532,15 @@ components:
           http: '#/components/schemas/HTTPNotificationEndpoint'
           telegram: '#/components/schemas/TelegramNotificationEndpoint'
     NotificationEndpoint:
-      allOf:
-        - $ref: '#/components/schemas/NotificationEndpointDiscriminator'
+      $ref: '#/components/schemas/NotificationEndpointDiscriminator'
     PostNotificationEndpoint:
-      allOf:
-        - $ref: '#/components/schemas/NotificationEndpointDiscriminator'
+      $ref: '#/components/schemas/NotificationEndpointDiscriminator'
     NotificationEndpoints:
       properties:
         notificationEndpoints:
           type: array
           items:
-            $ref: '#/components/schemas/NotificationEndpoint'
+            $ref: '#/components/schemas/NotificationEndpointDiscriminator'
         links:
           $ref: '#/components/schemas/Links'
     NotificationEndpointBase:

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -8155,14 +8155,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PostCheck'
+              $ref: '#/components/schemas/CheckDiscriminator'
       responses:
         '201':
           description: Check created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Check'
+                $ref: '#/components/schemas/CheckDiscriminator'
         default:
           description: Unexpected error
           content:
@@ -8189,7 +8189,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Check'
+                $ref: '#/components/schemas/CheckDiscriminator'
         default:
           description: Unexpected error
           content:
@@ -8207,7 +8207,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Check'
+              $ref: '#/components/schemas/CheckDiscriminator'
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -8222,7 +8222,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Check'
+                $ref: '#/components/schemas/CheckDiscriminator'
         '404':
           description: The check was not found
           content:
@@ -8261,7 +8261,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Check'
+                $ref: '#/components/schemas/CheckDiscriminator'
         '404':
           description: The check was not found
           content:
@@ -8449,14 +8449,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PostNotificationRule'
+              $ref: '#/components/schemas/NotificationRuleDiscriminator'
       responses:
         '201':
           description: Notification rule created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationRule'
+                $ref: '#/components/schemas/NotificationRuleDiscriminator'
         default:
           description: Unexpected error
           content:
@@ -8522,7 +8522,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationRule'
+                $ref: '#/components/schemas/NotificationRuleDiscriminator'
         default:
           description: Unexpected error
           content:
@@ -8540,7 +8540,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NotificationRule'
+              $ref: '#/components/schemas/NotificationRuleDiscriminator'
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -8555,7 +8555,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationRule'
+                $ref: '#/components/schemas/NotificationRuleDiscriminator'
         '404':
           description: The notification rule was not found
           content:
@@ -8594,7 +8594,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationRule'
+                $ref: '#/components/schemas/NotificationRuleDiscriminator'
         '404':
           description: The notification rule was not found
           content:
@@ -8809,14 +8809,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PostNotificationEndpoint'
+              $ref: '#/components/schemas/NotificationEndpointDiscriminator'
       responses:
         '201':
           description: Notification endpoint created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationEndpoint'
+                $ref: '#/components/schemas/NotificationEndpointDiscriminator'
         default:
           description: Unexpected error
           content:
@@ -8843,7 +8843,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationEndpoint'
+                $ref: '#/components/schemas/NotificationEndpointDiscriminator'
         default:
           description: Unexpected error
           content:
@@ -8861,7 +8861,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NotificationEndpoint'
+              $ref: '#/components/schemas/NotificationEndpointDiscriminator'
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -8876,7 +8876,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationEndpoint'
+                $ref: '#/components/schemas/NotificationEndpointDiscriminator'
         '404':
           description: The notification endpoint was not found
           content:
@@ -8915,7 +8915,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationEndpoint'
+                $ref: '#/components/schemas/NotificationEndpointDiscriminator'
         '404':
           description: The notification endpoint was not found
           content:
@@ -13220,7 +13220,7 @@ components:
         checkID:
           type: string
         check:
-          $ref: '#/components/schemas/Check'
+          $ref: '#/components/schemas/CheckDiscriminator'
         queries:
           type: array
           items:
@@ -14135,17 +14135,15 @@ components:
           threshold: '#/components/schemas/ThresholdCheck'
           custom: '#/components/schemas/CustomCheck'
     Check:
-      allOf:
-        - $ref: '#/components/schemas/CheckDiscriminator'
+      $ref: '#/components/schemas/CheckDiscriminator'
     PostCheck:
-      allOf:
-        - $ref: '#/components/schemas/CheckDiscriminator'
+      $ref: '#/components/schemas/CheckDiscriminator'
     Checks:
       properties:
         checks:
           type: array
           items:
-            $ref: '#/components/schemas/Check'
+            $ref: '#/components/schemas/CheckDiscriminator'
         links:
           $ref: '#/components/schemas/Links'
     CheckBase:
@@ -14429,17 +14427,15 @@ components:
           http: '#/components/schemas/HTTPNotificationRule'
           telegram: '#/components/schemas/TelegramNotificationRule'
     NotificationRule:
-      allOf:
-        - $ref: '#/components/schemas/NotificationRuleDiscriminator'
+      $ref: '#/components/schemas/NotificationRuleDiscriminator'
     PostNotificationRule:
-      allOf:
-        - $ref: '#/components/schemas/NotificationRuleDiscriminator'
+      $ref: '#/components/schemas/NotificationRuleDiscriminator'
     NotificationRules:
       properties:
         notificationRules:
           type: array
           items:
-            $ref: '#/components/schemas/NotificationRule'
+            $ref: '#/components/schemas/NotificationRuleDiscriminator'
         links:
           $ref: '#/components/schemas/Links'
     NotificationRuleBase:
@@ -14701,17 +14697,15 @@ components:
           http: '#/components/schemas/HTTPNotificationEndpoint'
           telegram: '#/components/schemas/TelegramNotificationEndpoint'
     NotificationEndpoint:
-      allOf:
-        - $ref: '#/components/schemas/NotificationEndpointDiscriminator'
+      $ref: '#/components/schemas/NotificationEndpointDiscriminator'
     PostNotificationEndpoint:
-      allOf:
-        - $ref: '#/components/schemas/NotificationEndpointDiscriminator'
+      $ref: '#/components/schemas/NotificationEndpointDiscriminator'
     NotificationEndpoints:
       properties:
         notificationEndpoints:
           type: array
           items:
-            $ref: '#/components/schemas/NotificationEndpoint'
+            $ref: '#/components/schemas/NotificationEndpointDiscriminator'
         links:
           $ref: '#/components/schemas/Links'
     NotificationEndpointBase:

--- a/contracts/common.yml
+++ b/contracts/common.yml
@@ -10940,20 +10940,26 @@ components:
             description: Key identified as environment reference and is the key identified in the template
           value:
             description: Value provided to fulfill reference
-            nullable: true
             oneOf:
               - type: string
+                nullable: true
               - type: integer
+                nullable: true
               - type: number
+                nullable: true
               - type: boolean
+                nullable: true
           defaultValue:
             description: Default value that will be provided for the reference when no value is provided
-            nullable: true
             oneOf:
               - type: string
+                nullable: true
               - type: integer
+                nullable: true
               - type: number
+                nullable: true
               - type: boolean
+                nullable: true
         required:
           - resourceField
           - envRefKey

--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -3727,240 +3727,239 @@ paths:
                                             checkID:
                                               type: string
                                             check:
-                                              allOf:
-                                                - oneOf:
-                                                    - allOf:
-                                                        - properties:
-                                                            id:
-                                                              readOnly: true
-                                                              type: string
-                                                            name:
-                                                              type: string
-                                                            orgID:
-                                                              description: The ID of the organization that owns this check.
-                                                              type: string
-                                                            taskID:
-                                                              description: The ID of the task associated with this check.
-                                                              type: string
-                                                            ownerID:
-                                                              description: The ID of creator used to create this check.
-                                                              type: string
-                                                              readOnly: true
-                                                            createdAt:
-                                                              type: string
-                                                              format: date-time
-                                                              readOnly: true
-                                                            updatedAt:
-                                                              type: string
-                                                              format: date-time
-                                                              readOnly: true
-                                                            query:
-                                                              $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/1/allOf/1/properties/cells/items/allOf/1/properties/properties/oneOf/0/properties/queries/items'
-                                                            status:
-                                                              $ref: '#/components/schemas/Task/properties/status'
-                                                            description:
-                                                              description: An optional description of the check.
-                                                              type: string
-                                                            latestCompleted:
-                                                              type: string
-                                                              description: 'A timestamp ([RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp)) of the latest scheduled and completed run.'
-                                                              format: date-time
-                                                              readOnly: true
-                                                            lastRunStatus:
-                                                              readOnly: true
-                                                              type: string
-                                                              enum:
-                                                                - failed
-                                                                - success
-                                                                - canceled
-                                                            lastRunError:
-                                                              readOnly: true
-                                                              type: string
+                                              oneOf:
+                                                - allOf:
+                                                    - properties:
+                                                        id:
+                                                          readOnly: true
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        orgID:
+                                                          description: The ID of the organization that owns this check.
+                                                          type: string
+                                                        taskID:
+                                                          description: The ID of the task associated with this check.
+                                                          type: string
+                                                        ownerID:
+                                                          description: The ID of creator used to create this check.
+                                                          type: string
+                                                          readOnly: true
+                                                        createdAt:
+                                                          type: string
+                                                          format: date-time
+                                                          readOnly: true
+                                                        updatedAt:
+                                                          type: string
+                                                          format: date-time
+                                                          readOnly: true
+                                                        query:
+                                                          $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/1/allOf/1/properties/cells/items/allOf/1/properties/properties/oneOf/0/properties/queries/items'
+                                                        status:
+                                                          $ref: '#/components/schemas/Task/properties/status'
+                                                        description:
+                                                          description: An optional description of the check.
+                                                          type: string
+                                                        latestCompleted:
+                                                          type: string
+                                                          description: 'A timestamp ([RFC3339 date/time format]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#rfc3339-timestamp)) of the latest scheduled and completed run.'
+                                                          format: date-time
+                                                          readOnly: true
+                                                        lastRunStatus:
+                                                          readOnly: true
+                                                          type: string
+                                                          enum:
+                                                            - failed
+                                                            - success
+                                                            - canceled
+                                                        lastRunError:
+                                                          readOnly: true
+                                                          type: string
+                                                        labels:
+                                                          $ref: '#/components/schemas/Variable/properties/labels'
+                                                        links:
+                                                          type: object
+                                                          readOnly: true
+                                                          example:
+                                                            self: /api/v2/checks/1
+                                                            labels: /api/v2/checks/1/labels
+                                                            members: /api/v2/checks/1/members
+                                                            owners: /api/v2/checks/1/owners
+                                                            query: /api/v2/checks/1/query
+                                                          properties:
+                                                            self:
+                                                              description: The URL for this check.
+                                                              $ref: '#/components/schemas/ScraperTargetResponse/allOf/1/properties/links/properties/self'
                                                             labels:
-                                                              $ref: '#/components/schemas/Variable/properties/labels'
-                                                            links:
-                                                              type: object
-                                                              readOnly: true
-                                                              example:
-                                                                self: /api/v2/checks/1
-                                                                labels: /api/v2/checks/1/labels
-                                                                members: /api/v2/checks/1/members
-                                                                owners: /api/v2/checks/1/owners
-                                                                query: /api/v2/checks/1/query
-                                                              properties:
-                                                                self:
-                                                                  description: The URL for this check.
-                                                                  $ref: '#/components/schemas/ScraperTargetResponse/allOf/1/properties/links/properties/self'
-                                                                labels:
-                                                                  description: The URL to retrieve labels for this check.
-                                                                  $ref: '#/components/schemas/ScraperTargetResponse/allOf/1/properties/links/properties/self'
-                                                                members:
-                                                                  description: The URL to retrieve members for this check.
-                                                                  $ref: '#/components/schemas/ScraperTargetResponse/allOf/1/properties/links/properties/self'
-                                                                owners:
-                                                                  description: The URL to retrieve owners for this check.
-                                                                  $ref: '#/components/schemas/ScraperTargetResponse/allOf/1/properties/links/properties/self'
-                                                                query:
-                                                                  description: The URL to retrieve the Flux script for this check.
-                                                                  $ref: '#/components/schemas/ScraperTargetResponse/allOf/1/properties/links/properties/self'
-                                                          required:
-                                                            - name
-                                                            - orgID
-                                                            - query
-                                                        - type: object
-                                                          required:
-                                                            - type
-                                                          properties:
-                                                            type:
-                                                              type: string
-                                                              enum:
-                                                                - deadman
-                                                            timeSince:
-                                                              description: String duration before deadman triggers.
-                                                              type: string
-                                                            staleTime:
-                                                              description: String duration for time that a series is considered stale and should not trigger deadman.
-                                                              type: string
-                                                            reportZero:
-                                                              description: 'If only zero values reported since time, trigger an alert'
-                                                              type: boolean
-                                                            level:
-                                                              description: The state to record if check matches a criteria.
-                                                              type: string
-                                                              enum:
-                                                                - UNKNOWN
-                                                                - OK
-                                                                - INFO
-                                                                - CRIT
-                                                                - WARN
-                                                            every:
-                                                              description: Check repetition interval.
-                                                              type: string
-                                                            offset:
-                                                              description: 'Duration to delay after the schedule, before executing check.'
-                                                              type: string
-                                                            tags:
-                                                              description: List of tags to write to each status.
-                                                              type: array
-                                                              items:
-                                                                type: object
-                                                                properties:
-                                                                  key:
-                                                                    type: string
-                                                                  value:
-                                                                    type: string
-                                                            statusMessageTemplate:
-                                                              description: The template used to generate and write a status message.
-                                                              type: string
-                                                    - allOf:
-                                                        - $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/1/allOf/1/properties/cells/items/allOf/1/properties/properties/oneOf/8/properties/check/allOf/0/oneOf/0/allOf/0'
-                                                        - type: object
-                                                          required:
-                                                            - type
-                                                          properties:
-                                                            type:
-                                                              type: string
-                                                              enum:
-                                                                - threshold
-                                                            thresholds:
-                                                              type: array
-                                                              items:
-                                                                oneOf:
-                                                                  - allOf:
-                                                                      - properties:
-                                                                          level:
-                                                                            $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/1/allOf/1/properties/cells/items/allOf/1/properties/properties/oneOf/8/properties/check/allOf/0/oneOf/0/allOf/1/properties/level'
-                                                                          allValues:
-                                                                            description: 'If true, only alert if all values meet threshold.'
-                                                                            type: boolean
-                                                                      - type: object
-                                                                        required:
-                                                                          - type
-                                                                          - value
-                                                                        properties:
-                                                                          type:
-                                                                            type: string
-                                                                            enum:
-                                                                              - greater
-                                                                          value:
-                                                                            type: number
-                                                                            format: float
-                                                                  - allOf:
-                                                                      - $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/1/allOf/1/properties/cells/items/allOf/1/properties/properties/oneOf/8/properties/check/allOf/0/oneOf/1/allOf/1/properties/thresholds/items/oneOf/0/allOf/0'
-                                                                      - type: object
-                                                                        required:
-                                                                          - type
-                                                                          - value
-                                                                        properties:
-                                                                          type:
-                                                                            type: string
-                                                                            enum:
-                                                                              - lesser
-                                                                          value:
-                                                                            type: number
-                                                                            format: float
-                                                                  - allOf:
-                                                                      - $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/1/allOf/1/properties/cells/items/allOf/1/properties/properties/oneOf/8/properties/check/allOf/0/oneOf/1/allOf/1/properties/thresholds/items/oneOf/0/allOf/0'
-                                                                      - type: object
-                                                                        required:
-                                                                          - type
-                                                                          - min
-                                                                          - max
-                                                                          - within
-                                                                        properties:
-                                                                          type:
-                                                                            type: string
-                                                                            enum:
-                                                                              - range
-                                                                          min:
-                                                                            type: number
-                                                                            format: float
-                                                                          max:
-                                                                            type: number
-                                                                            format: float
-                                                                          within:
-                                                                            type: boolean
-                                                                discriminator:
-                                                                  propertyName: type
-                                                                  mapping:
-                                                                    greater: '#/components/schemas/GreaterThreshold'
-                                                                    lesser: '#/components/schemas/LesserThreshold'
-                                                                    range: '#/components/schemas/RangeThreshold'
-                                                            every:
-                                                              description: Check repetition interval.
-                                                              type: string
-                                                            offset:
-                                                              description: 'Duration to delay after the schedule, before executing check.'
-                                                              type: string
-                                                            tags:
-                                                              description: List of tags to write to each status.
-                                                              type: array
-                                                              items:
-                                                                type: object
-                                                                properties:
-                                                                  key:
-                                                                    type: string
-                                                                  value:
-                                                                    type: string
-                                                            statusMessageTemplate:
-                                                              description: The template used to generate and write a status message.
-                                                              type: string
-                                                    - allOf:
-                                                        - $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/1/allOf/1/properties/cells/items/allOf/1/properties/properties/oneOf/8/properties/check/allOf/0/oneOf/0/allOf/0'
-                                                        - type: object
-                                                          properties:
-                                                            type:
-                                                              type: string
-                                                              enum:
-                                                                - custom
-                                                          required:
-                                                            - type
-                                                  discriminator:
-                                                    propertyName: type
-                                                    mapping:
-                                                      deadman: '#/components/schemas/DeadmanCheck'
-                                                      threshold: '#/components/schemas/ThresholdCheck'
-                                                      custom: '#/components/schemas/CustomCheck'
+                                                              description: The URL to retrieve labels for this check.
+                                                              $ref: '#/components/schemas/ScraperTargetResponse/allOf/1/properties/links/properties/self'
+                                                            members:
+                                                              description: The URL to retrieve members for this check.
+                                                              $ref: '#/components/schemas/ScraperTargetResponse/allOf/1/properties/links/properties/self'
+                                                            owners:
+                                                              description: The URL to retrieve owners for this check.
+                                                              $ref: '#/components/schemas/ScraperTargetResponse/allOf/1/properties/links/properties/self'
+                                                            query:
+                                                              description: The URL to retrieve the Flux script for this check.
+                                                              $ref: '#/components/schemas/ScraperTargetResponse/allOf/1/properties/links/properties/self'
+                                                      required:
+                                                        - name
+                                                        - orgID
+                                                        - query
+                                                    - type: object
+                                                      required:
+                                                        - type
+                                                      properties:
+                                                        type:
+                                                          type: string
+                                                          enum:
+                                                            - deadman
+                                                        timeSince:
+                                                          description: String duration before deadman triggers.
+                                                          type: string
+                                                        staleTime:
+                                                          description: String duration for time that a series is considered stale and should not trigger deadman.
+                                                          type: string
+                                                        reportZero:
+                                                          description: 'If only zero values reported since time, trigger an alert'
+                                                          type: boolean
+                                                        level:
+                                                          description: The state to record if check matches a criteria.
+                                                          type: string
+                                                          enum:
+                                                            - UNKNOWN
+                                                            - OK
+                                                            - INFO
+                                                            - CRIT
+                                                            - WARN
+                                                        every:
+                                                          description: Check repetition interval.
+                                                          type: string
+                                                        offset:
+                                                          description: 'Duration to delay after the schedule, before executing check.'
+                                                          type: string
+                                                        tags:
+                                                          description: List of tags to write to each status.
+                                                          type: array
+                                                          items:
+                                                            type: object
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                        statusMessageTemplate:
+                                                          description: The template used to generate and write a status message.
+                                                          type: string
+                                                - allOf:
+                                                    - $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/1/allOf/1/properties/cells/items/allOf/1/properties/properties/oneOf/8/properties/check/oneOf/0/allOf/0'
+                                                    - type: object
+                                                      required:
+                                                        - type
+                                                      properties:
+                                                        type:
+                                                          type: string
+                                                          enum:
+                                                            - threshold
+                                                        thresholds:
+                                                          type: array
+                                                          items:
+                                                            oneOf:
+                                                              - allOf:
+                                                                  - properties:
+                                                                      level:
+                                                                        $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/1/allOf/1/properties/cells/items/allOf/1/properties/properties/oneOf/8/properties/check/oneOf/0/allOf/1/properties/level'
+                                                                      allValues:
+                                                                        description: 'If true, only alert if all values meet threshold.'
+                                                                        type: boolean
+                                                                  - type: object
+                                                                    required:
+                                                                      - type
+                                                                      - value
+                                                                    properties:
+                                                                      type:
+                                                                        type: string
+                                                                        enum:
+                                                                          - greater
+                                                                      value:
+                                                                        type: number
+                                                                        format: float
+                                                              - allOf:
+                                                                  - $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/1/allOf/1/properties/cells/items/allOf/1/properties/properties/oneOf/8/properties/check/oneOf/1/allOf/1/properties/thresholds/items/oneOf/0/allOf/0'
+                                                                  - type: object
+                                                                    required:
+                                                                      - type
+                                                                      - value
+                                                                    properties:
+                                                                      type:
+                                                                        type: string
+                                                                        enum:
+                                                                          - lesser
+                                                                      value:
+                                                                        type: number
+                                                                        format: float
+                                                              - allOf:
+                                                                  - $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/1/allOf/1/properties/cells/items/allOf/1/properties/properties/oneOf/8/properties/check/oneOf/1/allOf/1/properties/thresholds/items/oneOf/0/allOf/0'
+                                                                  - type: object
+                                                                    required:
+                                                                      - type
+                                                                      - min
+                                                                      - max
+                                                                      - within
+                                                                    properties:
+                                                                      type:
+                                                                        type: string
+                                                                        enum:
+                                                                          - range
+                                                                      min:
+                                                                        type: number
+                                                                        format: float
+                                                                      max:
+                                                                        type: number
+                                                                        format: float
+                                                                      within:
+                                                                        type: boolean
+                                                            discriminator:
+                                                              propertyName: type
+                                                              mapping:
+                                                                greater: '#/components/schemas/GreaterThreshold'
+                                                                lesser: '#/components/schemas/LesserThreshold'
+                                                                range: '#/components/schemas/RangeThreshold'
+                                                        every:
+                                                          description: Check repetition interval.
+                                                          type: string
+                                                        offset:
+                                                          description: 'Duration to delay after the schedule, before executing check.'
+                                                          type: string
+                                                        tags:
+                                                          description: List of tags to write to each status.
+                                                          type: array
+                                                          items:
+                                                            type: object
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                        statusMessageTemplate:
+                                                          description: The template used to generate and write a status message.
+                                                          type: string
+                                                - allOf:
+                                                    - $ref: '#/paths/~1dashboards/post/responses/201/content/application~1json/schema/oneOf/1/allOf/1/properties/cells/items/allOf/1/properties/properties/oneOf/8/properties/check/oneOf/0/allOf/0'
+                                                    - type: object
+                                                      properties:
+                                                        type:
+                                                          type: string
+                                                          enum:
+                                                            - custom
+                                                      required:
+                                                        - type
+                                              discriminator:
+                                                propertyName: type
+                                                mapping:
+                                                  deadman: '#/components/schemas/DeadmanCheck'
+                                                  threshold: '#/components/schemas/ThresholdCheck'
+                                                  custom: '#/components/schemas/CustomCheck'
                                             queries:
                                               type: array
                                               items:

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -9896,7 +9896,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/PostCheck"
+                "$ref": "#/components/schemas/CheckDiscriminator"
               }
             }
           }
@@ -9907,7 +9907,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Check"
+                  "$ref": "#/components/schemas/CheckDiscriminator"
                 }
               }
             }
@@ -9952,7 +9952,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Check"
+                  "$ref": "#/components/schemas/CheckDiscriminator"
                 }
               }
             }
@@ -9981,7 +9981,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/Check"
+                "$ref": "#/components/schemas/CheckDiscriminator"
               }
             }
           }
@@ -10006,7 +10006,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Check"
+                  "$ref": "#/components/schemas/CheckDiscriminator"
                 }
               }
             }
@@ -10070,7 +10070,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Check"
+                  "$ref": "#/components/schemas/CheckDiscriminator"
                 }
               }
             }
@@ -10380,7 +10380,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/PostNotificationRule"
+                "$ref": "#/components/schemas/NotificationRuleDiscriminator"
               }
             }
           }
@@ -10391,7 +10391,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NotificationRule"
+                  "$ref": "#/components/schemas/NotificationRuleDiscriminator"
                 }
               }
             }
@@ -10501,7 +10501,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NotificationRule"
+                  "$ref": "#/components/schemas/NotificationRuleDiscriminator"
                 }
               }
             }
@@ -10530,7 +10530,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/NotificationRule"
+                "$ref": "#/components/schemas/NotificationRuleDiscriminator"
               }
             }
           }
@@ -10555,7 +10555,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NotificationRule"
+                  "$ref": "#/components/schemas/NotificationRuleDiscriminator"
                 }
               }
             }
@@ -10619,7 +10619,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NotificationRule"
+                  "$ref": "#/components/schemas/NotificationRuleDiscriminator"
                 }
               }
             }
@@ -10976,7 +10976,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/PostNotificationEndpoint"
+                "$ref": "#/components/schemas/NotificationEndpointDiscriminator"
               }
             }
           }
@@ -10987,7 +10987,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NotificationEndpoint"
+                  "$ref": "#/components/schemas/NotificationEndpointDiscriminator"
                 }
               }
             }
@@ -11032,7 +11032,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NotificationEndpoint"
+                  "$ref": "#/components/schemas/NotificationEndpointDiscriminator"
                 }
               }
             }
@@ -11061,7 +11061,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/NotificationEndpoint"
+                "$ref": "#/components/schemas/NotificationEndpointDiscriminator"
               }
             }
           }
@@ -11086,7 +11086,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NotificationEndpoint"
+                  "$ref": "#/components/schemas/NotificationEndpointDiscriminator"
                 }
               }
             }
@@ -11150,7 +11150,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NotificationEndpoint"
+                  "$ref": "#/components/schemas/NotificationEndpointDiscriminator"
                 }
               }
             }
@@ -20963,7 +20963,7 @@
             "type": "string"
           },
           "check": {
-            "$ref": "#/components/schemas/Check"
+            "$ref": "#/components/schemas/CheckDiscriminator"
           },
           "queries": {
             "type": "array",
@@ -22349,25 +22349,17 @@
         }
       },
       "Check": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/CheckDiscriminator"
-          }
-        ]
+        "$ref": "#/components/schemas/CheckDiscriminator"
       },
       "PostCheck": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/CheckDiscriminator"
-          }
-        ]
+        "$ref": "#/components/schemas/CheckDiscriminator"
       },
       "Checks": {
         "properties": {
           "checks": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Check"
+              "$ref": "#/components/schemas/CheckDiscriminator"
             }
           },
           "links": {
@@ -22807,25 +22799,17 @@
         }
       },
       "NotificationRule": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/NotificationRuleDiscriminator"
-          }
-        ]
+        "$ref": "#/components/schemas/NotificationRuleDiscriminator"
       },
       "PostNotificationRule": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/NotificationRuleDiscriminator"
-          }
-        ]
+        "$ref": "#/components/schemas/NotificationRuleDiscriminator"
       },
       "NotificationRules": {
         "properties": {
           "notificationRules": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/NotificationRule"
+              "$ref": "#/components/schemas/NotificationRuleDiscriminator"
             }
           },
           "links": {
@@ -23224,25 +23208,17 @@
         }
       },
       "NotificationEndpoint": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/NotificationEndpointDiscriminator"
-          }
-        ]
+        "$ref": "#/components/schemas/NotificationEndpointDiscriminator"
       },
       "PostNotificationEndpoint": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/NotificationEndpointDiscriminator"
-          }
-        ]
+        "$ref": "#/components/schemas/NotificationEndpointDiscriminator"
       },
       "NotificationEndpoints": {
         "properties": {
           "notificationEndpoints": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/NotificationEndpoint"
+              "$ref": "#/components/schemas/NotificationEndpointDiscriminator"
             }
           },
           "links": {

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -17713,37 +17713,43 @@
             },
             "value": {
               "description": "Value provided to fulfill reference",
-              "nullable": true,
               "oneOf": [
                 {
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
-                  "type": "integer"
+                  "type": "integer",
+                  "nullable": true
                 },
                 {
-                  "type": "number"
+                  "type": "number",
+                  "nullable": true
                 },
                 {
-                  "type": "boolean"
+                  "type": "boolean",
+                  "nullable": true
                 }
               ]
             },
             "defaultValue": {
               "description": "Default value that will be provided for the reference when no value is provided",
-              "nullable": true,
               "oneOf": [
                 {
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
-                  "type": "integer"
+                  "type": "integer",
+                  "nullable": true
                 },
                 {
-                  "type": "number"
+                  "type": "number",
+                  "nullable": true
                 },
                 {
-                  "type": "boolean"
+                  "type": "boolean",
+                  "nullable": true
                 }
               ]
             }

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -14356,20 +14356,26 @@ components:
             description: Key identified as environment reference and is the key identified in the template
           value:
             description: Value provided to fulfill reference
-            nullable: true
             oneOf:
               - type: string
+                nullable: true
               - type: integer
+                nullable: true
               - type: number
+                nullable: true
               - type: boolean
+                nullable: true
           defaultValue:
             description: Default value that will be provided for the reference when no value is provided
-            nullable: true
             oneOf:
               - type: string
+                nullable: true
               - type: integer
+                nullable: true
               - type: number
+                nullable: true
               - type: boolean
+                nullable: true
         required:
           - resourceField
           - envRefKey

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -8434,14 +8434,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PostCheck'
+              $ref: '#/components/schemas/CheckDiscriminator'
       responses:
         '201':
           description: Check created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Check'
+                $ref: '#/components/schemas/CheckDiscriminator'
         default:
           description: Unexpected error
           content:
@@ -8468,7 +8468,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Check'
+                $ref: '#/components/schemas/CheckDiscriminator'
         default:
           description: Unexpected error
           content:
@@ -8486,7 +8486,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Check'
+              $ref: '#/components/schemas/CheckDiscriminator'
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -8501,7 +8501,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Check'
+                $ref: '#/components/schemas/CheckDiscriminator'
         '404':
           description: The check was not found
           content:
@@ -8540,7 +8540,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Check'
+                $ref: '#/components/schemas/CheckDiscriminator'
         '404':
           description: The check was not found
           content:
@@ -8728,14 +8728,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PostNotificationRule'
+              $ref: '#/components/schemas/NotificationRuleDiscriminator'
       responses:
         '201':
           description: Notification rule created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationRule'
+                $ref: '#/components/schemas/NotificationRuleDiscriminator'
         default:
           description: Unexpected error
           content:
@@ -8801,7 +8801,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationRule'
+                $ref: '#/components/schemas/NotificationRuleDiscriminator'
         default:
           description: Unexpected error
           content:
@@ -8819,7 +8819,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NotificationRule'
+              $ref: '#/components/schemas/NotificationRuleDiscriminator'
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -8834,7 +8834,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationRule'
+                $ref: '#/components/schemas/NotificationRuleDiscriminator'
         '404':
           description: The notification rule was not found
           content:
@@ -8873,7 +8873,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationRule'
+                $ref: '#/components/schemas/NotificationRuleDiscriminator'
         '404':
           description: The notification rule was not found
           content:
@@ -9088,14 +9088,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PostNotificationEndpoint'
+              $ref: '#/components/schemas/NotificationEndpointDiscriminator'
       responses:
         '201':
           description: Notification endpoint created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationEndpoint'
+                $ref: '#/components/schemas/NotificationEndpointDiscriminator'
         default:
           description: Unexpected error
           content:
@@ -9122,7 +9122,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationEndpoint'
+                $ref: '#/components/schemas/NotificationEndpointDiscriminator'
         default:
           description: Unexpected error
           content:
@@ -9140,7 +9140,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NotificationEndpoint'
+              $ref: '#/components/schemas/NotificationEndpointDiscriminator'
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -9155,7 +9155,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationEndpoint'
+                $ref: '#/components/schemas/NotificationEndpointDiscriminator'
         '404':
           description: The notification endpoint was not found
           content:
@@ -9194,7 +9194,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationEndpoint'
+                $ref: '#/components/schemas/NotificationEndpointDiscriminator'
         '404':
           description: The notification endpoint was not found
           content:
@@ -16636,7 +16636,7 @@ components:
         checkID:
           type: string
         check:
-          $ref: '#/components/schemas/Check'
+          $ref: '#/components/schemas/CheckDiscriminator'
         queries:
           type: array
           items:
@@ -17551,17 +17551,15 @@ components:
           threshold: '#/components/schemas/ThresholdCheck'
           custom: '#/components/schemas/CustomCheck'
     Check:
-      allOf:
-        - $ref: '#/components/schemas/CheckDiscriminator'
+      $ref: '#/components/schemas/CheckDiscriminator'
     PostCheck:
-      allOf:
-        - $ref: '#/components/schemas/CheckDiscriminator'
+      $ref: '#/components/schemas/CheckDiscriminator'
     Checks:
       properties:
         checks:
           type: array
           items:
-            $ref: '#/components/schemas/Check'
+            $ref: '#/components/schemas/CheckDiscriminator'
         links:
           $ref: '#/components/schemas/Links'
     CheckBase:
@@ -17845,17 +17843,15 @@ components:
           http: '#/components/schemas/HTTPNotificationRule'
           telegram: '#/components/schemas/TelegramNotificationRule'
     NotificationRule:
-      allOf:
-        - $ref: '#/components/schemas/NotificationRuleDiscriminator'
+      $ref: '#/components/schemas/NotificationRuleDiscriminator'
     PostNotificationRule:
-      allOf:
-        - $ref: '#/components/schemas/NotificationRuleDiscriminator'
+      $ref: '#/components/schemas/NotificationRuleDiscriminator'
     NotificationRules:
       properties:
         notificationRules:
           type: array
           items:
-            $ref: '#/components/schemas/NotificationRule'
+            $ref: '#/components/schemas/NotificationRuleDiscriminator'
         links:
           $ref: '#/components/schemas/Links'
     NotificationRuleBase:
@@ -18117,17 +18113,15 @@ components:
           http: '#/components/schemas/HTTPNotificationEndpoint'
           telegram: '#/components/schemas/TelegramNotificationEndpoint'
     NotificationEndpoint:
-      allOf:
-        - $ref: '#/components/schemas/NotificationEndpointDiscriminator'
+      $ref: '#/components/schemas/NotificationEndpointDiscriminator'
     PostNotificationEndpoint:
-      allOf:
-        - $ref: '#/components/schemas/NotificationEndpointDiscriminator'
+      $ref: '#/components/schemas/NotificationEndpointDiscriminator'
     NotificationEndpoints:
       properties:
         notificationEndpoints:
           type: array
           items:
-            $ref: '#/components/schemas/NotificationEndpoint'
+            $ref: '#/components/schemas/NotificationEndpointDiscriminator'
         links:
           $ref: '#/components/schemas/Links'
     NotificationEndpointBase:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -788,8 +788,7 @@ components:
         $ref: '#/components/schemas/CellWithViewProperties'
       type: array
     Check:
-      allOf:
-      - $ref: '#/components/schemas/CheckDiscriminator'
+      $ref: '#/components/schemas/CheckDiscriminator'
     CheckBase:
       properties:
         createdAt:
@@ -906,7 +905,7 @@ components:
         adaptiveZoomHide:
           type: boolean
         check:
-          $ref: '#/components/schemas/Check'
+          $ref: '#/components/schemas/CheckDiscriminator'
         checkID:
           type: string
         colors:
@@ -946,7 +945,7 @@ components:
       properties:
         checks:
           items:
-            $ref: '#/components/schemas/Check'
+            $ref: '#/components/schemas/CheckDiscriminator'
           type: array
         links:
           $ref: '#/components/schemas/Links'
@@ -3089,8 +3088,7 @@ components:
       description: Type of AST node
       type: string
     NotificationEndpoint:
-      allOf:
-      - $ref: '#/components/schemas/NotificationEndpointDiscriminator'
+      $ref: '#/components/schemas/NotificationEndpointDiscriminator'
     NotificationEndpointBase:
       properties:
         createdAt:
@@ -3186,11 +3184,10 @@ components:
           $ref: '#/components/schemas/Links'
         notificationEndpoints:
           items:
-            $ref: '#/components/schemas/NotificationEndpoint'
+            $ref: '#/components/schemas/NotificationEndpointDiscriminator'
           type: array
     NotificationRule:
-      allOf:
-      - $ref: '#/components/schemas/NotificationRuleDiscriminator'
+      $ref: '#/components/schemas/NotificationRuleDiscriminator'
     NotificationRuleBase:
       properties:
         createdAt:
@@ -3337,7 +3334,7 @@ components:
           $ref: '#/components/schemas/Links'
         notificationRules:
           items:
-            $ref: '#/components/schemas/NotificationRule'
+            $ref: '#/components/schemas/NotificationRuleDiscriminator'
           type: array
     ObjectExpression:
       description: Allows the declaration of an anonymous object within a declaration
@@ -3755,14 +3752,11 @@ components:
       - orgID
       - name
     PostCheck:
-      allOf:
-      - $ref: '#/components/schemas/CheckDiscriminator'
+      $ref: '#/components/schemas/CheckDiscriminator'
     PostNotificationEndpoint:
-      allOf:
-      - $ref: '#/components/schemas/NotificationEndpointDiscriminator'
+      $ref: '#/components/schemas/NotificationEndpointDiscriminator'
     PostNotificationRule:
-      allOf:
-      - $ref: '#/components/schemas/NotificationRuleDiscriminator'
+      $ref: '#/components/schemas/NotificationRuleDiscriminator'
     PostOrganizationRequest:
       properties:
         description:
@@ -8821,7 +8815,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PostCheck'
+              $ref: '#/components/schemas/CheckDiscriminator'
         description: Check to create
         required: true
       responses:
@@ -8829,7 +8823,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Check'
+                $ref: '#/components/schemas/CheckDiscriminator'
           description: Check created
         default:
           content:
@@ -8884,7 +8878,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Check'
+                $ref: '#/components/schemas/CheckDiscriminator'
           description: The check requested
         default:
           content:
@@ -8917,7 +8911,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Check'
+                $ref: '#/components/schemas/CheckDiscriminator'
           description: An updated check
         "404":
           content:
@@ -8948,7 +8942,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Check'
+              $ref: '#/components/schemas/CheckDiscriminator'
         description: Check update to apply
         required: true
       responses:
@@ -8956,7 +8950,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Check'
+                $ref: '#/components/schemas/CheckDiscriminator'
           description: An updated check
         "404":
           content:
@@ -10818,7 +10812,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PostNotificationEndpoint'
+              $ref: '#/components/schemas/NotificationEndpointDiscriminator'
         description: Notification endpoint to create
         required: true
       responses:
@@ -10826,7 +10820,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationEndpoint'
+                $ref: '#/components/schemas/NotificationEndpointDiscriminator'
           description: Notification endpoint created
         default:
           content:
@@ -10881,7 +10875,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationEndpoint'
+                $ref: '#/components/schemas/NotificationEndpointDiscriminator'
           description: The notification endpoint requested
         default:
           content:
@@ -10914,7 +10908,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationEndpoint'
+                $ref: '#/components/schemas/NotificationEndpointDiscriminator'
           description: An updated notification endpoint
         "404":
           content:
@@ -10945,7 +10939,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NotificationEndpoint'
+              $ref: '#/components/schemas/NotificationEndpointDiscriminator'
         description: A new notification endpoint to replace the existing endpoint
           with
         required: true
@@ -10954,7 +10948,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationEndpoint'
+                $ref: '#/components/schemas/NotificationEndpointDiscriminator'
           description: An updated notification endpoint
         "404":
           content:
@@ -11115,7 +11109,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PostNotificationRule'
+              $ref: '#/components/schemas/NotificationRuleDiscriminator'
         description: Notification rule to create
         required: true
       responses:
@@ -11123,7 +11117,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationRule'
+                $ref: '#/components/schemas/NotificationRuleDiscriminator'
           description: Notification rule created
         default:
           content:
@@ -11178,7 +11172,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationRule'
+                $ref: '#/components/schemas/NotificationRuleDiscriminator'
           description: The notification rule requested
         default:
           content:
@@ -11211,7 +11205,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationRule'
+                $ref: '#/components/schemas/NotificationRuleDiscriminator'
           description: An updated notification rule
         "404":
           content:
@@ -11242,7 +11236,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NotificationRule'
+              $ref: '#/components/schemas/NotificationRuleDiscriminator'
         description: Notification rule update to apply
         required: true
       responses:
@@ -11250,7 +11244,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationRule'
+                $ref: '#/components/schemas/NotificationRuleDiscriminator'
           description: An updated notification rule
         "404":
           content:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -5484,12 +5484,15 @@ components:
           defaultValue:
             description: Default value that will be provided for the reference when
               no value is provided
-            nullable: true
             oneOf:
-            - type: string
-            - type: integer
-            - type: number
-            - type: boolean
+            - nullable: true
+              type: string
+            - nullable: true
+              type: integer
+            - nullable: true
+              type: number
+            - nullable: true
+              type: boolean
           envRefKey:
             description: Key identified as environment reference and is the key identified
               in the template
@@ -5499,12 +5502,15 @@ components:
             type: string
           value:
             description: Value provided to fulfill reference
-            nullable: true
             oneOf:
-            - type: string
-            - type: integer
-            - type: number
-            - type: boolean
+            - nullable: true
+              type: string
+            - nullable: true
+              type: integer
+            - nullable: true
+              type: number
+            - nullable: true
+              type: boolean
         required:
         - resourceField
         - envRefKey

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -5539,12 +5539,15 @@ components:
           defaultValue:
             description: Default value that will be provided for the reference when
               no value is provided
-            nullable: true
             oneOf:
-            - type: string
-            - type: integer
-            - type: number
-            - type: boolean
+            - nullable: true
+              type: string
+            - nullable: true
+              type: integer
+            - nullable: true
+              type: number
+            - nullable: true
+              type: boolean
           envRefKey:
             description: Key identified as environment reference and is the key identified
               in the template
@@ -5554,12 +5557,15 @@ components:
             type: string
           value:
             description: Value provided to fulfill reference
-            nullable: true
             oneOf:
-            - type: string
-            - type: integer
-            - type: number
-            - type: boolean
+            - nullable: true
+              type: string
+            - nullable: true
+              type: integer
+            - nullable: true
+              type: number
+            - nullable: true
+              type: boolean
         required:
         - resourceField
         - envRefKey

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -817,8 +817,7 @@ components:
         $ref: '#/components/schemas/CellWithViewProperties'
       type: array
     Check:
-      allOf:
-      - $ref: '#/components/schemas/CheckDiscriminator'
+      $ref: '#/components/schemas/CheckDiscriminator'
     CheckBase:
       properties:
         createdAt:
@@ -935,7 +934,7 @@ components:
         adaptiveZoomHide:
           type: boolean
         check:
-          $ref: '#/components/schemas/Check'
+          $ref: '#/components/schemas/CheckDiscriminator'
         checkID:
           type: string
         colors:
@@ -975,7 +974,7 @@ components:
       properties:
         checks:
           items:
-            $ref: '#/components/schemas/Check'
+            $ref: '#/components/schemas/CheckDiscriminator'
           type: array
         links:
           $ref: '#/components/schemas/Links'
@@ -2853,8 +2852,7 @@ components:
       description: Type of AST node
       type: string
     NotificationEndpoint:
-      allOf:
-      - $ref: '#/components/schemas/NotificationEndpointDiscriminator'
+      $ref: '#/components/schemas/NotificationEndpointDiscriminator'
     NotificationEndpointBase:
       properties:
         createdAt:
@@ -2950,11 +2948,10 @@ components:
           $ref: '#/components/schemas/Links'
         notificationEndpoints:
           items:
-            $ref: '#/components/schemas/NotificationEndpoint'
+            $ref: '#/components/schemas/NotificationEndpointDiscriminator'
           type: array
     NotificationRule:
-      allOf:
-      - $ref: '#/components/schemas/NotificationRuleDiscriminator'
+      $ref: '#/components/schemas/NotificationRuleDiscriminator'
     NotificationRuleBase:
       properties:
         createdAt:
@@ -3101,7 +3098,7 @@ components:
           $ref: '#/components/schemas/Links'
         notificationRules:
           items:
-            $ref: '#/components/schemas/NotificationRule'
+            $ref: '#/components/schemas/NotificationRuleDiscriminator'
           type: array
     ObjectExpression:
       description: Allows the declaration of an anonymous object within a declaration
@@ -3506,14 +3503,11 @@ components:
       - orgID
       - name
     PostCheck:
-      allOf:
-      - $ref: '#/components/schemas/CheckDiscriminator'
+      $ref: '#/components/schemas/CheckDiscriminator'
     PostNotificationEndpoint:
-      allOf:
-      - $ref: '#/components/schemas/NotificationEndpointDiscriminator'
+      $ref: '#/components/schemas/NotificationEndpointDiscriminator'
     PostNotificationRule:
-      allOf:
-      - $ref: '#/components/schemas/NotificationRuleDiscriminator'
+      $ref: '#/components/schemas/NotificationRuleDiscriminator'
     PostOrganizationRequest:
       properties:
         description:
@@ -8611,7 +8605,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PostCheck'
+              $ref: '#/components/schemas/CheckDiscriminator'
         description: Check to create
         required: true
       responses:
@@ -8619,7 +8613,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Check'
+                $ref: '#/components/schemas/CheckDiscriminator'
           description: Check created
         default:
           content:
@@ -8674,7 +8668,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Check'
+                $ref: '#/components/schemas/CheckDiscriminator'
           description: The check requested
         default:
           content:
@@ -8707,7 +8701,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Check'
+                $ref: '#/components/schemas/CheckDiscriminator'
           description: An updated check
         "404":
           content:
@@ -8738,7 +8732,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Check'
+              $ref: '#/components/schemas/CheckDiscriminator'
         description: Check update to apply
         required: true
       responses:
@@ -8746,7 +8740,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Check'
+                $ref: '#/components/schemas/CheckDiscriminator'
           description: An updated check
         "404":
           content:
@@ -11454,7 +11448,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PostNotificationEndpoint'
+              $ref: '#/components/schemas/NotificationEndpointDiscriminator'
         description: Notification endpoint to create
         required: true
       responses:
@@ -11462,7 +11456,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationEndpoint'
+                $ref: '#/components/schemas/NotificationEndpointDiscriminator'
           description: Notification endpoint created
         default:
           content:
@@ -11517,7 +11511,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationEndpoint'
+                $ref: '#/components/schemas/NotificationEndpointDiscriminator'
           description: The notification endpoint requested
         default:
           content:
@@ -11550,7 +11544,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationEndpoint'
+                $ref: '#/components/schemas/NotificationEndpointDiscriminator'
           description: An updated notification endpoint
         "404":
           content:
@@ -11581,7 +11575,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NotificationEndpoint'
+              $ref: '#/components/schemas/NotificationEndpointDiscriminator'
         description: A new notification endpoint to replace the existing endpoint
           with
         required: true
@@ -11590,7 +11584,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationEndpoint'
+                $ref: '#/components/schemas/NotificationEndpointDiscriminator'
           description: An updated notification endpoint
         "404":
           content:
@@ -11751,7 +11745,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PostNotificationRule'
+              $ref: '#/components/schemas/NotificationRuleDiscriminator'
         description: Notification rule to create
         required: true
       responses:
@@ -11759,7 +11753,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationRule'
+                $ref: '#/components/schemas/NotificationRuleDiscriminator'
           description: Notification rule created
         default:
           content:
@@ -11814,7 +11808,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationRule'
+                $ref: '#/components/schemas/NotificationRuleDiscriminator'
           description: The notification rule requested
         default:
           content:
@@ -11847,7 +11841,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationRule'
+                $ref: '#/components/schemas/NotificationRuleDiscriminator'
           description: An updated notification rule
         "404":
           content:
@@ -11878,7 +11872,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NotificationRule'
+              $ref: '#/components/schemas/NotificationRuleDiscriminator'
         description: Notification rule update to apply
         required: true
       responses:
@@ -11886,7 +11880,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationRule'
+                $ref: '#/components/schemas/NotificationRuleDiscriminator'
           description: An updated notification rule
         "404":
           content:

--- a/src/common/schemas/Check.yml
+++ b/src/common/schemas/Check.yml
@@ -1,2 +1,1 @@
-  allOf:
-    - $ref: "./CheckDiscriminator.yml"
+  $ref: "./CheckDiscriminator.yml"

--- a/src/common/schemas/NotificationEndpoint.yml
+++ b/src/common/schemas/NotificationEndpoint.yml
@@ -1,2 +1,1 @@
-  allOf:
-    - $ref: "./NotificationEndpointDiscriminator.yml"
+  $ref: "./NotificationEndpointDiscriminator.yml"

--- a/src/common/schemas/NotificationRule.yml
+++ b/src/common/schemas/NotificationRule.yml
@@ -1,2 +1,1 @@
-  allOf:
-    - $ref: "./NotificationRuleDiscriminator.yml"
+  $ref: "./NotificationRuleDiscriminator.yml"

--- a/src/common/schemas/PostCheck.yml
+++ b/src/common/schemas/PostCheck.yml
@@ -1,2 +1,1 @@
-  allOf:
-    - $ref: "./CheckDiscriminator.yml"
+  $ref: "./CheckDiscriminator.yml"

--- a/src/common/schemas/PostNotificationEndpoint.yml
+++ b/src/common/schemas/PostNotificationEndpoint.yml
@@ -1,2 +1,1 @@
-  allOf:
-    - $ref: "./NotificationEndpointDiscriminator.yml"
+  $ref: "./NotificationEndpointDiscriminator.yml"

--- a/src/common/schemas/PostNotificationRule.yml
+++ b/src/common/schemas/PostNotificationRule.yml
@@ -1,2 +1,1 @@
-  allOf:
-    - $ref: "./NotificationRuleDiscriminator.yml"
+  $ref: "./NotificationRuleDiscriminator.yml"

--- a/src/common/schemas/TemplateEnvReferences.yml
+++ b/src/common/schemas/TemplateEnvReferences.yml
@@ -10,18 +10,24 @@
         description: Key identified as environment reference and is the key identified in the template
       value:
         description: Value provided to fulfill reference
-        nullable: true
         oneOf:
           - type: string
+            nullable: true
           - type: integer
+            nullable: true
           - type: number
+            nullable: true
           - type: boolean
+            nullable: true
       defaultValue:
         description: Default value that will be provided for the reference when no value is provided
-        nullable: true
         oneOf:
           - type: string
+            nullable: true
           - type: integer
+            nullable: true
           - type: number
+            nullable: true
           - type: boolean
+            nullable: true
     required: [resourceField, envRefKey]


### PR DESCRIPTION
- Removes unnecessary allOf.
- Redundant allOf in discriminators causes some processors (Redoc and Redocly CLI) to
create unintended implicit schema mappings.
- For example, for PostCheck In Redoc, this generates the following possible request objects:
  - deadman
  - threshold
  - custom
  and, the unintended implicit objects:
  - Check
  - PostCheck

Redoc before (current prod):
![prod-cloud-postcheck](https://user-images.githubusercontent.com/212227/213562319-0a2fbefc-4443-45fa-87ee-3ff3cbc1f4aa.png)

Redoc after:
![local-cloud-postcheck](https://user-images.githubusercontent.com/212227/213562428-cbcf07c9-a868-412e-ad0c-5d4d411f1224.png)

This error from `@redocly/cli split` alerted me and helped me pinpoint the problem:

```sh
/usr/local/lib/node_modules/@redocly/cli/lib/commands/split/index.js:167
    const discriminatorPropSchema = obj.properties[obj.discriminator.propertyName];
                                                  ^

TypeError: Cannot read properties of undefined (reading 'type')
    at implicitlyReferenceDiscriminator (/usr/local/lib/node_modules/@redocly/cli/lib/commands/split/index.js:167:51)
```
