### PR TITLE
feat: Update openapi contracts to include onConflict parameter for restore

### DIFF
--- a/contracts/oss-diff.yml
+++ b/contracts/oss-diff.yml
@@ -2519,6 +2519,15 @@ paths:
       summary: Create a new bucket pre-seeded with shard info from a backup.
       parameters:
         - $ref: '#/paths/~1ready/get/parameters/0'
+        - in: query
+          name: onConflict
+          description: Behavior when a bucket with the same name already exists.
+          schema:
+            type: string
+            enum:
+              - error
+              - skip
+              - replace
       requestBody:
         description: Metadata manifest for a bucket.
         required: true

--- a/contracts/oss.json
+++ b/contracts/oss.json
@@ -14708,6 +14708,19 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/TraceSpan"
+          },
+          {
+            "in": "query",
+            "name": "onConflict",
+            "description": "Behavior when a bucket with the same name already exists.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "error",
+                "skip",
+                "replace"
+              ]
+            }
           }
         ],
         "requestBody": {

--- a/contracts/oss.yml
+++ b/contracts/oss.yml
@@ -11907,6 +11907,15 @@ paths:
       summary: Create a new bucket pre-seeded with shard info from a backup.
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
+        - in: query
+          name: onConflict
+          description: Behavior when a bucket with the same name already exists.
+          schema:
+            type: string
+            enum:
+              - error
+              - skip
+              - replace
       requestBody:
         description: Metadata manifest for a bucket.
         required: true

--- a/contracts/ref/oss.yml
+++ b/contracts/ref/oss.yml
@@ -14995,6 +14995,15 @@ paths:
       operationId: PostRestoreBucketMetadata
       parameters:
       - $ref: '#/components/parameters/TraceSpan'
+      - description: Behavior when a bucket with the same name already exists.
+        in: query
+        name: onConflict
+        schema:
+          enum:
+          - error
+          - skip
+          - replace
+          type: string
       requestBody:
         content:
           application/json:

--- a/src/oss/paths/restore_bucketMetadata.yml
+++ b/src/oss/paths/restore_bucketMetadata.yml
@@ -5,6 +5,15 @@ post:
   summary: Create a new bucket pre-seeded with shard info from a backup.
   parameters:
     - $ref: "../../common/parameters/TraceSpan.yml"
+    - in: query
+      name: onConflict
+      description: Behavior when a bucket with the same name already exists.
+      schema:
+        type: string
+        enum:
+          - error
+          - skip
+          - replace
   requestBody:
     description: Metadata manifest for a bucket.
     required: true


### PR DESCRIPTION
This is part of https://github.com/influxdata/influxdb/issues/27578 

Adds an additional parameter to our openAPI contracts for bucket metadata restore which allows for 
`onConflict` as a param with the following string values

- skip
- error
- replace
