### PR TITLE
fix(quartz): Add Reactivate Accounts to Unity

### DIFF
--- a/contracts/priv/unity.yml
+++ b/contracts/priv/unity.yml
@@ -1242,6 +1242,41 @@ paths:
         default:
           description: Unexpected error
           $ref: '#/components/responses/ServerError'
+  '/operator/accounts/{accountId}/reactivate':
+    patch:
+      operationId: ReactivateAccountById
+      tags:
+        - Accounts
+      summary: Reactivate a cancelled account
+      requestBody:
+        content:
+          application/json; charset=utf-8:
+            schema:
+              type: object
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: path
+          name: accountId
+          schema:
+            type: string
+          required: true
+          description: The ID of the account to reactivate
+      responses:
+        '200':
+          description: Account reactivated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OperatorAccount'
+        '401':
+          description: Unauthorized
+          $ref: '#/components/responses/ServerError'
+        '422':
+          description: Missing or invalid information
+          $ref: '#/components/responses/ServerError'
+        default:
+          description: Unexpected error
+          $ref: '#/components/responses/ServerError'
   /operator/providers:
     get:
       operationId: GetProvidersInfo

--- a/src/unity.yml
+++ b/src/unity.yml
@@ -78,6 +78,8 @@ paths:
     $ref: './unity/paths/operator_accounts_accountId.yml'
   '/operator/accounts/{accountId}/convert':
     $ref: './unity/paths/operator_accounts_accountId_convert.yml'
+  '/operator/accounts/{accountId}/reactivate':
+    $ref: './unity/paths/operator_accounts_accountId_reactivate.yml'
   '/operator/providers':
     $ref: './unity/paths/operator_providers.yml'
   '/operator/orgs':

--- a/src/unity/paths/operator_accounts_accountId_reactivate.yml
+++ b/src/unity/paths/operator_accounts_accountId_reactivate.yml
@@ -3,6 +3,11 @@ patch:
   tags:
     - Accounts
   summary: Reactivate a cancelled account
+  requestBody:
+    content:
+      application/json; charset=utf-8:
+        schema:
+          type: object
   parameters:
     - $ref: '../../common/parameters/TraceSpan.yml'
     - in: path


### PR DESCRIPTION
In #642 I missed adding the route to the `unity.yml` file as well as forgot that oats requires the request body, even if blank. This fixes both.