### PR TITLE
feat(quartz): Add `reactivatable` flag to Operator Accounts

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -1698,6 +1698,9 @@ components:
         deletable:
           type: boolean
           description: flag whether the account can be deleted or not
+        reactivatable:
+          type: boolean
+          description: flag whether the account can be reactivated or not
         balance:
           type: number
           description: 'remaining balance on the account, nil if none'

--- a/src/unity/schemas/OperatorAccount.yml
+++ b/src/unity/schemas/OperatorAccount.yml
@@ -16,6 +16,9 @@ properties:
   deletable:
     type: boolean
     description: flag whether the account can be deleted or not
+  reactivatable:
+    type: boolean
+    description: flag whether the account can be reactivated or not
   balance:
     type: number
     description: remaining balance on the account, nil if none


### PR DESCRIPTION
Adds a flag to operator accounts to indicate whether or not they can be reactivated.