### PR TITLE
feat: add ioxQuery limitis to unity schema

### DIFF
--- a/src/unity/schemas/OperatorOrgLimits.yml
+++ b/src/unity/schemas/OperatorOrgLimits.yml
@@ -22,6 +22,8 @@ properties:
     $ref: "../../quartz/schemas/StackLimits.yml"
   timeout:
     $ref: "../../quartz/schemas/TimeoutLimits.yml"
+  ioxQuery:
+    $ref: "../../quartz/schemas/IOxQueryLimits.yml"
 required:
   [
     orgID,


### PR DESCRIPTION
Adds the new ioxQuery limits defintion to the unity schema so that it can be used by the UI.