### PR TITLE
chore: add influxql support to the yml

### DIFF
--- a/contracts/invocable-scripts.yml
+++ b/contracts/invocable-scripts.yml
@@ -852,3 +852,4 @@ components:
       enum:
         - flux
         - sql
+        - influxQL

--- a/contracts/invocable-scripts.yml
+++ b/contracts/invocable-scripts.yml
@@ -852,4 +852,4 @@ components:
       enum:
         - flux
         - sql
-        - influxQL
+        - influxql

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -4490,7 +4490,7 @@ components:
       enum:
       - flux
       - sql
-      - influxQL
+      - influxql
       type: string
     ScriptUpdateRequest:
       properties:

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -4490,6 +4490,7 @@ components:
       enum:
       - flux
       - sql
+      - influxQL
       type: string
     ScriptUpdateRequest:
       properties:

--- a/contracts/svc/invocable-scripts.yml
+++ b/contracts/svc/invocable-scripts.yml
@@ -852,3 +852,4 @@ components:
       enum:
         - flux
         - sql
+        - influxQL

--- a/contracts/svc/invocable-scripts.yml
+++ b/contracts/svc/invocable-scripts.yml
@@ -852,4 +852,4 @@ components:
       enum:
         - flux
         - sql
-        - influxQL
+        - influxql

--- a/src/svc/invocable-scripts/schemas/ScriptLanguage.yml
+++ b/src/svc/invocable-scripts/schemas/ScriptLanguage.yml
@@ -1,2 +1,2 @@
 type: string
-enum: [flux, sql, influxQL]
+enum: [flux, sql, influxql]

--- a/src/svc/invocable-scripts/schemas/ScriptLanguage.yml
+++ b/src/svc/invocable-scripts/schemas/ScriptLanguage.yml
@@ -1,2 +1,2 @@
 type: string
-enum: [flux, sql]
+enum: [flux, sql, influxQL]


### PR DESCRIPTION
Part of https://github.com/influxdata/ui/issues/6730

InfluxQL is supported in idpe invocable scripts https://github.com/influxdata/idpe/pull/17768, so updating the enum definition here.

I mainly updated one file `src/svc/invocable-scripts/schemas/ScriptLanguage.yml`. The rest of the files under `contracts` are auto generated from following the instruction [here](https://github.com/influxdata/openapi#how-to-contribute).

Similar to the work done for SQL in https://github.com/influxdata/openapi/pull/578.