### PR TITLE
fix: add missing `partial` and schema descriptions for InfluxQL JSON response

### DIFF
--- a/contracts/legacy.yml
+++ b/contracts/legacy.yml
@@ -112,6 +112,15 @@ paths:
                 enum:
                   - gzip
                   - identity
+            Transfer-Encoding:
+              description: |
+                `chunked` if the response is chunked.
+              schema:
+                type: string
+                description: The transfer encoding.
+                default: chunked
+                enum:
+                  - chunked
             Trace-Id:
               description: 'The trace ID, if generated, of the request.'
               schema:
@@ -127,6 +136,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InfluxqlJsonResponse'
+              examples:
+                influxql-chunk_size_2:
+                  value: |
+                    {"results":[{"statement_id":0,"series":[{"name":"mymeas","columns":["time","myfield","mytag"],"values":[["2016-05-19T18:37:55Z",90,"1"],["2016-05-19T18:37:56Z",90,"1"]],"partial":true}],"partial":true}]}
+                    {"results":[{"statement_id":0,"series":[{"name":"mymeas","columns":["time","myfield","mytag"],"values":[["2016-05-19T18:37:57Z",90,"1"],["2016-05-19T18:37:58Z",90,"1"]]}]}]}
             application/x-msgpack:
               schema:
                 type: string
@@ -536,40 +550,75 @@ components:
               items:
                 $ref: '#/components/schemas/Permission'
     InfluxqlJsonResponse:
-      description: JSON Response to InfluxQL Query
+      description: |
+        The JSON response for an InfluxQL query.
+
+        A response contains the collection of results for a query.
+        `results` is an array of resultset objects.
+
+        If the response is chunked, the `transfer-encoding` response header is set to `chunked` and each resultset object is sent in a separate JSON object.
       type: object
       properties:
         results:
           type: array
+          oneOf:
+            - required:
+                - statement_id
+                - error
+            - required:
+                - statement_id
+                - series
           items:
             type: object
+            description: |
+              A resultset object that contains the `statement_id` and the `series` array.
+
+              Except for `statement_id`, all properties are optional and omitted if empty. If a property is not present, it is assumed to be `null`.
             properties:
               statement_id:
                 type: integer
+                description: |
+                  An integer that represents the statement's position in the query. If statement results are buffered in memory, `statement_id` is used to combine statement results.
               error:
                 type: string
               series:
                 type: array
+                description: |
+                  An array of series objects--the results of the query. A series of rows shares the same group key returned from the execution of a statement.
+
+                  If a property is not present, it is assumed to be `null`.
                 items:
                   type: object
                   properties:
                     name:
                       type: string
+                      description: The name of the series
                     tags:
                       type: object
+                      description: |
+                        A map of tag key-value pairs. If a tag key is not present, it is assumed to be `null`.
                       additionalProperties:
                         type: string
                     partial:
                       type: boolean
+                      description: |
+                        True if the series is not complete--the response data is chunked; otherwise, false or omitted.
                     columns:
                       type: array
+                      description: An array of column names
                       items:
                         type: string
                     values:
                       type: array
+                      description: |
+                        An array of rows, where each row is an array of values.
                       items:
                         type: array
                         items: {}
+              partial:
+                type: boolean
+                description: |
+                  True if the resultset is not complete--the response data is chunked; otherwise, false or omitted.
     InfluxqlCsvResponse:
       description: CSV Response to InfluxQL Query
       type: string

--- a/contracts/ref/cloud.yml
+++ b/contracts/ref/cloud.yml
@@ -2233,29 +2233,55 @@ components:
         name,tags,time,test_field,test_tag test_measurement,,1603740794286107366,1,tag_value test_measurement,,1603740870053205649,2,tag_value test_measurement,,1603741221085428881,3,tag_value
       type: string
     InfluxqlJsonResponse:
-      description: JSON Response to InfluxQL Query
+      description: |
+        The JSON response for an InfluxQL query.
+
+        A response contains the collection of results for a query.
+        `results` is an array of resultset objects.
+
+        If the response is chunked, the `transfer-encoding` response header is set to `chunked` and each resultset object is sent in a separate JSON object.
       properties:
         results:
           items:
+            description: |
+              A resultset object that contains the `statement_id` and the `series` array.
+
+              Except for `statement_id`, all properties are optional and omitted if empty. If a property is not present, it is assumed to be `null`.
             properties:
               error:
                 type: string
+              partial:
+                description: |
+                  True if the resultset is not complete--the response data is chunked; otherwise, false or omitted.
+                type: boolean
               series:
+                description: |
+                  An array of series objects--the results of the query. A series of rows shares the same group key returned from the execution of a statement.
+
+                  If a property is not present, it is assumed to be `null`.
                 items:
                   properties:
                     columns:
+                      description: An array of column names
                       items:
                         type: string
                       type: array
                     name:
+                      description: The name of the series
                       type: string
                     partial:
+                      description: |
+                        True if the series is not complete--the response data is chunked; otherwise, false or omitted.
                       type: boolean
                     tags:
                       additionalProperties:
                         type: string
+                      description: |
+                        A map of tag key-value pairs. If a tag key is not present, it is assumed to be `null`.
                       type: object
                     values:
+                      description: |
+                        An array of rows, where each row is an array of values.
                       items:
                         items: {}
                         type: array
@@ -2263,8 +2289,17 @@ components:
                   type: object
                 type: array
               statement_id:
+                description: |
+                  An integer that represents the statement's position in the query. If statement results are buffered in memory, `statement_id` is used to combine statement results.
                 type: integer
             type: object
+          oneOf:
+          - required:
+            - statement_id
+            - error
+          - required:
+            - statement_id
+            - series
           type: array
       type: object
     IntegerLiteral:
@@ -18829,6 +18864,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/InfluxqlCsvResponse'
             application/json:
+              examples:
+                influxql-chunk_size_2:
+                  value: |
+                    {"results":[{"statement_id":0,"series":[{"name":"mymeas","columns":["time","myfield","mytag"],"values":[["2016-05-19T18:37:55Z",90,"1"],["2016-05-19T18:37:56Z",90,"1"]],"partial":true}],"partial":true}]}
+                    {"results":[{"statement_id":0,"series":[{"name":"mymeas","columns":["time","myfield","mytag"],"values":[["2016-05-19T18:37:57Z",90,"1"],["2016-05-19T18:37:58Z",90,"1"]]}]}]}
               schema:
                 $ref: '#/components/schemas/InfluxqlJsonResponse'
             application/x-msgpack:
@@ -18857,6 +18897,15 @@ paths:
               description: The trace ID, if generated, of the request.
               schema:
                 description: Trace ID of a request.
+                type: string
+            Transfer-Encoding:
+              description: |
+                `chunked` if the response is chunked.
+              schema:
+                default: chunked
+                description: The transfer encoding.
+                enum:
+                - chunked
                 type: string
         "429":
           description: |

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -2252,29 +2252,55 @@ components:
         name,tags,time,test_field,test_tag test_measurement,,1603740794286107366,1,tag_value test_measurement,,1603740870053205649,2,tag_value test_measurement,,1603741221085428881,3,tag_value
       type: string
     InfluxqlJsonResponse:
-      description: JSON Response to InfluxQL Query
+      description: |
+        The JSON response for an InfluxQL query.
+
+        A response contains the collection of results for a query.
+        `results` is an array of resultset objects.
+
+        If the response is chunked, the `transfer-encoding` response header is set to `chunked` and each resultset object is sent in a separate JSON object.
       properties:
         results:
           items:
+            description: |
+              A resultset object that contains the `statement_id` and the `series` array.
+
+              Except for `statement_id`, all properties are optional and omitted if empty. If a property is not present, it is assumed to be `null`.
             properties:
               error:
                 type: string
+              partial:
+                description: |
+                  True if the resultset is not complete--the response data is chunked; otherwise, false or omitted.
+                type: boolean
               series:
+                description: |
+                  An array of series objects--the results of the query. A series of rows shares the same group key returned from the execution of a statement.
+
+                  If a property is not present, it is assumed to be `null`.
                 items:
                   properties:
                     columns:
+                      description: An array of column names
                       items:
                         type: string
                       type: array
                     name:
+                      description: The name of the series
                       type: string
                     partial:
+                      description: |
+                        True if the series is not complete--the response data is chunked; otherwise, false or omitted.
                       type: boolean
                     tags:
                       additionalProperties:
                         type: string
+                      description: |
+                        A map of tag key-value pairs. If a tag key is not present, it is assumed to be `null`.
                       type: object
                     values:
+                      description: |
+                        An array of rows, where each row is an array of values.
                       items:
                         items: {}
                         type: array
@@ -2282,8 +2308,17 @@ components:
                   type: object
                 type: array
               statement_id:
+                description: |
+                  An integer that represents the statement's position in the query. If statement results are buffered in memory, `statement_id` is used to combine statement results.
                 type: integer
             type: object
+          oneOf:
+          - required:
+            - statement_id
+            - error
+          - required:
+            - statement_id
+            - series
           type: array
       type: object
     IntegerLiteral:
@@ -19719,6 +19754,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/InfluxqlCsvResponse'
             application/json:
+              examples:
+                influxql-chunk_size_2:
+                  value: |
+                    {"results":[{"statement_id":0,"series":[{"name":"mymeas","columns":["time","myfield","mytag"],"values":[["2016-05-19T18:37:55Z",90,"1"],["2016-05-19T18:37:56Z",90,"1"]],"partial":true}],"partial":true}]}
+                    {"results":[{"statement_id":0,"series":[{"name":"mymeas","columns":["time","myfield","mytag"],"values":[["2016-05-19T18:37:57Z",90,"1"],["2016-05-19T18:37:58Z",90,"1"]]}]}]}
               schema:
                 $ref: '#/components/schemas/InfluxqlJsonResponse'
             application/x-msgpack:
@@ -19747,6 +19787,15 @@ paths:
               description: The trace ID, if generated, of the request.
               schema:
                 description: Trace ID of a request.
+                type: string
+            Transfer-Encoding:
+              description: |
+                `chunked` if the response is chunked.
+              schema:
+                default: chunked
+                description: The transfer encoding.
+                enum:
+                - chunked
                 type: string
         "429":
           description: |

--- a/contracts/swaggerV1Compat.yml
+++ b/contracts/swaggerV1Compat.yml
@@ -112,7 +112,7 @@ paths:
       operationId: PostQueryV1
       tags:
         - Query
-      summary: Query InfluxDB in a V1 compatible format
+      summary: Query using the InfluxDB v1 HTTP API
       requestBody:
         description: InfluxQL query to execute.
         content:

--- a/src/legacy/paths/query.yml
+++ b/src/legacy/paths/query.yml
@@ -94,7 +94,7 @@ get:
             enum:
               - gzip
               - identity
-        Transfer-Encoding: 
+        Transfer-Encoding:
           description: |
             `chunked` if the response is chunked.
           schema:

--- a/src/legacy/paths/query.yml
+++ b/src/legacy/paths/query.yml
@@ -94,6 +94,15 @@ get:
             enum:
               - gzip
               - identity
+        Transfer-Encoding: 
+          description: |
+            `chunked` if the response is chunked.
+          schema:
+            type: string
+            description: The transfer encoding.
+            default: chunked
+            enum:
+              - chunked
         Trace-Id:
           description: The trace ID, if generated, of the request.
           schema:
@@ -109,6 +118,11 @@ get:
         application/json:
           schema:
             $ref: ../schemas/InfluxqlJsonResponse.yml
+          examples:
+            influxql-chunk_size_2:
+              value: |
+                {"results":[{"statement_id":0,"series":[{"name":"mymeas","columns":["time","myfield","mytag"],"values":[["2016-05-19T18:37:55Z",90,"1"],["2016-05-19T18:37:56Z",90,"1"]],"partial":true}],"partial":true}]}
+                {"results":[{"statement_id":0,"series":[{"name":"mymeas","columns":["time","myfield","mytag"],"values":[["2016-05-19T18:37:57Z",90,"1"],["2016-05-19T18:37:58Z",90,"1"]]}]}]}
         application/x-msgpack:
           schema:
             type: string

--- a/src/legacy/schemas/InfluxqlJsonResponse.yml
+++ b/src/legacy/schemas/InfluxqlJsonResponse.yml
@@ -1,34 +1,69 @@
-description: JSON Response to InfluxQL Query
+description: |
+ The JSON response for an InfluxQL query.
+
+ A response contains the collection of results for a query.
+ `results` is an array of resultset objects.
+
+ If the response is chunked, the `transfer-encoding` response header is set to `chunked` and each resultset object is sent in a separate JSON object.
 type: object
 properties:
   results:
     type: array
+    oneOf:
+      - required:
+          - statement_id
+          - error
+      - required:
+          - statement_id
+          - series
     items:
       type: object
+      description: |
+        A resultset object that contains the `statement_id` and the `series` array.
+
+        Except for `statement_id`, all properties are optional and omitted if empty. If a property is not present, it is assumed to be `null`.
       properties:
         statement_id:
           type: integer
+          description: |
+            An integer that represents the statement's position in the query. If statement results are buffered in memory, `statement_id` is used to combine statement results.
         error:
           type: string
         series:
           type: array
+          description: |
+            An array of series objects--the results of the query. A series of rows shares the same group key returned from the execution of a statement.
+
+            If a property is not present, it is assumed to be `null`.
           items:
             type: object
             properties:
               name:
                 type: string
+                description: The name of the series
               tags:
                 type: object
+                description: |
+                  A map of tag key-value pairs. If a tag key is not present, it is assumed to be `null`.
                 additionalProperties:
                   type: string
               partial:
                 type: boolean
+                description: |
+                  True if the series is not complete--the response data is chunked; otherwise, false or omitted.
               columns:
                 type: array
+                description: An array of column names
                 items:
                   type: string
               values:
                 type: array
+                description: |
+                  An array of rows, where each row is an array of values.
                 items:
                   type: array
                   items: {}
+        partial:
+          type: boolean
+          description: |
+            True if the resultset is not complete--the response data is chunked; otherwise, false or omitted.


### PR DESCRIPTION
Closes #650, part of https://github.com/influxdata/DAR/issues/424

- Add descriptions for InfluxQL JSON response properties.
-  Add example chunked response
- Fix: `Transfer-Encoding` header to schema (for chunked responses).
- Fix: add missing `partial` property to `results` schema.