### PR TITLE
feat: update timerange options for usage

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -1916,7 +1916,35 @@ components:
       description: The timerange options for usage information
       enum:
         - 24h
+        - 1d
+        - 2d
+        - 3d
+        - 4d
+        - 5d
+        - 6d
         - 7d
+        - 8d
+        - 9d
+        - 10d
+        - 11d
+        - 12d
+        - 13d
+        - 14d
+        - 15d
+        - 16d
+        - 17d
+        - 18d
+        - 19d
+        - 20d
+        - 21d
+        - 22d
+        - 23d
+        - 24d
+        - 25d
+        - 26d
+        - 27d
+        - 28d
+        - 29d
         - 30d
       default: 24h
     VectorName:

--- a/src/unity/schemas/TimeRange.yml
+++ b/src/unity/schemas/TimeRange.yml
@@ -2,6 +2,34 @@ type: string
 description: The timerange options for usage information
 enum:
   - 24h
+  - 1d
+  - 2d
+  - 3d
+  - 4d
+  - 5d
+  - 6d
   - 7d
+  - 8d
+  - 9d
+  - 10d
+  - 11d
+  - 12d
+  - 13d
+  - 14d
+  - 15d
+  - 16d
+  - 17d
+  - 18d
+  - 19d
+  - 20d
+  - 21d
+  - 22d
+  - 23d
+  - 24d
+  - 25d
+  - 26d
+  - 27d
+  - 28d
+  - 29d
   - 30d
 default: 24h


### PR DESCRIPTION
Part of #[7238](https://github.com/influxdata/quartz/issues/7238)

This PR updates the `timerange` options for usage information to reflect the latest changes in the system. The endpoint now supports a larger range of `timerange` options, from 1 day (1d or ~24h) to 30 days (30d). 
